### PR TITLE
Fix: Performer related fixes and additions

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovie/AddNewMovieSearchResult.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovie/AddNewMovieSearchResult.js
@@ -97,12 +97,13 @@ class AddNewMovieSearchResult extends Component {
     if (itemType === 'scene') {
       ImageItem = ScenePoster;
       posterWidth = 300;
-      posterHeight = 167;
+      posterHeight = 169;
     }
 
     const elementStyle = {
       width: `${posterWidth}px`,
-      height: `${posterHeight}px`
+      height: `${posterHeight}px`,
+      objectFit: 'contain'
     };
 
     return (

--- a/frontend/src/AddMovie/AddNewMovie/AddNewPerformer/AddNewPerformerModalContent.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewPerformer/AddNewPerformerModalContent.js
@@ -39,7 +39,7 @@ class AddNewPerformerModalContent extends Component {
       rootFolderPath,
       monitor,
       qualityProfileId,
-      searchForPerformer,
+      searchForMovie,
       tags,
       isSmallScreen,
       safeForWorkMode,
@@ -130,15 +130,15 @@ class AddNewPerformerModalContent extends Component {
         <ModalFooter className={styles.modalFooter}>
           <label className={styles.searchForMissingMovieLabelContainer}>
             <span className={styles.searchForMissingMovieLabel}>
-              {translate('StartSearchForMissingPerformer')}
+              {translate('SearchOnAddPerformerHelpText')}
             </span>
 
             <CheckInput
               containerClassName={styles.searchForMissingMovieContainer}
               className={styles.searchForMissingMovieInput}
-              name="searchForPerformer"
+              name="searchForMovie"
               onChange={onInputChange}
-              {...searchForPerformer}
+              {...searchForMovie}
             />
           </label>
 
@@ -164,7 +164,7 @@ AddNewPerformerModalContent.propTypes = {
   rootFolderPath: PropTypes.object,
   monitor: PropTypes.object.isRequired,
   qualityProfileId: PropTypes.object,
-  searchForPerformer: PropTypes.object.isRequired,
+  searchForMovie: PropTypes.object.isRequired,
   tags: PropTypes.object.isRequired,
   isSmallScreen: PropTypes.bool.isRequired,
   isWindows: PropTypes.bool.isRequired,

--- a/frontend/src/AddMovie/AddNewMovie/AddNewPerformer/AddNewPerformerModalContentConnector.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewPerformer/AddNewPerformerModalContentConnector.js
@@ -60,7 +60,7 @@ class AddNewPerformerModalContentConnector extends Component {
       rootFolderPath,
       monitor,
       qualityProfileId,
-      searchForPerformer,
+      searchForMovie,
       tags
     } = this.props;
 
@@ -69,7 +69,7 @@ class AddNewPerformerModalContentConnector extends Component {
       rootFolderPath: rootFolderPath.value,
       monitor: monitor.value,
       qualityProfileId: qualityProfileId.value,
-      searchForPerformer: searchForPerformer.value,
+      searchForMovie: searchForMovie.value,
       tags: tags.value
     });
   };
@@ -93,7 +93,7 @@ AddNewPerformerModalContentConnector.propTypes = {
   rootFolderPath: PropTypes.object,
   monitor: PropTypes.object.isRequired,
   qualityProfileId: PropTypes.object,
-  searchForPerformer: PropTypes.object.isRequired,
+  searchForMovie: PropTypes.object.isRequired,
   tags: PropTypes.object.isRequired,
   onModalClose: PropTypes.func.isRequired,
   setAddPerformerDefault: PropTypes.func.isRequired,

--- a/frontend/src/Movie/Details/MovieDetails.css
+++ b/frontend/src/Movie/Details/MovieDetails.css
@@ -55,9 +55,11 @@
 .screenShot {
   z-index: 2;
   flex-shrink: 0;
+  margin-top: 10px;
   margin-right: 35px;
   width: 368px;
-  height: 250px;
+  height: 207px;
+  object-fit: 'contain';
 }
 
 .info {

--- a/frontend/src/Performer/Details/SceneRow.css
+++ b/frontend/src/Performer/Details/SceneRow.css
@@ -10,6 +10,12 @@
   width: 42px;
 }
 
+.performers {
+  composes: cell from '~Components/Table/Cells/TableRowCell.css';
+
+  width: 400px;
+}
+
 .runtime {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 

--- a/frontend/src/Performer/Details/SceneRow.css.d.ts
+++ b/frontend/src/Performer/Details/SceneRow.css.d.ts
@@ -6,6 +6,7 @@ interface CssExports {
   'customFormatScore': string;
   'languages': string;
   'monitored': string;
+  'performers': string;
   'releaseGroup': string;
   'runtime': string;
   'size': string;

--- a/frontend/src/Performer/Details/SceneRow.js
+++ b/frontend/src/Performer/Details/SceneRow.js
@@ -58,6 +58,7 @@ class SceneRow extends Component {
       hasFile,
       movieFile,
       monitored,
+      credits,
       runtime,
       movieRuntimeFormat,
       releaseDate,
@@ -110,6 +111,22 @@ class SceneRow extends Component {
                     foreignId={foreignId}
                     title={title}
                   />
+                </TableRowCell>
+              );
+            }
+
+            if (name === 'credits') {
+              const joinedPerformers = credits
+                .slice(0, 4)
+                .sort((a, b) => {
+                  return a.performer.name > b.performer.name ? 1 : -1;
+                })
+                .map((credit) => credit.performer.name)
+                .join(', ');
+
+              return (
+                <TableRowCell key={name} className={styles.performers}>
+                  <span title={joinedPerformers}>{joinedPerformers}</span>
                 </TableRowCell>
               );
             }
@@ -337,6 +354,8 @@ SceneRow.propTypes = {
   runtime: PropTypes.number,
   movieRuntimeFormat: PropTypes.string,
   title: PropTypes.string.isRequired,
+  credits: PropTypes.arrayOf(PropTypes.object),
+  joinedPerformers: PropTypes.string,
   isSaving: PropTypes.bool,
   movieFilePath: PropTypes.string,
   movieFileRelativePath: PropTypes.string,

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -64,11 +64,15 @@ const sceneTokens = [
   { token: '{Scene CleanTitle}', example: 'Scenes Title' },
   { token: '{Scene TitleThe}', example: 'Scene\'s Title, The' },
   { token: '{Scene TitleFirstCharacter}', example: 'S' },
-  { token: '{Release Date}', example: '2009-02-04' }
+  { token: '{Scene Performers}', example: 'Abigail Mac Tera Patrick John Holmes' },
+  { token: '{Scene PerformersFemale}', example: 'Abigail Mac Tera Patrick' },
+  { token: '{Release Date}', example: '2009-02-04' },
+  { token: '{Release ShortDate}', example: '09 02 04' }
 ];
 
 const studioTokens = [
   { token: '{Studio Title}', example: 'Studio\'s Title' },
+  { token: '{Studio TitleSlug}', example: 'Studio\'sTitle' },
   { token: '{Studio CleanTitle}', example: 'Studios Title' },
   { token: '{Studio TitleThe}', example: 'Studio\'s Title, The' },
   { token: '{Studio TitleFirstCharacter}', example: 'S' },

--- a/frontend/src/Store/Actions/addMovieActions.js
+++ b/frontend/src/Store/Actions/addMovieActions.js
@@ -4,6 +4,7 @@ import { batchActions } from 'redux-batched-actions';
 import { createThunk, handleThunks } from 'Store/thunks';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
 import getNewMovie from 'Utilities/Movie/getNewMovie';
+import getNewPerformer from 'Utilities/Performer/getNewPerformer';
 import getSectionState from 'Utilities/State/getSectionState';
 import updateSectionState from 'Utilities/State/updateSectionState';
 import { set, update, updateItem } from './baseActions';
@@ -39,7 +40,7 @@ export const defaultState = {
     rootFolderPath: '',
     monitor: 'movieOnly',
     qualityProfileId: 0,
-    searchForPerformer: true,
+    searchForMovie: true,
     tags: []
   }
 };
@@ -227,7 +228,7 @@ export const actionHandlers = handleThunks({
     const foreignId = payload.foreignId;
     const items = getState().addMovie.items;
     const itemToAdd = _.find(items, { foreignId });
-    const newPerformer = getNewMovie(_.cloneDeep(itemToAdd.performer), payload);
+    const newPerformer = getNewPerformer(_.cloneDeep(itemToAdd.performer), payload);
     newPerformer.id = 0;
 
     const promise = createAjaxRequest({

--- a/frontend/src/Store/Actions/performerActions.js
+++ b/frontend/src/Store/Actions/performerActions.js
@@ -54,7 +54,7 @@ export const defaultState = {
     rootFolderPath: '',
     monitor: 'movieOnly',
     qualityProfileId: 0,
-    searchForPerformer: true,
+    searchForMovie: true,
     tags: []
   },
 

--- a/frontend/src/Store/Actions/performerScenesActions.js
+++ b/frontend/src/Store/Actions/performerScenesActions.js
@@ -35,6 +35,11 @@ export const defaultState = {
       isSortable: true
     },
     {
+      name: 'credits',
+      label: 'Performers',
+      isVisible: true
+    },
+    {
       name: 'path',
       label: () => translate('Path'),
       isVisible: false,

--- a/frontend/src/Store/Actions/studioScenesActions.js
+++ b/frontend/src/Store/Actions/studioScenesActions.js
@@ -35,6 +35,11 @@ export const defaultState = {
       isSortable: true
     },
     {
+      name: 'credits',
+      label: 'Performers',
+      isVisible: true
+    },
+    {
       name: 'path',
       label: () => translate('Path'),
       isVisible: false,

--- a/frontend/src/Studio/Details/SceneRow.css
+++ b/frontend/src/Studio/Details/SceneRow.css
@@ -10,6 +10,12 @@
   width: 42px;
 }
 
+.performers {
+  composes: cell from '~Components/Table/Cells/TableRowCell.css';
+
+  width: 400px;
+}
+
 .runtime {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 

--- a/frontend/src/Studio/Details/SceneRow.css.d.ts
+++ b/frontend/src/Studio/Details/SceneRow.css.d.ts
@@ -6,6 +6,7 @@ interface CssExports {
   'customFormatScore': string;
   'languages': string;
   'monitored': string;
+  'performers': string;
   'releaseGroup': string;
   'runtime': string;
   'size': string;

--- a/frontend/src/Studio/Details/SceneRow.js
+++ b/frontend/src/Studio/Details/SceneRow.js
@@ -55,6 +55,7 @@ class SceneRow extends Component {
       foreignId,
       movieFileId,
       monitored,
+      credits,
       runtime,
       isAvailable,
       hasFile,
@@ -110,6 +111,22 @@ class SceneRow extends Component {
                     foreignId={foreignId}
                     title={title}
                   />
+                </TableRowCell>
+              );
+            }
+
+            if (name === 'credits') {
+              const joinedPerformers = credits
+                .slice(0, 4)
+                .sort((a, b) => {
+                  return a.performer.name > b.performer.name ? 1 : -1;
+                })
+                .map((credit) => credit.performer.name)
+                .join(', ');
+
+              return (
+                <TableRowCell key={name} className={styles.performers}>
+                  <span title={joinedPerformers}>{joinedPerformers}</span>
                 </TableRowCell>
               );
             }
@@ -333,6 +350,8 @@ SceneRow.propTypes = {
   hasFile: PropTypes.bool.isRequired,
   movieFile: PropTypes.object,
   monitored: PropTypes.bool.isRequired,
+  credits: PropTypes.arrayOf(PropTypes.object),
+  joinedPerformers: PropTypes.string,
   releaseDate: PropTypes.string,
   runtime: PropTypes.number,
   movieRuntimeFormat: PropTypes.string,

--- a/frontend/src/Studio/Details/StudioDetails.js
+++ b/frontend/src/Studio/Details/StudioDetails.js
@@ -231,7 +231,7 @@ class StudioDetails extends Component {
     const fanartUrl = getFanartUrl(images);
 
     const elementStyle = {
-      'object-fit': 'contain'
+      objectFit: 'contain'
     };
 
     return (

--- a/frontend/src/Studio/Index/Posters/StudioIndexPoster.tsx
+++ b/frontend/src/Studio/Index/Posters/StudioIndexPoster.tsx
@@ -61,7 +61,6 @@ function StudioIndexPoster(props: StudioIndexPosterProps) {
   const elementStyle = {
     width: `${posterWidth}px`,
     height: `${posterHeight}px`,
-    'object-fit': 'contain',
   };
 
   return (

--- a/frontend/src/Utilities/Performer/getNewPerformer.js
+++ b/frontend/src/Utilities/Performer/getNewPerformer.js
@@ -1,0 +1,26 @@
+
+function getNewPerformer(performer, payload) {
+  const {
+    rootFolderPath,
+    monitor,
+    qualityProfileId,
+    tags,
+    searchForMovie = false
+  } = payload;
+
+  const addOptions = {
+    monitor,
+    searchForMovie
+  };
+
+  performer.addOptions = addOptions;
+  performer.monitored = monitor !== 'none';
+  performer.qualityProfileId = qualityProfileId;
+  performer.rootFolderPath = rootFolderPath;
+  performer.tags = tags;
+  performer.searchOnAdd = searchForMovie;
+
+  return performer;
+}
+
+export default getNewPerformer;

--- a/src/NzbDrone.Core/Movies/Performers/Performer.cs
+++ b/src/NzbDrone.Core/Movies/Performers/Performer.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Movies.Performers
         public void ApplyChanges(Performer otherPerformer)
         {
             QualityProfileId = otherPerformer.QualityProfileId;
-
+            SearchOnAdd = otherPerformer.SearchOnAdd;
             Monitored = otherPerformer.Monitored;
 
             RootFolderPath = otherPerformer.RootFolderPath;

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -14,6 +14,7 @@ using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Qualities;
 
@@ -291,8 +292,8 @@ namespace NzbDrone.Core.Organizer
         public static string SlugTitle(string title)
         {
             title = title.Replace(" ", "");
-            title = ScenifyReplaceChars.Replace(title, " ");
             title = ScenifyRemoveChars.Replace(title, string.Empty);
+            title = ScenifyReplaceChars.Replace(title, " ");
 
             return title;
         }
@@ -328,11 +329,21 @@ namespace NzbDrone.Core.Organizer
         {
             if (movie.MovieMetadata.Value.ReleaseDate.IsNotNullOrWhiteSpace())
             {
-                tokenHandlers["{Release Date}"] = m => movie.MovieMetadata.Value.ReleaseDate;
+                var releaseDate = movie.MovieMetadata.Value.ReleaseDate;
+                tokenHandlers["{Release Date}"] = m => releaseDate;
+                tokenHandlers["{Release ShortDate}"] = m => releaseDate.Replace("-", " ").Substring(2);
             }
             else
             {
                 tokenHandlers["{Release Date}"] = m => "Unknown";
+            }
+
+            if (movie.MovieMetadata.Value.Credits != null)
+            {
+                var credits = movie.MovieMetadata.Value.Credits;
+                tokenHandlers["{Scene Performers}"] = m => credits.Select(p => p.Performer.Name).Join(" ");
+                tokenHandlers["{Scene PerformersFemale}"] = m => credits.Where(a => a.Performer.Gender == Gender.Female)
+                                                                        .Select(a => a.Performer.Name).Join(" ");
             }
         }
 


### PR DESCRIPTION
Database Migration
NO

Description
- When adding a performer, the option to search for scenes has been fixed.
- When a Site has 2 or more releases on the same date, the indexer will include all scenes with that date. By adding the performer to the indexer search, it narrows down the amount of scenes returned.
- Added performer naming tokens (male & female, female only).
- Added performers option to the scene row in both performer view and studio view.