### PR TITLE
Fixed: Release Date using UTC

### DIFF
--- a/src/Whisparr.Api.V3/Movies/MovieResource.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieResource.cs
@@ -31,7 +31,7 @@ namespace Whisparr.Api.V3.Movies
         public long? SizeOnDisk { get; set; }
         public MovieStatusType Status { get; set; }
         public string Overview { get; set; }
-        public DateTime? ReleaseDate { get; set; }
+        public string ReleaseDate { get; set; }
         public string PhysicalReleaseNote { get; set; }
         public List<MediaCover> Images { get; set; }
         public string Website { get; set; }
@@ -93,7 +93,7 @@ namespace Whisparr.Api.V3.Movies
                 Title = model.Title,
                 OriginalLanguage = model.MovieMetadata.Value.OriginalLanguage,
                 SortTitle = model.Title.NormalizeTitle(),
-                ReleaseDate = model.MovieMetadata.Value.ReleaseDateUtc,
+                ReleaseDate = model.MovieMetadata.Value.ReleaseDate,
                 HasFile = model.HasFile,
 
                 SizeOnDisk = size,
@@ -150,7 +150,7 @@ namespace Whisparr.Api.V3.Movies
                     Genres = resource.Genres,
                     Images = resource.Images,
                     SortTitle = resource.SortTitle,
-                    ReleaseDateUtc = resource.ReleaseDate,
+                    ReleaseDate = resource.ReleaseDate,
                     Year = resource.Year,
                     Overview = resource.Overview,
                     Website = resource.Website,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Scenes were using ReleaseDateUtc causing issues with finding files on an Indexer and displaying the wrong dates. Both ReleaseDate and ReleaseDateUtc are in the DB with the same date. Works with both scenes and movies.