### PR TITLE
Fixed: Scene sorting by date in performer/studio detail pages

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetailsStudioConnector.js
+++ b/frontend/src/Performer/Details/PerformerDetailsStudioConnector.js
@@ -37,10 +37,17 @@ function createMapStateToProps() {
     (studioForeignId, performerScenes, studio, scenes, performer, dimensions) => {
 
       const scenesInStudio = scenes.filter((scene) => scene.studioForeignId === studioForeignId && scene.credits.some((credit) => credit.performer.foreignId === performer.foreignId));
+      const sortedScenes =scenesInStudio.sort(
+        (a, b) => {
+          if (performerScenes.sortDirection === 'ascending') {
+            return new Date(a.releaseDate) - new Date(b.releaseDate);
+          }
+          return new Date(b.releaseDate) - new Date(a.releaseDate);
+        });
 
       return {
         ...studio,
-        items: scenesInStudio,
+        items: sortedScenes,
         columns: performerScenes.columns,
         sortKey: performerScenes.sortKey,
         sortDirection: performerScenes.sortDirection,

--- a/frontend/src/Store/Actions/performerScenesActions.js
+++ b/frontend/src/Store/Actions/performerScenesActions.js
@@ -16,9 +16,9 @@ export const section = 'performerScenes';
 // State
 
 export const defaultState = {
-  sortKey: 'fullName',
-  sortDirection: sortDirections.ASCENDING,
-  secondarySortKey: 'fullName',
+  sortKey: 'releaseDate',
+  sortDirection: sortDirections.DESCENDING,
+  secondarySortKey: 'title',
   secondarySortDirection: sortDirections.ASCENDING,
 
   columns: [

--- a/frontend/src/Store/Actions/studioScenesActions.js
+++ b/frontend/src/Store/Actions/studioScenesActions.js
@@ -16,9 +16,9 @@ export const section = 'studioScenes';
 // State
 
 export const defaultState = {
-  sortKey: 'fullName',
-  sortDirection: sortDirections.ASCENDING,
-  secondarySortKey: 'fullName',
+  sortKey: 'releaseDate',
+  sortDirection: sortDirections.DESCENDING,
+  secondarySortKey: 'title',
   secondarySortDirection: sortDirections.ASCENDING,
 
   columns: [

--- a/frontend/src/Studio/Details/StudioDetailsYearConnector.js
+++ b/frontend/src/Studio/Details/StudioDetailsYearConnector.js
@@ -22,10 +22,17 @@ function createMapStateToProps() {
     (year, studioForeignId, studioScenes, scenes, studio, dimensions) => {
 
       const scenesInYear = scenes.filter((scene) => scene.studioForeignId === studioForeignId && scene.year === year);
+      const sortedScenes =scenesInYear.sort(
+        (a, b) => {
+          if (studioScenes.sortDirection === 'ascending') {
+            return new Date(a.releaseDate) - new Date(b.releaseDate);
+          }
+          return new Date(b.releaseDate) - new Date(a.releaseDate);
+        });
 
       return {
         year,
-        items: scenesInYear,
+        items: sortedScenes,
         columns: studioScenes.columns,
         sortKey: studioScenes.sortKey,
         sortDirection: studioScenes.sortDirection,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Sort scenes in the performer/studio detail pages. Default is desc releaseDate, then by asc title.

#### Screenshot (if UI related)
![scene_sorting_desc](https://github.com/Whisparr/Whisparr/assets/79065505/5c249088-46b1-4a34-966f-b1d011bee41d)
![scene_sorting_asc](https://github.com/Whisparr/Whisparr/assets/79065505/60b1420c-7408-434c-ba1b-dd735a42390d)
