### PR TITLE
Fix #127 Monitoring adds all scenes to wanted

### DIFF
--- a/src/Whisparr.Api.V3/Wanted/MissingController.cs
+++ b/src/Whisparr.Api.V3/Wanted/MissingController.cs
@@ -35,7 +35,7 @@ namespace Whisparr.Api.V3.Wanted
                 SortDirection = pagingResource.SortDirection
             };
 
-            pagingSpec.FilterExpressions.Add(v => v.Monitored == monitored || v.Series.Monitored == monitored);
+            pagingSpec.FilterExpressions.Add(v => v.Monitored == monitored);
 
             var resource = pagingSpec.ApplyToPage(_episodeService.EpisodesWithoutFiles, v => MapToResource(v, includeSeries, false, includeImages));
 


### PR DESCRIPTION

#### Database Migration
NO

#### Description
Only include monitored scenes in wanted. This resolve the issue with every site showing up and having hundreds or thousands of pages of wanted. Searching for all monitored scenes is once again feasible.

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests
- [ N/A ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ N/A ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #127 