### PR TITLE
Fixed: date mismatch for episode air date

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -228,7 +228,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             episode.Runtime = oracleEpisode.Duration.GetValueOrDefault();
 
             episode.AirDate = oracleEpisode.ReleaseDate;
-            episode.AirDateUtc = DateTime.Parse(episode.AirDate, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AdjustToUniversal);
+            episode.AirDateUtc = DateTime.Parse(episode.AirDate, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
             episode.Actors = oracleEpisode.Credits.Select(MapActors).ToList();
 
             episode.Ratings = new Ratings();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The old way of parsing left the DateTime with DateTimeKind.Unspecified. This resulted in a conversion to UTC when written to the database and thus a different date for everybody in a timezone ahead of UTC (for example UTC+1). When we parse the DateTime with DateTimeStyles.AssumeUniversal it sets the kind to DateTimeKind.Utc and no conversions happen.

To get the correct date for existing scenes a refresh of the site in Whisparr is enough.

#### Screenshot (if UI related)

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #109 