### PR TITLE
Fix: Indexer search with scene name instead of studio name

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -112,7 +112,7 @@ namespace NzbDrone.Core.IndexerSearch
             where TSpec : SearchCriteriaBase, new()
         {
             var spec = new TSpec();
-            spec.SceneTitles = new List<string> { series.Title, series.TitleSlug };
+            spec.SceneTitles = episodes.Select(e => e.Title).ToList();
 
             spec.Series = series;
             spec.Episodes = episodes;

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -113,6 +113,7 @@ namespace NzbDrone.Core.IndexerSearch
         {
             var spec = new TSpec();
             spec.SceneTitles = episodes.Select(e => e.Title).ToList();
+            spec.SceneTitles.Add(series.TitleSlug);
 
             spec.Series = series;
             spec.Episodes = episodes;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Indexer search used to use the studio name and date which usually returned no results.

This PR changes search to use the scene title and date instead which works a lot better.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #115 