### PR TITLE
Remove unsupported fields from Stash scan call

### DIFF
--- a/src/NzbDrone.Core/Notifications/Stash/StashProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Stash/StashProxy.cs
@@ -49,8 +49,6 @@ namespace NzbDrone.Core.Notifications.Stash
                 Query = $@"mutation {{
                             metadataScan(
                             input: {{
-                                useFileMetadata: false,
-                                stripFileExtension: true,
                                 scanGenerateCovers: {(settings.GenerateCovers ? "true" : "false")},
                                 scanGeneratePreviews: {(settings.GeneratePreviews ? "true" : "false")},
                                 scanGenerateImagePreviews: {(settings.GenerateImagePreviews ? "true" : "false")},


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Currently, the Stash notification integration is failing with the following logged to the Whisparr log:

```
2023-12-28 22:56:28.0|Warn|HttpClient|HTTP Error - Res: HTTP/1.1 [POST] http://host:9999/graphql: 422.UnprocessableEntity (373 bytes)
{"errors":[{"message":"Field \"useFileMetadata\" is not defined by type \"ScanMetadataInput\".","locations":[{"line":4,"column":34}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}},{"message":"Field \"stripFileExtension\" is not defined by type \"ScanMetadataInput\".","locations":[{"line":5,"column":34}],"extensions":{"code":"GRAPHQL_VALIDATION_FAILED"}}],"data":null}
```

This PR fixes the integration by removing unsupported fields from the Stash scan call.

I'm not sure when or why these fields were added, but they're no longer supported by the Stash API.

#### Screenshot (if UI related)

N/A

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #138