### PR TITLE
Fixed: V3 Scene and Performer covers/screenshots stretch

### DIFF
--- a/frontend/src/Movie/Details/Credits/Cast/MovieCastPoster.js
+++ b/frontend/src/Movie/Details/Credits/Cast/MovieCastPoster.js
@@ -53,7 +53,8 @@ class MovieCastPoster extends Component {
     const elementStyle = {
       width: `${posterWidth}px`,
       height: `${posterHeight}px`,
-      borderRadius: '5px'
+      borderRadius: '5px',
+      'object-fit': 'cover'
     };
 
     const contentStyle = {
@@ -93,11 +94,10 @@ class MovieCastPoster extends Component {
                 onLoad={this.onPosterLoad}
               />
 
-              {
-                hasPosterError &&
-                  <div className={styles.overlayTitle}>
-                    {performer.fullName}
-                  </div>
+              {hasPosterError &&
+                <div className={styles.overlayTitle}>
+                  {performer.fullName}
+                </div>
               }
             </Link>
           </div>

--- a/frontend/src/Movie/Details/MovieDetails.js
+++ b/frontend/src/Movie/Details/MovieDetails.js
@@ -47,7 +47,9 @@ import styles from './MovieDetails.css';
 
 const defaultFontSize = parseInt(fonts.defaultFontSize);
 const lineHeight = parseFloat(fonts.lineHeight);
-
+const screenshotStyle = {
+  'object-fit': 'cover'
+};
 function getFanartUrl(images) {
   return _.find(images, { coverType: 'fanart' })?.url;
 }
@@ -357,7 +359,7 @@ class MovieDetails extends Component {
             </div>
 
             <div className={styles.headerContent}>
-              <ImageComponent
+              <ImageComponent style={screenshotStyle}
                 blur={safeForWorkMode}
                 className={itemType === 'movie' ? styles.poster : styles.screenShot}
                 images={images}
@@ -406,43 +408,39 @@ class MovieDetails extends Component {
 
                 <div className={styles.details}>
                   <div>
-                    {
-                      !!certification &&
-                        <span className={styles.certification}>
-                          {certification}
-                        </span>
+                    {!!certification &&
+                      <span className={styles.certification}>
+                        {certification}
+                      </span>
                     }
 
-                    {
-                      year > 0 &&
-                        <span className={styles.year}>
-                          <Popover
-                            anchor={
-                              year
-                            }
-                            title={translate('ReleaseDates')}
-                            body={
-                              <MovieReleaseDates
-                                releaseDate={releaseDate}
-                              />
-                            }
-                            position={tooltipPositions.BOTTOM}
-                          />
-                        </span>
+                    {year > 0 &&
+                      <span className={styles.year}>
+                        <Popover
+                          anchor={
+                            year
+                          }
+                          title={translate('ReleaseDates')}
+                          body={
+                            <MovieReleaseDates
+                              releaseDate={releaseDate}
+                            />
+                          }
+                          position={tooltipPositions.BOTTOM}
+                        />
+                      </span>
                     }
 
-                    {
-                      !!studioTitle &&
-                        <span className={styles.studio}>
-                          <MovieStudioLink foreignId={studioForeignId} studioTitle={studioTitle} />
-                        </span>
+                    {!!studioTitle &&
+                      <span className={styles.studio}>
+                        <MovieStudioLink foreignId={studioForeignId} studioTitle={studioTitle} />
+                      </span>
                     }
 
-                    {
-                      !!runtime &&
-                        <span className={styles.runtime}>
-                          {formatRuntime(runtime, movieRuntimeFormat)}
-                        </span>
+                    {!!runtime &&
+                      <span className={styles.runtime}>
+                        {formatRuntime(runtime, movieRuntimeFormat)}
+                      </span>
                     }
 
                     {
@@ -465,44 +463,41 @@ class MovieDetails extends Component {
                       </span>
                     }
 
-                    {
-                      !!tags.length &&
-                        <span>
-                          <Tooltip
-                            anchor={
-                              <Icon
-                                name={icons.TAGS}
-                                size={20}
-                              />
-                            }
-                            tooltip={
-                              <MovieTagsConnector movieId={id} />
-                            }
-                            position={tooltipPositions.BOTTOM}
-                          />
-                        </span>
+                    {!!tags.length &&
+                      <span>
+                        <Tooltip
+                          anchor={
+                            <Icon
+                              name={icons.TAGS}
+                              size={20}
+                            />
+                          }
+                          tooltip={
+                            <MovieTagsConnector movieId={id} />
+                          }
+                          position={tooltipPositions.BOTTOM}
+                        />
+                      </span>
                     }
                   </div>
                 </div>
 
                 <div className={styles.details}>
-                  {
-                    !!ratings.tmdb &&
-                      <span className={styles.rating}>
-                        <TmdbRating
-                          ratings={ratings}
-                          iconSize={20}
-                        />
-                      </span>
+                  {!!ratings.tmdb &&
+                    <span className={styles.rating}>
+                      <TmdbRating
+                        ratings={ratings}
+                        iconSize={20}
+                      />
+                    </span>
                   }
-                  {
-                    !!ratings.rottenTomatoes &&
-                      <span className={styles.rating}>
-                        <RottenTomatoRating
-                          ratings={ratings}
-                          iconSize={20}
-                        />
-                      </span>
+                  {!!ratings.rottenTomatoes &&
+                    <span className={styles.rating}>
+                      <RottenTomatoRating
+                        ratings={ratings}
+                        iconSize={20}
+                      />
+                    </span>
                   }
                 </div>
 
@@ -559,17 +554,16 @@ class MovieDetails extends Component {
                     </span>
                   </InfoLabel>
 
-                  {
-                    !!genres.length && !isSmallScreen &&
-                      <InfoLabel
-                        className={styles.detailsInfoLabel}
-                        title={translate('Genres')}
-                        size={sizes.LARGE}
-                      >
-                        <span className={styles.genres}>
-                          {genres.slice(0, 3).join(', ')}
-                        </span>
-                      </InfoLabel>
+                  {!!genres.length && !isSmallScreen &&
+                    <InfoLabel
+                      className={styles.detailsInfoLabel}
+                      title={translate('Genres')}
+                      size={sizes.LARGE}
+                    >
+                      <span className={styles.genres}>
+                        {genres.slice(0, 3).join(', ')}
+                      </span>
+                    </InfoLabel>
                   }
                 </div>
 

--- a/frontend/src/Performer/Details/PerformerDetails.css
+++ b/frontend/src/Performer/Details/PerformerDetails.css
@@ -41,7 +41,7 @@
 .poster {
   z-index: 2;
   flex-shrink: 0;
-  margin-right: 35px;
+  margin-right: 30px;
   width: 217px;
   height: 319px;
 }

--- a/frontend/src/Performer/Details/PerformerDetails.js
+++ b/frontend/src/Performer/Details/PerformerDetails.js
@@ -236,6 +236,9 @@ class PerformerDetails extends Component {
     const runningYears = statusDetails.title === translate('Inactive') ? `${careerStart}-${careerEnd}` : `${careerStart}-`;
 
     const fanartUrl = getFanartUrl(images);
+    const elementStyle = {
+      'object-fit': 'cover'
+    };
 
     return (
       <PageContent title={fullName}>
@@ -293,6 +296,7 @@ class PerformerDetails extends Component {
               <MovieHeadshot
                 blur={safeForWorkMode}
                 className={styles.poster}
+                style={elementStyle}
                 images={images}
                 size={250}
                 lazy={false}
@@ -339,25 +343,22 @@ class PerformerDetails extends Component {
 
                 <div className={styles.details}>
                   <div>
-                    {
-                      !!gender &&
-                        <span className={styles.gender}>
-                          {firstCharToUpper(gender)}
-                        </span>
+                    {!!gender &&
+                      <span className={styles.gender}>
+                        {firstCharToUpper(gender)}
+                      </span>
                     }
 
-                    {
-                      !!ethnicity &&
-                        <span className={styles.ethnicity}>
-                          {firstCharToUpper(ethnicity)}
-                        </span>
+                    {!!ethnicity &&
+                      <span className={styles.ethnicity}>
+                        {firstCharToUpper(ethnicity)}
+                      </span>
                     }
 
-                    {
-                      !!careerStart &&
-                        <span className={styles.years}>
-                          {runningYears}
-                        </span>
+                    {!!careerStart &&
+                      <span className={styles.years}>
+                        {runningYears}
+                      </span>
                     }
 
                     {
@@ -379,22 +380,21 @@ class PerformerDetails extends Component {
                       </span>
                     }
 
-                    {
-                      !!tags.length &&
-                        <span>
-                          <Tooltip
-                            anchor={
-                              <Icon
-                                name={icons.TAGS}
-                                size={20}
-                              />
-                            }
-                            tooltip={
-                              <PerformerTagsConnector performerId={id} />
-                            }
-                            position={tooltipPositions.BOTTOM}
-                          />
-                        </span>
+                    {!!tags.length &&
+                      <span>
+                        <Tooltip
+                          anchor={
+                            <Icon
+                              name={icons.TAGS}
+                              size={20}
+                            />
+                          }
+                          tooltip={
+                            <PerformerTagsConnector performerId={id} />
+                          }
+                          position={tooltipPositions.BOTTOM}
+                        />
+                      </span>
                     }
                   </div>
                 </div>
@@ -489,17 +489,16 @@ class PerformerDetails extends Component {
                     position={tooltipPositions.BOTTOM}
                   />
 
-                  {
-                    !!genres.length && !isSmallScreen &&
-                      <Label
-                        className={styles.detailsInfoLabel}
-                        title={translate('Genres')}
-                        size={sizes.LARGE}
-                      >
-                        <span className={styles.genres}>
-                          {genres.join(', ')}
-                        </span>
-                      </Label>
+                  {!!genres.length && !isSmallScreen &&
+                    <Label
+                      className={styles.detailsInfoLabel}
+                      title={translate('Genres')}
+                      size={sizes.LARGE}
+                    >
+                      <span className={styles.genres}>
+                        {genres.join(', ')}
+                      </span>
+                    </Label>
                   }
                 </div>
               </div>
@@ -523,29 +522,26 @@ class PerformerDetails extends Component {
                 null
             }
 
-            {
-              !isFetching && isPopulated && hasScenes ?
-                <FieldSet legend={translate('Scenes')}>
-                  {
-                    isPopulated && !!studios.length &&
-                      <div>
-                        {
-                          studios.map((studio) => {
-                            return (
-                              <PerformerDetailsStudioConnector
-                                key={studio.foreignId}
-                                performerId={id}
-                                studioForeignId={studio.foreignId}
-                                isExpanded={expandedState[studio.foreignId]}
-                                onExpandPress={this.onExpandPress}
-                              />
-                            );
-                          })
-                        }
-                      </div>
-                  }
-                </FieldSet> :
-                null
+            {!isFetching && isPopulated && hasScenes ?
+              <FieldSet legend={translate('Scenes')}>
+                {isPopulated && !!studios.length &&
+                  <div>
+                    {studios.map((studio) => {
+                      return (
+                        <PerformerDetailsStudioConnector
+                          key={studio.foreignId}
+                          performerId={id}
+                          studioForeignId={studio.foreignId}
+                          isExpanded={expandedState[studio.foreignId]}
+                          onExpandPress={this.onExpandPress}
+                        />
+                      );
+                    })
+                    }
+                  </div>
+                }
+              </FieldSet> :
+              null
             }
           </div>
 

--- a/frontend/src/Performer/Index/Posters/PerformerIndexPoster.tsx
+++ b/frontend/src/Performer/Index/Posters/PerformerIndexPoster.tsx
@@ -64,6 +64,7 @@ function PerformerIndexPoster(props: PerformerIndexPosterProps) {
   const elementStyle = {
     width: `${posterWidth}px`,
     height: `${posterHeight}px`,
+    'object-fit': 'cover',
   };
 
   return (

--- a/frontend/src/Scene/Index/Overview/SceneIndexOverview.tsx
+++ b/frontend/src/Scene/Index/Overview/SceneIndexOverview.tsx
@@ -124,6 +124,7 @@ function SceneIndexOverview(props: SceneIndexOverviewProps) {
   const elementStyle = {
     width: `${posterWidth}px`,
     height: `${posterHeight}px`,
+    'object-fit': 'cover',
   };
 
   const contentHeight = useMemo(() => {

--- a/frontend/src/Scene/Index/Posters/SceneIndexPoster.tsx
+++ b/frontend/src/Scene/Index/Posters/SceneIndexPoster.tsx
@@ -130,6 +130,7 @@ function SceneIndexPoster(props: SceneIndexPosterProps) {
   const elementStyle = {
     width: `${posterWidth}px`,
     height: `${posterHeight}px`,
+    'object-fit': 'cover',
   };
 
   return (


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When viewing the scenes index or detail pages, the screenshots/cover photos would be stretched unless they fit a specific consistent aspect ratio.  Many don't, and this is due due StashDB not enforcing a consistent standard for scene covers.  To correct for this, I added `object-fit: cover` to the rendered CSS for these.  I works, and looks a lot better than stretched images.  Note, my commit has extra edits as I ended up having to re-indent to make eslint happy

#### Screenshot (if UI related)
![2024-03-15_23-57-07 (1)](https://github.com/Whisparr/Whisparr/assets/132735020/d73ef453-67f5-4149-9a75-ade3301e0e19)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)