### PR TITLE
New: V3 Studio Title is now clickable from Movie/Scene Detail View

### DIFF
--- a/frontend/src/Movie/Details/MovieDetails.css
+++ b/frontend/src/Movie/Details/MovieDetails.css
@@ -145,6 +145,13 @@
   margin-right: 14px;
 }
 
+.studio>a:link,
+.studio>a:visited,
+.studio>a:hover,
+.studio>a:active {
+  color: var(--white);
+}
+
 .certification {
   margin-right: 15px;
   padding: 0 5px;

--- a/frontend/src/Movie/Details/MovieDetails.js
+++ b/frontend/src/Movie/Details/MovieDetails.js
@@ -41,6 +41,7 @@ import MovieCastPostersConnector from './Credits/Cast/MovieCastPostersConnector'
 import MovieDetailsLinks from './MovieDetailsLinks';
 import MovieReleaseDates from './MovieReleaseDates';
 import MovieStatusLabel from './MovieStatusLabel';
+import MovieStudioLink from './MovieStudioLink';
 import MovieTagsConnector from './MovieTagsConnector';
 import styles from './MovieDetails.css';
 
@@ -236,6 +237,7 @@ class MovieDetails extends Component {
       qualityProfileId,
       monitored,
       studioTitle,
+      studioForeignId,
       genres,
       overview,
       isAvailable,
@@ -432,7 +434,7 @@ class MovieDetails extends Component {
                     {
                       !!studioTitle &&
                         <span className={styles.studio}>
-                          {studioTitle}
+                          <MovieStudioLink foreignId={studioForeignId} studioTitle={studioTitle} />
                         </span>
                     }
 
@@ -680,6 +682,7 @@ MovieDetails.propTypes = {
   monitored: PropTypes.bool.isRequired,
   status: PropTypes.string.isRequired,
   studioTitle: PropTypes.string,
+  studioForeignId: PropTypes.string,
   genres: PropTypes.arrayOf(PropTypes.string).isRequired,
   collection: PropTypes.object,
   isAvailable: PropTypes.bool.isRequired,

--- a/frontend/src/Movie/Details/MovieStudioLink.js
+++ b/frontend/src/Movie/Details/MovieStudioLink.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import Link from 'Components/Link/Link';
+
+class MovieStudioLink extends PureComponent {
+
+  render() {
+    const {
+      foreignId,
+      studioTitle
+    } = this.props;
+
+    const link = `/studio/${foreignId}`;
+
+    return (
+      <Link
+        to={link}
+        title={studioTitle}
+      >
+        {studioTitle}
+      </Link>
+    );
+  }
+}
+
+MovieStudioLink.propTypes = {
+  foreignId: PropTypes.string.isRequired,
+  studioTitle: PropTypes.string.isRequired
+};
+
+export default MovieStudioLink;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I added a new wrapper on Studio Title to hyperlink to the Studio Detail View when viewing a Movie/Scene.  I got the component code from the existing MovieTitleLink one.

#### Screenshot (if UI related)
![image](https://github.com/Whisparr/Whisparr/assets/132735020/0361467d-1fd8-4487-b742-95ea73b87ce9)

#### Todos
- [Done ] Tests
- [n/a] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [n/a] [Wiki Updates](https://wiki.servarr.com)