### PR TITLE
Set the correct default port for Stash

### DIFF
--- a/src/NzbDrone.Core/Notifications/Stash/StashSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Stash/StashSettings.cs
@@ -28,7 +28,7 @@ namespace NzbDrone.Core.Notifications.Stash
 
         public StashSettings()
         {
-            Port = 9998;
+            Port = 9999;
         }
 
         [FieldDefinition(0, Label = "Host")]


### PR DESCRIPTION
#### Database Migration

NO

#### Description

Stash uses port 9999 by default,  but Whisparr defaults to connecting to Stash on port 9998. This is just a small change to align Whisparr with this default port of Stash.

#### Screenshot (if UI related)

N/A

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

N/A