### PR TITLE
Fixed: V3 Sdebar Highlighting

### DIFF
--- a/frontend/src/Components/Page/Sidebar/PageSidebar.js
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.js
@@ -203,8 +203,29 @@ function getActiveParent(pathname) {
       });
     }
 
+    // force "Scenes" sidebar when viewing scene detail
+    const uuidRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+    const movieId = pathname.split('movie/')[1];
+
+    if (pathname.contains('movie/') && uuidRegex.test(movieId)) {
+      activeParent = '/scenes';
+      return false;
+    }
+
+    // force Studios highlight when viewing a studio
+    if (pathname.contains('/studio/')) {
+      activeParent = '/studios';
+      return false;
+    }
+
+    // force Performers highlight when viewing a performer
+    if (pathname.contains('/performer/')) {
+      activeParent = '/performers';
+      return false;
+    }
+
     if (
-      (link.to !== '/' && pathname.startsWith(link.to)) ||
+      (pathname.startsWith(link.to)) ||
       (link.alias && pathname.startsWith(link.alias))
     ) {
       activeParent = link.to;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I fixed the highlighting/expansion on the left sidebar when viewing a scene, performer, or studio, as well as when viewing settings and system.  

#### Screenshot (if UI related)
**Scene Detail**
<img width="276" alt="image" src="https://github.com/Whisparr/Whisparr/assets/132735020/ac858367-ac82-427a-bb45-27f71d4a1562">

**Performer Detail**
<img width="380" alt="image" src="https://github.com/Whisparr/Whisparr/assets/132735020/e231691b-6df9-42fe-9ced-a6f9b10931e5">

**Studio Detail**
<img width="280" alt="image" src="https://github.com/Whisparr/Whisparr/assets/132735020/6b224d1c-7488-4574-bce4-6ad982ddb0c6">


#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)