### PR TITLE
V3 Scene Index table view fixes and tweaks

### DIFF
--- a/frontend/src/Movie/Movie.ts
+++ b/frontend/src/Movie/Movie.ts
@@ -32,6 +32,7 @@ interface Movie extends ModelBase {
   titleSlug: string;
   collection: Collection;
   studioTitle: string;
+  studioForeignId: string;
   qualityProfileId: number;
   added: string;
   year: number;

--- a/frontend/src/Scene/Index/Table/SceneIndexRow.css
+++ b/frontend/src/Scene/Index/Table/SceneIndexRow.css
@@ -18,10 +18,24 @@
   flex: 4 0 110px;
 }
 
+.sortTitle>a {
+  flex: 4 0 110px;
+  overflow: hidden;
+  width: max-content;
+  text-overflow: ellipsis;
+}
+
 .studio {
   composes: cell;
 
   flex: 2 0 90px;
+}
+
+.studio>a:link,
+.studio>a:visited,
+.studio>a:hover,
+.studio>a:active {
+  color: var(--white);
 }
 
 .originalLanguage,

--- a/frontend/src/Scene/Index/Table/SceneIndexRow.tsx
+++ b/frontend/src/Scene/Index/Table/SceneIndexRow.tsx
@@ -16,6 +16,7 @@ import EditMovieModalConnector from 'Movie/Edit/EditMovieModalConnector';
 import DeleteSceneModal from 'Scene/Delete/DeleteSceneModal';
 import SceneDetailsLinks from 'Scene/Details/SceneDetailsLinks';
 import createSceneIndexItemSelector from 'Scene/Index/createSceneIndexItemSelector';
+import SceneStudioTitleLink from 'Scene/SceneStudioTitleLink';
 import SceneTitleLink from 'Scene/SceneTitleLink';
 import { executeCommand } from 'Store/Actions/commandActions';
 import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
@@ -61,6 +62,7 @@ function SceneIndexRow(props: SceneIndexRowProps) {
     genres = [],
     tags = [],
     foreignId,
+    studioForeignId,
     isAvailable,
     hasFile,
     movieFile,
@@ -142,7 +144,7 @@ function SceneIndexRow(props: SceneIndexRowProps) {
             <SceneStatusCell
               key={name}
               className={styles[name]}
-              sceneId={sceneId}
+              movieId={sceneId}
               monitored={monitored}
               status={status}
               isSelectMode={isSelectMode}
@@ -163,7 +165,13 @@ function SceneIndexRow(props: SceneIndexRowProps) {
         if (name === 'studio') {
           return (
             <VirtualTableRowCell key={name} className={styles[name]}>
-              {studioTitle}
+              <SceneStudioTitleLink
+                studioForeignId={studioForeignId}
+                studioTitle={studioTitle}
+                className={styles.studio}
+              >
+                {studioTitle}
+              </SceneStudioTitleLink>
             </VirtualTableRowCell>
           );
         }

--- a/frontend/src/Scene/Index/Table/SceneStatusCell.tsx
+++ b/frontend/src/Scene/Index/Table/SceneStatusCell.tsx
@@ -11,7 +11,7 @@ import styles from './SceneStatusCell.css';
 
 interface SceneStatusCellProps {
   className: string;
-  sceneId: number;
+  movieId: number;
   monitored: boolean;
   status: string;
   isSelectMode: boolean;
@@ -22,7 +22,7 @@ interface SceneStatusCellProps {
 function SceneStatusCell(props: SceneStatusCellProps) {
   const {
     className,
-    sceneId,
+    movieId,
     monitored,
     status,
     isSelectMode,
@@ -36,8 +36,8 @@ function SceneStatusCell(props: SceneStatusCellProps) {
   const dispatch = useDispatch();
 
   const onMonitoredPress = useCallback(() => {
-    dispatch(toggleMovieMonitored({ sceneId, monitored: !monitored }));
-  }, [sceneId, monitored, dispatch]);
+    dispatch(toggleMovieMonitored({ movieId, monitored: !monitored }));
+  }, [movieId, monitored, dispatch]);
 
   return (
     <Component className={className} {...otherProps}>

--- a/frontend/src/Scene/SceneStudioTitleLink.js
+++ b/frontend/src/Scene/SceneStudioTitleLink.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import Link from 'Components/Link/Link';
+
+class SceneStudioTitleLink extends PureComponent {
+
+  render() {
+    const {
+      studioForeignId,
+      studioTitle
+    } = this.props;
+
+    const link = `/studio/${studioForeignId}`;
+
+    return (
+      <Link
+        to={link}
+        title={studioTitle}
+      >
+        {studioTitle}
+      </Link>
+    );
+  }
+}
+
+SceneStudioTitleLink.propTypes = {
+  studioForeignId: PropTypes.string.isRequired,
+  studioTitle: PropTypes.string.isRequired
+};
+
+export default SceneStudioTitleLink;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
* Fixed CSS for scene title so it doesn't flex behind the Studio column
* Made Studio name clickable to go to the studio detail sceen
* Fixed the toggle to monitor scenes while in edit mode.  This was looking for `movieId` as a property, and I think when this component was cloned, someone did a blanket find/replace for `movie` -> `scene`.  There may be a better fix, but it's working as desired now.

#### Screenshot (if UI related)
![image](https://github.com/Whisparr/Whisparr/assets/132735020/ba98fae5-4290-4e61-aaf7-112627e11533)
![image](https://github.com/Whisparr/Whisparr/assets/132735020/e489f3c2-85d0-49b5-b231-a7a80338dfc8)


#### Todos
- [ x] Tests
- [x ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ n/a] [Wiki Updates](https://wiki.servarr.com)