### PR TITLE
New: Option to control which new site episodes get monitored

### DIFF
--- a/frontend/src/AddSeries/SeriesMonitorNewItemsOptionsPopoverContent.js
+++ b/frontend/src/AddSeries/SeriesMonitorNewItemsOptionsPopoverContent.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import DescriptionList from 'Components/DescriptionList/DescriptionList';
+import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem';
+import translate from 'Utilities/String/translate';
+
+function SeriesMonitorNewItemsOptionsPopoverContent() {
+  return (
+    <DescriptionList>
+      <DescriptionListItem
+        title={translate('MonitorAllEpisodes')}
+        data="Monitor all new episodes"
+      />
+
+      <DescriptionListItem
+        title={translate('MonitorNone')}
+        data="Don't monitor any new episodes"
+      />
+    </DescriptionList>
+  );
+}
+
+export default SeriesMonitorNewItemsOptionsPopoverContent;

--- a/frontend/src/Components/Form/FormInputGroup.js
+++ b/frontend/src/Components/Form/FormInputGroup.js
@@ -14,6 +14,7 @@ import FormInputHelpText from './FormInputHelpText';
 import IndexerSelectInputConnector from './IndexerSelectInputConnector';
 import KeyValueListInput from './KeyValueListInput';
 import MonitorEpisodesSelectInput from './MonitorEpisodesSelectInput';
+import MonitorNewItemsSelectInput from './MonitorNewItemsSelectInput';
 import NumberInput from './NumberInput';
 import OAuthInputConnector from './OAuthInputConnector';
 import PasswordInput from './PasswordInput';
@@ -47,6 +48,9 @@ function getComponent(type) {
 
     case inputTypes.MONITOR_EPISODES_SELECT:
       return MonitorEpisodesSelectInput;
+
+    case inputTypes.MONITOR_NEW_ITEMS_SELECT:
+      return MonitorNewItemsSelectInput;
 
     case inputTypes.NUMBER:
       return NumberInput;

--- a/frontend/src/Components/Form/MonitorNewItemsSelectInput.js
+++ b/frontend/src/Components/Form/MonitorNewItemsSelectInput.js
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import monitorNewItemsOptions from 'Utilities/Series/monitorNewItemsOptions';
+import SelectInput from './SelectInput';
+
+function MonitorNewItemsSelectInput(props) {
+  const {
+    includeNoChange,
+    includeMixed,
+    ...otherProps
+  } = props;
+
+  const values = [...monitorNewItemsOptions];
+
+  if (includeNoChange) {
+    values.unshift({
+      key: 'noChange',
+      value: 'No Change',
+      disabled: true
+    });
+  }
+
+  if (includeMixed) {
+    values.unshift({
+      key: 'mixed',
+      value: '(Mixed)',
+      disabled: true
+    });
+  }
+
+  return (
+    <SelectInput
+      values={values}
+      {...otherProps}
+    />
+  );
+}
+
+MonitorNewItemsSelectInput.propTypes = {
+  includeNoChange: PropTypes.bool.isRequired,
+  includeMixed: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired
+};
+
+MonitorNewItemsSelectInput.defaultProps = {
+  includeNoChange: false,
+  includeMixed: false
+};
+
+export default MonitorNewItemsSelectInput;

--- a/frontend/src/Helpers/Props/inputTypes.js
+++ b/frontend/src/Helpers/Props/inputTypes.js
@@ -4,6 +4,7 @@ export const CHECK = 'check';
 export const DEVICE = 'device';
 export const KEY_VALUE_LIST = 'keyValueList';
 export const MONITOR_EPISODES_SELECT = 'monitorEpisodesSelect';
+export const MONITOR_NEW_ITEMS_SELECT = 'monitorNewItemsSelect';
 export const FLOAT = 'float';
 export const NUMBER = 'number';
 export const OAUTH = 'oauth';
@@ -30,6 +31,7 @@ export const all = [
   DEVICE,
   KEY_VALUE_LIST,
   MONITOR_EPISODES_SELECT,
+  MONITOR_NEW_ITEMS_SELECT,
   FLOAT,
   NUMBER,
   OAUTH,

--- a/frontend/src/Series/Edit/EditSeriesModalContent.css
+++ b/frontend/src/Series/Edit/EditSeriesModalContent.css
@@ -3,3 +3,7 @@
 
   margin-right: auto;
 }
+
+.labelIcon {
+  margin-left: 8px;
+}

--- a/frontend/src/Series/Edit/EditSeriesModalContent.css.d.ts
+++ b/frontend/src/Series/Edit/EditSeriesModalContent.css.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'deleteButton': string;
+  'labelIcon': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/frontend/src/Series/Edit/EditSeriesModalContent.js
+++ b/frontend/src/Series/Edit/EditSeriesModalContent.js
@@ -1,16 +1,19 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import SeriesMonitorNewItemsOptionsPopoverContent from 'AddSeries/SeriesMonitorNewItemsOptionsPopoverContent';
 import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormLabel from 'Components/Form/FormLabel';
+import Icon from 'Components/Icon';
 import Button from 'Components/Link/Button';
 import SpinnerButton from 'Components/Link/SpinnerButton';
 import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
 import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
-import { inputTypes, kinds } from 'Helpers/Props';
+import Popover from 'Components/Tooltip/Popover';
+import { icons, inputTypes, kinds, tooltipPositions } from 'Helpers/Props';
 import MoveSeriesModal from 'Series/MoveSeries/MoveSeriesModal';
 import translate from 'Utilities/String/translate';
 import styles from './EditSeriesModalContent.css';
@@ -73,6 +76,7 @@ class EditSeriesModalContent extends Component {
 
     const {
       monitored,
+      monitorNewItems,
       qualityProfileId,
       path,
       tags
@@ -94,6 +98,31 @@ class EditSeriesModalContent extends Component {
                 name="monitored"
                 helpText={translate('MonitoredHelpText')}
                 {...monitored}
+                onChange={onInputChange}
+              />
+            </FormGroup>
+
+            <FormGroup>
+              <FormLabel>
+                {translate('MonitorNewItems')}
+                <Popover
+                  anchor={
+                    <Icon
+                      className={styles.labelIcon}
+                      name={icons.INFO}
+                    />
+                  }
+                  title={translate('MonitorNewItems')}
+                  body={<SeriesMonitorNewItemsOptionsPopoverContent />}
+                  position={tooltipPositions.RIGHT}
+                />
+              </FormLabel>
+
+              <FormInputGroup
+                type={inputTypes.MONITOR_NEW_ITEMS_SELECT}
+                name="monitorNewItems"
+                helpText={translate('MonitorNewItemsHelpText')}
+                {...monitorNewItems}
                 onChange={onInputChange}
               />
             </FormGroup>

--- a/frontend/src/Series/Edit/EditSeriesModalContentConnector.js
+++ b/frontend/src/Series/Edit/EditSeriesModalContentConnector.js
@@ -38,6 +38,7 @@ function createMapStateToProps() {
 
       const seriesSettings = _.pick(series, [
         'monitored',
+        'monitorNewItems',
         'qualityProfileId',
         'path',
         'tags'

--- a/frontend/src/Series/Index/Select/Edit/EditSeriesModalContent.tsx
+++ b/frontend/src/Series/Index/Select/Edit/EditSeriesModalContent.tsx
@@ -14,6 +14,7 @@ import styles from './EditSeriesModalContent.css';
 
 interface SavePayload {
   monitored?: boolean;
+  monitorNewItems?: string;
   qualityProfileId?: number;
   seasonFolder?: boolean;
   rootFolderPath?: string;
@@ -76,6 +77,7 @@ function EditSeriesModalContent(props: EditSeriesModalContentProps) {
   const { seriesIds, onSavePress, onModalClose } = props;
 
   const [monitored, setMonitored] = useState(NO_CHANGE);
+  const [monitorNewItems, setMonitorNewItems] = useState(NO_CHANGE);
   const [qualityProfileId, setQualityProfileId] = useState<string | number>(
     NO_CHANGE
   );
@@ -91,6 +93,11 @@ function EditSeriesModalContent(props: EditSeriesModalContentProps) {
       if (monitored !== NO_CHANGE) {
         hasChanges = true;
         payload.monitored = monitored === 'monitored';
+      }
+
+      if (monitorNewItems !== NO_CHANGE) {
+        hasChanges = true;
+        payload.monitorNewItems = monitorNewItems;
       }
 
       if (qualityProfileId !== NO_CHANGE) {
@@ -117,6 +124,7 @@ function EditSeriesModalContent(props: EditSeriesModalContentProps) {
     },
     [
       monitored,
+      monitorNewItems,
       qualityProfileId,
       seasonFolder,
       rootFolderPath,
@@ -130,6 +138,9 @@ function EditSeriesModalContent(props: EditSeriesModalContentProps) {
       switch (name) {
         case 'monitored':
           setMonitored(value);
+          break;
+        case 'monitorNewItems':
+          setMonitorNewItems(value);
           break;
         case 'qualityProfileId':
           setQualityProfileId(value);
@@ -184,6 +195,19 @@ function EditSeriesModalContent(props: EditSeriesModalContentProps) {
             name="monitored"
             value={monitored}
             values={monitoredOptions}
+            onChange={onInputChange}
+          />
+        </FormGroup>
+
+        <FormGroup>
+          <FormLabel>{translate('MonitorNewItems')}</FormLabel>
+
+          <FormInputGroup
+            type={inputTypes.MONITOR_NEW_ITEMS_SELECT}
+            name="monitorNewItems"
+            value={monitorNewItems}
+            includeNoChange={true}
+            includeNoChangeDisabled={false}
             onChange={onInputChange}
           />
         </FormGroup>

--- a/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.js
+++ b/frontend/src/Settings/ImportLists/ImportLists/EditImportListModalContent.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import SeriesMonitoringOptionsPopoverContent from 'AddSeries/SeriesMonitoringOptionsPopoverContent';
+import SeriesMonitorNewItemsOptionsPopoverContent from 'AddSeries/SeriesMonitorNewItemsOptionsPopoverContent';
 import Alert from 'Components/Alert';
 import Form from 'Components/Form/Form';
 import FormGroup from 'Components/Form/FormGroup';
@@ -56,6 +57,7 @@ function EditImportListModalContent(props) {
     shouldMonitor,
     siteMonitorType,
     rootFolderPath,
+    monitorNewItems,
     qualityProfileId,
     tags,
     fields
@@ -141,6 +143,31 @@ function EditImportListModalContent(props) {
                   values={monitorOptions}
                   onChange={onInputChange}
                   {...shouldMonitor}
+                />
+              </FormGroup>
+
+              <FormGroup>
+                <FormLabel>
+                  {translate('MonitorNewItems')}
+                  <Popover
+                    anchor={
+                      <Icon
+                        className={styles.labelIcon}
+                        name={icons.INFO}
+                      />
+                    }
+                    title={translate('MonitorNewItems')}
+                    body={<SeriesMonitorNewItemsOptionsPopoverContent />}
+                    position={tooltipPositions.RIGHT}
+                  />
+                </FormLabel>
+
+                <FormInputGroup
+                  type={inputTypes.MONITOR_NEW_ITEMS_SELECT}
+                  name="monitorNewItems"
+                  helpText={translate('MonitorNewItemsHelpText')}
+                  {...monitorNewItems}
+                  onChange={onInputChange}
                 />
               </FormGroup>
 

--- a/frontend/src/Utilities/Series/getNewSeries.js
+++ b/frontend/src/Utilities/Series/getNewSeries.js
@@ -3,6 +3,7 @@ function getNewSeries(series, payload) {
   const {
     rootFolderPath,
     monitor,
+    monitorNewItems,
     qualityProfileId,
     tags,
     searchForMissingEpisodes = false,
@@ -17,6 +18,7 @@ function getNewSeries(series, payload) {
 
   series.addOptions = addOptions;
   series.monitored = true;
+  series.monitorNewItems = monitorNewItems;
   series.qualityProfileId = qualityProfileId;
   series.rootFolderPath = rootFolderPath;
   series.tags = tags;

--- a/frontend/src/Utilities/Series/monitorNewItemsOptions.js
+++ b/frontend/src/Utilities/Series/monitorNewItemsOptions.js
@@ -1,0 +1,18 @@
+import translate from 'Utilities/String/translate';
+
+const monitorNewItemsOptions = [
+  {
+    key: 'all',
+    get value() {
+      return translate('MonitorAllScenes');
+    }
+  },
+  {
+    key: 'none',
+    get value() {
+      return translate('MonitorNone');
+    }
+  }
+];
+
+export default monitorNewItemsOptions;

--- a/src/NzbDrone.Core/Datastore/Migration/013_monitor_new_items.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/013_monitor_new_items.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(013)]
+    public class AddNewItemMonitorType : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Series").AddColumn("MonitorNewItems").AsInt32().WithDefaultValue(0);
+            Alter.Table("ImportLists").AddColumn("MonitorNewItems").AsInt32().WithDefaultValue(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ImportListDefinition.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListDefinition.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.ImportLists
     {
         public bool EnableAutomaticAdd { get; set; }
         public ImportListMonitorTypes ShouldMonitor { get; set; }
+        public NewItemMonitorTypes MonitorNewItems { get; set; }
         public MonitorTypes SiteMonitorType { get; set; }
         public int QualityProfileId { get; set; }
         public string RootFolderPath { get; set; }

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -152,6 +152,7 @@ namespace NzbDrone.Core.ImportLists
                         Title = item.Title,
                         Year = item.Year,
                         Monitored = monitored,
+                        MonitorNewItems = importList.MonitorNewItems,
                         RootFolderPath = importList.RootFolderPath,
                         QualityProfileId = importList.QualityProfileId,
                         Tags = importList.Tags,

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -779,6 +779,8 @@
   "MonitorLatestYearDescription": "Monitor all episodes of the latest year that released within the last 90 days and all future years",
   "MonitorMissingScenes": "Missing Scene",
   "MonitorMissingScenesDescription": "Monitor scenes that do not have files or have not aired yet",
+  "MonitorNewItems": "Monitor New Items",
+  "MonitorNewItemsHelpText": "Which new scenes should be monitored",
   "MonitorNone": "None",
   "MonitorNoneDescription": "No episodes will be monitored",
   "MonitorSite": "Monitor Site",

--- a/src/NzbDrone.Core/Tv/MonitoringOptions.cs
+++ b/src/NzbDrone.Core/Tv/MonitoringOptions.cs
@@ -27,4 +27,10 @@ namespace NzbDrone.Core.Tv
         LatestSeason,
         None
     }
+
+    public enum NewItemMonitorTypes
+    {
+        All,
+        None
+    }
 }

--- a/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.Tv
                     else
                     {
                         episodeToUpdate = new Episode();
-                        episodeToUpdate.Monitored = GetMonitoredStatus(episode, seasons);
+                        episodeToUpdate.Monitored = GetMonitoredStatus(episode, seasons, series);
                         newList.Add(episodeToUpdate);
                     }
 
@@ -105,8 +105,13 @@ namespace NzbDrone.Core.Tv
             }
         }
 
-        private bool GetMonitoredStatus(Episode episode, IEnumerable<Season> seasons)
+        private bool GetMonitoredStatus(Episode episode, IEnumerable<Season> seasons, Series series)
         {
+            if (series.MonitorNewItems == NewItemMonitorTypes.None)
+            {
+                return false;
+            }
+
             var season = seasons.SingleOrDefault(c => c.SeasonNumber == episode.SeasonNumber);
             return season == null || season.Monitored;
         }

--- a/src/NzbDrone.Core/Tv/Series.cs
+++ b/src/NzbDrone.Core/Tv/Series.cs
@@ -25,6 +25,7 @@ namespace NzbDrone.Core.Tv
         public SeriesStatusType Status { get; set; }
         public string Overview { get; set; }
         public bool Monitored { get; set; }
+        public NewItemMonitorTypes MonitorNewItems { get; set; }
         public int QualityProfileId { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public int Runtime { get; set; }
@@ -61,6 +62,7 @@ namespace NzbDrone.Core.Tv
             QualityProfileId = otherSeries.QualityProfileId;
 
             Monitored = otherSeries.Monitored;
+            MonitorNewItems = otherSeries.MonitorNewItems;
 
             RootFolderPath = otherSeries.RootFolderPath;
             Tags = otherSeries.Tags;

--- a/src/Whisparr.Api.V3/ImportLists/ImportListResource.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListResource.cs
@@ -9,6 +9,7 @@ namespace Whisparr.Api.V3.ImportLists
         public bool EnableAutomaticAdd { get; set; }
         public ImportListMonitorTypes ShouldMonitor { get; set; }
         public MonitorTypes SiteMonitorType { get; set; }
+        public NewItemMonitorTypes MonitorNewItems { get; set; }
         public string RootFolderPath { get; set; }
         public int QualityProfileId { get; set; }
         public ImportListType ListType { get; set; }
@@ -30,6 +31,7 @@ namespace Whisparr.Api.V3.ImportLists
             resource.EnableAutomaticAdd = definition.EnableAutomaticAdd;
             resource.ShouldMonitor = definition.ShouldMonitor;
             resource.SiteMonitorType = definition.SiteMonitorType;
+            resource.MonitorNewItems = definition.MonitorNewItems;
             resource.RootFolderPath = definition.RootFolderPath;
             resource.QualityProfileId = definition.QualityProfileId;
             resource.ListType = definition.ListType;
@@ -51,6 +53,7 @@ namespace Whisparr.Api.V3.ImportLists
             definition.EnableAutomaticAdd = resource.EnableAutomaticAdd;
             definition.ShouldMonitor = resource.ShouldMonitor;
             definition.SiteMonitorType = resource.SiteMonitorType;
+            definition.MonitorNewItems = resource.MonitorNewItems;
             definition.RootFolderPath = resource.RootFolderPath;
             definition.QualityProfileId = resource.QualityProfileId;
             definition.ListType = resource.ListType;

--- a/src/Whisparr.Api.V3/Series/SeriesEditorController.cs
+++ b/src/Whisparr.Api.V3/Series/SeriesEditorController.cs
@@ -34,6 +34,11 @@ namespace Whisparr.Api.V3.Series
                     series.Monitored = resource.Monitored.Value;
                 }
 
+                if (resource.MonitorNewItems.HasValue)
+                {
+                    series.MonitorNewItems = resource.MonitorNewItems.Value;
+                }
+
                 if (resource.QualityProfileId.HasValue)
                 {
                     series.QualityProfileId = resource.QualityProfileId.Value;

--- a/src/Whisparr.Api.V3/Series/SeriesEditorResource.cs
+++ b/src/Whisparr.Api.V3/Series/SeriesEditorResource.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using NzbDrone.Core.Tv;
 
 namespace Whisparr.Api.V3.Series
 {
@@ -6,6 +7,7 @@ namespace Whisparr.Api.V3.Series
     {
         public List<int> SeriesIds { get; set; }
         public bool? Monitored { get; set; }
+        public NewItemMonitorTypes? MonitorNewItems { get; set; }
         public int? QualityProfileId { get; set; }
         public string RootFolderPath { get; set; }
         public List<int> Tags { get; set; }

--- a/src/Whisparr.Api.V3/Series/SeriesResource.cs
+++ b/src/Whisparr.Api.V3/Series/SeriesResource.cs
@@ -41,6 +41,7 @@ namespace Whisparr.Api.V3.Series
 
         // Editing Only
         public bool Monitored { get; set; }
+        public NewItemMonitorTypes MonitorNewItems { get; set; }
 
         public bool UseSceneNumbering { get; set; }
         public int Runtime { get; set; }
@@ -100,6 +101,7 @@ namespace Whisparr.Api.V3.Series
                        QualityProfileId = model.QualityProfileId,
 
                        Monitored = model.Monitored,
+                       MonitorNewItems = model.MonitorNewItems,
 
                        UseSceneNumbering = model.UseSceneNumbering,
                        Runtime = model.Runtime,
@@ -156,6 +158,7 @@ namespace Whisparr.Api.V3.Series
                        QualityProfileId = resource.QualityProfileId,
 
                        Monitored = resource.Monitored,
+                       MonitorNewItems = resource.MonitorNewItems,
 
                        UseSceneNumbering = resource.UseSceneNumbering,
                        Runtime = resource.Runtime,


### PR DESCRIPTION
#### Database Migration
YES - 013

#### Description
Adds option to prevent future episodes from being auto monitored on a series. 

#### Screenshot (if UI related)

#### Todos
- [ ] Tests

#### Issues Fixed or Closed by this PR

* Fixes #XXXX