### PR TITLE
New: Add "Scene Info" (TPDB) link to scene modal

### DIFF
--- a/frontend/src/Episode/Summary/EpisodeSummary.css
+++ b/frontend/src/Episode/Summary/EpisodeSummary.css
@@ -8,6 +8,10 @@
   margin-top: 20px;
 }
 
+.sceneInfoLink {
+  color: var(--textColor);
+}
+
 .actors {
   display: inline-block;
   margin-top: 10px;

--- a/frontend/src/Episode/Summary/EpisodeSummary.css.d.ts
+++ b/frontend/src/Episode/Summary/EpisodeSummary.css.d.ts
@@ -12,6 +12,7 @@ interface CssExports {
   'overview': string;
   'path': string;
   'quality': string;
+  'sceneInfoLink': string;
   'size': string;
 }
 export const cssExports: CssExports;

--- a/frontend/src/Episode/Summary/EpisodeSummary.js
+++ b/frontend/src/Episode/Summary/EpisodeSummary.js
@@ -103,7 +103,7 @@ class EpisodeSummary extends Component {
     } = this.props;
 
     const hasOverview = !!overview;
-    const sceneInfoLink = `https://metadataapi.net/scenes/${tvdbId}`
+    const sceneInfoLink = `https://metadataapi.net/scenes/${tvdbId}`;
     return (
       <div>
         <div>
@@ -161,9 +161,9 @@ class EpisodeSummary extends Component {
               translate('NoEpisodeOverview')
           }
         </div>
-        <a 
+        <a
           className={styles.sceneInfoLink}
-          href={sceneInfoLink} target="_blank" 
+          href={sceneInfoLink} target="_blank"
         >
           {translate('SceneInfo')}
         </a>

--- a/frontend/src/Episode/Summary/EpisodeSummary.js
+++ b/frontend/src/Episode/Summary/EpisodeSummary.js
@@ -94,6 +94,7 @@ class EpisodeSummary extends Component {
       path,
       size,
       actors,
+      tvdbId,
       languages,
       quality,
       customFormats,
@@ -102,7 +103,7 @@ class EpisodeSummary extends Component {
     } = this.props;
 
     const hasOverview = !!overview;
-
+    const sceneInfoLink = `https://metadataapi.net/scenes/${tvdbId}`
     return (
       <div>
         <div>
@@ -160,7 +161,12 @@ class EpisodeSummary extends Component {
               translate('NoEpisodeOverview')
           }
         </div>
-
+        <a 
+          className={styles.sceneInfoLink}
+          href={sceneInfoLink} target="_blank" 
+        >
+          {translate('SceneInfo')}
+        </a>
         {
           path ?
             <Table columns={columns}>

--- a/frontend/src/Episode/Summary/EpisodeSummary.js
+++ b/frontend/src/Episode/Summary/EpisodeSummary.js
@@ -212,6 +212,7 @@ EpisodeSummary.propTypes = {
   path: PropTypes.string,
   size: PropTypes.number,
   actors: PropTypes.arrayOf(PropTypes.object),
+  tvdbId: PropTypes.string,
   joinedPerformers: PropTypes.string,
   languages: PropTypes.arrayOf(PropTypes.object),
   quality: PropTypes.object,

--- a/frontend/src/Episode/Summary/EpisodeSummaryConnector.js
+++ b/frontend/src/Episode/Summary/EpisodeSummaryConnector.js
@@ -25,7 +25,8 @@ function createMapStateToProps() {
       const {
         releaseDate,
         overview,
-        actors
+        actors,
+        tvdbId
       } = episode;
 
       const {
@@ -45,6 +46,7 @@ function createMapStateToProps() {
         releaseDate,
         overview,
         actors,
+        tvdbId,
         mediaInfo,
         path,
         size,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The goal was to provide an easy way to get to the source data for a specific scene/episode.  Having a direct link to the TPDB (or Stash, when V3 comes around) page gets around the inability to see things like the scene image, tags, etc. that aren't pulled into Whisparr.  This uses the tvdbId of the Episode as the key, so assuming V3 retains that in the DB scheme, this change will be portable to V3 without much more than changing the URL path for the link.

#### Screenshot (if UI related)
![image](https://github.com/Whisparr/Whisparr/assets/132735020/afae65b5-1997-42a9-90ec-5c550339cd35)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)