### PR TITLE
Fixup: Performer sync items and rescan

### DIFF
--- a/frontend/src/Commands/commandNames.js
+++ b/frontend/src/Commands/commandNames.js
@@ -13,6 +13,7 @@ export const MOVE_MOVIE = 'MoveMovie';
 export const REFRESH_COLLECTIONS = 'RefreshCollections';
 export const REFRESH_MOVIE = 'RefreshMovie';
 export const REFRESH_PERFORMER = 'SyncPerformerItems';
+export const REFRESH_STUDIO = 'SyncStudioItems';
 export const RENAME_FILES = 'RenameFiles';
 export const RENAME_MOVIE = 'RenameMovie';
 export const RESET_API_KEY = 'ResetApiKey';

--- a/frontend/src/Commands/commandNames.js
+++ b/frontend/src/Commands/commandNames.js
@@ -12,6 +12,7 @@ export const MISSING_MOVIES_SEARCH = 'MissingMoviesSearch';
 export const MOVE_MOVIE = 'MoveMovie';
 export const REFRESH_COLLECTIONS = 'RefreshCollections';
 export const REFRESH_MOVIE = 'RefreshMovie';
+export const REFRESH_PERFORMER = 'SyncPerformerItems';
 export const RENAME_FILES = 'RenameFiles';
 export const RENAME_MOVIE = 'RenameMovie';
 export const RESET_API_KEY = 'ResetApiKey';

--- a/frontend/src/Performer/Details/PerformerDetailsConnector.js
+++ b/frontend/src/Performer/Details/PerformerDetailsConnector.js
@@ -169,8 +169,8 @@ class PerformerDetailsConnector extends Component {
 
   onRefreshPress = () => {
     this.props.dispatchExecuteCommand({
-      name: commandNames.REFRESH_MOVIE,
-      movieIds: [this.props.id]
+      name: commandNames.REFRESH_PERFORMER,
+      performerIds: [this.props.id]
     });
   };
 

--- a/frontend/src/Studio/Details/StudioDetailsConnector.js
+++ b/frontend/src/Studio/Details/StudioDetailsConnector.js
@@ -169,8 +169,8 @@ class StudioDetailsConnector extends Component {
 
   onRefreshPress = () => {
     this.props.dispatchExecuteCommand({
-      name: commandNames.REFRESH_MOVIE,
-      movieIds: [this.props.id]
+      name: commandNames.REFRESH_STUDIO,
+      studioIds: [this.props.id]
     });
   };
 

--- a/src/NzbDrone.Core/Movies/Performers/SyncPerformerItemsService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/SyncPerformerItemsService.cs
@@ -24,7 +24,6 @@ namespace NzbDrone.Core.Movies.Performers
         private readonly IEventAggregator _eventAggregator;
         private readonly IImportExclusionsService _importExclusionService;
 
-        private readonly RefreshMovieService _refreshMovieService;
         private readonly Logger _logger;
 
         public SyncPerformerItemsService(IProvideMovieInfo movieInfo,
@@ -45,7 +44,6 @@ namespace NzbDrone.Core.Movies.Performers
             _configService = configService;
             _diskScanService = diskScanService;
             _eventAggregator = eventAggregator;
-            _refreshMovieService = refreshMovieService;
             _importExclusionService = importExclusionsService;
             _logger = logger;
         }

--- a/src/NzbDrone.Core/Movies/Performers/SyncPerformerItemsService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/SyncPerformerItemsService.cs
@@ -1,9 +1,13 @@
 using System;
 using System.Linq;
 using NLog;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.ImportLists.ImportExclusions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Commands;
+using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies.Commands;
 
@@ -15,21 +19,33 @@ namespace NzbDrone.Core.Movies.Performers
         private readonly IPerformerService _performerService;
         private readonly IMovieService _movieService;
         private readonly IAddMovieService _addMovieService;
+        private readonly IConfigService _configService;
+        private readonly IDiskScanService _diskScanService;
+        private readonly IEventAggregator _eventAggregator;
         private readonly IImportExclusionsService _importExclusionService;
 
+        private readonly RefreshMovieService _refreshMovieService;
         private readonly Logger _logger;
 
         public SyncPerformerItemsService(IProvideMovieInfo movieInfo,
                                         IPerformerService performerService,
                                         IMovieService movieService,
                                         IAddMovieService addMovieService,
-                                        IImportExclusionsService importExclusionsService,
+                                        IConfigService configService,
+                                        IDiskScanService diskScanService,
+                                        IEventAggregator eventAggregator,
+                                        RefreshMovieService refreshMovieService,
+                                        ImportExclusionsService importExclusionsService,
                                         Logger logger)
         {
             _movieInfo = movieInfo;
             _performerService = performerService;
             _movieService = movieService;
             _addMovieService = addMovieService;
+            _configService = configService;
+            _diskScanService = diskScanService;
+            _eventAggregator = eventAggregator;
+            _refreshMovieService = refreshMovieService;
             _importExclusionService = importExclusionsService;
             _logger = logger;
         }
@@ -62,6 +78,39 @@ namespace NzbDrone.Core.Movies.Performers
             }
         }
 
+        private void RescanMovie(Movie movie, bool isNew, CommandTrigger trigger)
+        {
+            var rescanAfterRefresh = _configService.RescanAfterRefresh;
+
+            if (isNew)
+            {
+                _logger.Trace("Forcing rescan of {0}. Reason: New movie", movie);
+            }
+            else if (rescanAfterRefresh == RescanAfterRefreshType.Never)
+            {
+                _logger.Trace("Skipping rescan of {0}. Reason: Never rescan after refresh", movie);
+                _eventAggregator.PublishEvent(new MovieScanSkippedEvent(movie, MovieScanSkippedReason.NeverRescanAfterRefresh));
+
+                return;
+            }
+            else if (rescanAfterRefresh == RescanAfterRefreshType.AfterManual && trigger != CommandTrigger.Manual)
+            {
+                _logger.Trace("Skipping rescan of {0}. Reason: Not after automatic scans", movie);
+                _eventAggregator.PublishEvent(new MovieScanSkippedEvent(movie, MovieScanSkippedReason.RescanAfterManualRefreshOnly));
+
+                return;
+            }
+
+            try
+            {
+                _diskScanService.Scan(movie);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, "Couldn't rescan movie {0}", movie);
+            }
+        }
+
         public void Execute(SyncPerformerItemsCommand message)
         {
             if (message.PerformerIds.Any())
@@ -69,6 +118,17 @@ namespace NzbDrone.Core.Movies.Performers
                 foreach (var performerId in message.PerformerIds)
                 {
                     var performer = _performerService.GetById(performerId);
+                    var items = _movieService.GetByPerformerForeignId(performer.ForeignId);
+                    var trigger = message.Trigger;
+                    var isNew = false;
+
+                    // Rescan before sync since syncing will add a new movie and scan automatically
+                    foreach (var movieItem in items)
+                    {
+                        var movie = _movieService.GetMovie(movieItem.Id);
+                        RescanMovie(movie, isNew, trigger);
+                    }
+
                     SyncPerformerItems(performer);
                 }
             }

--- a/src/NzbDrone.Core/Movies/Studios/SyncStudioItemsService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/SyncStudioItemsService.cs
@@ -1,9 +1,13 @@
 using System;
 using System.Linq;
 using NLog;
+using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.ImportLists.ImportExclusions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Commands;
+using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies.Commands;
 
@@ -15,6 +19,9 @@ namespace NzbDrone.Core.Movies.Studios
         private readonly IStudioService _studioService;
         private readonly IMovieService _movieService;
         private readonly IAddMovieService _addMovieService;
+        private readonly IConfigService _configService;
+        private readonly IDiskScanService _diskScanService;
+        private readonly IEventAggregator _eventAggregator;
         private readonly IImportExclusionsService _importExclusionService;
 
         private readonly Logger _logger;
@@ -23,6 +30,9 @@ namespace NzbDrone.Core.Movies.Studios
                                         IStudioService studioService,
                                         IMovieService movieService,
                                         IAddMovieService addMovieService,
+                                        IConfigService configService,
+                                        IDiskScanService diskScanService,
+                                        IEventAggregator eventAggregator,
                                         IImportExclusionsService importExclusionsService,
                                         Logger logger)
         {
@@ -30,6 +40,9 @@ namespace NzbDrone.Core.Movies.Studios
             _studioService = studioService;
             _movieService = movieService;
             _addMovieService = addMovieService;
+            _configService = configService;
+            _diskScanService = diskScanService;
+            _eventAggregator = eventAggregator;
             _importExclusionService = importExclusionsService;
             _logger = logger;
         }
@@ -62,6 +75,39 @@ namespace NzbDrone.Core.Movies.Studios
             }
         }
 
+        private void RescanMovie(Movie movie, bool isNew, CommandTrigger trigger)
+        {
+            var rescanAfterRefresh = _configService.RescanAfterRefresh;
+
+            if (isNew)
+            {
+                _logger.Trace("Forcing rescan of {0}. Reason: New movie", movie);
+            }
+            else if (rescanAfterRefresh == RescanAfterRefreshType.Never)
+            {
+                _logger.Trace("Skipping rescan of {0}. Reason: Never rescan after refresh", movie);
+                _eventAggregator.PublishEvent(new MovieScanSkippedEvent(movie, MovieScanSkippedReason.NeverRescanAfterRefresh));
+
+                return;
+            }
+            else if (rescanAfterRefresh == RescanAfterRefreshType.AfterManual && trigger != CommandTrigger.Manual)
+            {
+                _logger.Trace("Skipping rescan of {0}. Reason: Not after automatic scans", movie);
+                _eventAggregator.PublishEvent(new MovieScanSkippedEvent(movie, MovieScanSkippedReason.RescanAfterManualRefreshOnly));
+
+                return;
+            }
+
+            try
+            {
+                _diskScanService.Scan(movie);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, "Couldn't rescan movie {0}", movie);
+            }
+        }
+
         public void Execute(SyncStudioItemsCommand message)
         {
             if (message.StudioIds.Any())
@@ -69,6 +115,17 @@ namespace NzbDrone.Core.Movies.Studios
                 foreach (var studioId in message.StudioIds)
                 {
                     var studio = _studioService.GetById(studioId);
+                    var items = _movieService.GetByStudioForeignId(studio.ForeignId);
+                    var trigger = message.Trigger;
+                    var isNew = false;
+
+                    // Rescan before sync since syncing will add a new movie and scan automatically
+                    foreach (var movieItem in items)
+                    {
+                        var movie = _movieService.GetMovie(movieItem.Id);
+                        RescanMovie(movie, isNew, trigger);
+                    }
+
                     SyncStudioItems(studio);
                 }
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Changed the Performer Refresh & Scan command from RefreshMovie to SyncPerformerItems and added Rescan to the class.

#### Screenshot (if UI related)
N/A

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
N/A
* Fixes #XXXX