### PR TITLE
Fix: Search on add for scene when Studio Network is in the filename

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -407,6 +407,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             {
                 movie.StudioForeignId = resource.Studio.ForeignIds.StashId;
                 movie.StudioTitle = resource.Studio.Title;
+                movie.StudioNetwork = resource.Studio.Network;
             }
             else if (resource.Studio.ForeignIds != null && resource.Studio.ForeignIds.TmdbId > 0)
             {

--- a/src/NzbDrone.Core/Movies/MovieMetadata.cs
+++ b/src/NzbDrone.Core/Movies/MovieMetadata.cs
@@ -27,6 +27,7 @@ namespace NzbDrone.Core.Movies
         public Ratings Ratings { get; set; }
         public string StudioForeignId { get; set; }
         public string StudioTitle { get; set; }
+        public string StudioNetwork { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public int Runtime { get; set; }
         public string Website { get; set; }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -313,10 +313,14 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{Studio TitleThe}"] = m => TitleThe(movie.MovieMetadata.Value.StudioTitle);
             tokenHandlers["{Studio TitleFirstCharacter}"] = m => TitleThe(movie.MovieMetadata.Value.StudioTitle).Substring(0, 1).FirstCharToUpper();
 
-            if (movie.MovieMetadata.Value.StudioForeignId.IsNotNullOrWhiteSpace())
+            if (movie.MovieMetadata.Value.StudioNetwork.IsNotNullOrWhiteSpace())
+            {
+                tokenHandlers["{Studio Network}"] = m => CleanTitle(movie.MovieMetadata.Value.StudioNetwork);
+            }
+            else if (movie.MovieMetadata.Value.StudioForeignId.IsNotNullOrWhiteSpace())
             {
                 var studio = _studioService.FindByForeignId(movie.MovieMetadata.Value.StudioForeignId);
-                tokenHandlers["{Studio Network}"] = m => studio.Network ?? string.Empty;
+                tokenHandlers["{Studio Network}"] = m => studio?.Network ?? string.Empty;
             }
             else
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow the Studio Network token to be used when the studio is not currently in the database by passing the value from the search results. Also null check the studio from the database as it can be null.