### PR TITLE
Fixed: V3 Filter scenes by studio(s)

### DIFF
--- a/frontend/src/Store/Actions/sceneIndexActions.js
+++ b/frontend/src/Store/Actions/sceneIndexActions.js
@@ -193,7 +193,7 @@ export const defaultState = {
       valueType: filterBuilderValueTypes.RELEASE_STATUS
     },
     {
-      name: 'studio',
+      name: 'studioTitle',
       label: () => translate('Studio'),
       type: filterBuilderTypes.EXACT,
       optionsSelector: function(items) {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Eros had a small bug in scene custom filters where when creating one based on one or more studios, it would always return the `All scenes hidden due to filter` message.  I dug in, and found that the filter being saved to the DB was using `studio` instead of `studioTitle`, where the latter is the proper column on the Movie table.  This change only fixes it for Scenes, which was definitely broken.  I don't know if the same holds true for Movies as I don't have any with a non-null studio in this build.  Before/after custom filter posted [on Discord](https://discord.com/channels/957516730727563285/957516731843215360/1217335696709386320).

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)