### PR TITLE
Fix: V3 Allow the Studio Network token to be used in file/folder name

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -407,11 +407,13 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             {
                 movie.StudioForeignId = resource.Studio.ForeignIds.StashId;
                 movie.StudioTitle = resource.Studio.Title;
+                movie.Studio = resource.Studio;
             }
             else if (resource.Studio.ForeignIds != null && resource.Studio.ForeignIds.TmdbId > 0)
             {
                 movie.StudioForeignId = resource.Studio.ForeignIds.TmdbId.ToString();
                 movie.StudioTitle = resource.Studio.Title;
+                movie.Studio = resource.Studio;
             }
 
             return movie;

--- a/src/NzbDrone.Core/Movies/MovieMetadata.cs
+++ b/src/NzbDrone.Core/Movies/MovieMetadata.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Equ;
 using NzbDrone.Core.Languages;
+using NzbDrone.Core.MetadataSource.SkyHook.Resource;
 
 namespace NzbDrone.Core.Movies
 {
@@ -26,6 +27,7 @@ namespace NzbDrone.Core.Movies
         public int Year { get; set; }
         public Ratings Ratings { get; set; }
         public string StudioForeignId { get; set; }
+        public StudioResource Studio { get; set; }
         public string StudioTitle { get; set; }
         public DateTime? LastInfoSync { get; set; }
         public int Runtime { get; set; }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -195,11 +195,11 @@ namespace NzbDrone.Core.Organizer
             }
             else
             {
-                AddStudioTokens(tokenHandlers, movie);
                 AddSceneTokens(tokenHandlers, movie);
                 AddSceneTitlePlaceholderTokens(tokenHandlers, movie);
             }
 
+            AddStudioTokens(tokenHandlers, movie);
             AddReleaseDateTokens(tokenHandlers, movie.Year);
             AddIdTokens(tokenHandlers, movie);
 
@@ -308,16 +308,23 @@ namespace NzbDrone.Core.Organizer
 
         private void AddStudioTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie)
         {
-            tokenHandlers["{Studio Title}"] = m => movie.MovieMetadata.Value.StudioTitle;
-            tokenHandlers["{Studio TitleSlug}"] = m => SlugTitle(movie.MovieMetadata.Value.StudioTitle);
-            tokenHandlers["{Studio CleanTitle}"] = m => CleanTitle(movie.MovieMetadata.Value.StudioTitle);
-            tokenHandlers["{Studio TitleThe}"] = m => TitleThe(movie.MovieMetadata.Value.StudioTitle);
-            tokenHandlers["{Studio TitleFirstCharacter}"] = m => TitleThe(movie.MovieMetadata.Value.StudioTitle).Substring(0, 1).FirstCharToUpper();
+            if (movie.MovieMetadata.Value.StudioTitle.IsNotNullOrWhiteSpace())
+            {
+                tokenHandlers["{Studio Title}"] = m => movie.MovieMetadata.Value.StudioTitle;
+                tokenHandlers["{Studio TitleSlug}"] = m => SlugTitle(movie.MovieMetadata.Value.StudioTitle);
+                tokenHandlers["{Studio CleanTitle}"] = m => CleanTitle(movie.MovieMetadata.Value.StudioTitle);
+                tokenHandlers["{Studio TitleThe}"] = m => TitleThe(movie.MovieMetadata.Value.StudioTitle);
+                tokenHandlers["{Studio TitleFirstCharacter}"] = m => TitleThe(movie.MovieMetadata.Value.StudioTitle).Substring(0, 1).FirstCharToUpper();
+            }
 
-            if (movie.MovieMetadata.Value.StudioForeignId.IsNotNullOrWhiteSpace())
+            if (movie.MovieMetadata.Value.Studio != null && movie.MovieMetadata.Value.Studio.Network.IsNotNullOrWhiteSpace())
+            {
+                tokenHandlers["{Studio Network}"] = m => movie.MovieMetadata.Value.Studio.Network;
+            }
+            else if (movie.MovieMetadata.Value.StudioForeignId.IsNotNullOrWhiteSpace())
             {
                 var studio = _studioService.FindByForeignId(movie.MovieMetadata.Value.StudioForeignId);
-                tokenHandlers["{Studio Network}"] = m => studio.Network ?? string.Empty;
+                tokenHandlers["{Studio Network}"] = m => studio?.Network ?? string.Empty;
             }
             else
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow the Studio Network token to be used when the studio is not currently in the database by passing the value from the search results. Also null check the studio from the database as it can be null.

The issue is that you can not have the studio network within a file/folder name unless it is stored in the database as the information was extracted from the database. Passing the value through the search results allows a new scene to be added and the studio details created.

The studio network now can also be used in a movies File/Folder name.

#### Screenshot (if UI related)

![image](https://github.com/Whisparr/Whisparr/assets/80544409/6a97b665-6662-4133-a6f6-a584f141e58d)

![image](https://github.com/Whisparr/Whisparr/assets/80544409/fd2fd03d-444f-4142-ac05-7b8c9b737bce)

[v3.0.0.503] System.NullReferenceException: Object reference not set to an instance of an object.
   at NzbDrone.Core.Organizer.FileNameBuilder.<>c__DisplayClass30_1.<**AddStudioTokens**>b__6(TokenMatch m) in ./Whisparr.Core/Organizer/**FileNameBuilder.cs:line 320**
   at NzbDrone.Core.Organizer.FileNameBuilder.ReplaceToken(Match match, Dictionary`2 tokenHandlers, NamingConfig namingConfig) in ./Whisparr.Core/Organizer/FileNameBuilder.cs:line 606
   at NzbDrone.Core.Organizer.FileNameBuilder.<>c__DisplayClass45_0.<ReplaceTokens>b__0(Match match) in ./Whisparr.Core/Organizer/FileNameBuilder.cs:line 583
   at System.Text.RegularExpressions.Regex.<>c.<Replace>b__84_0(ValueTuple`5& state, Match match)
   at System.Text.RegularExpressions.RegexRunner.Scan[TState](Regex regex, String text, Int32 textstart, TState& state, MatchCallback`1 callback, Boolean reuseMatchObject, TimeSpan timeout)
   at System.Text.RegularExpressions.Regex.Run[TState](String input, Int32 startat, TState& state, MatchCallback`1 callback, Boolean reuseMatchObject)
   at System.Text.RegularExpressions.Regex.Replace(MatchEvaluator evaluator, Regex regex, String input, Int32 count, Int32 startat)
   at NzbDrone.Core.Organizer.FileNameBuilder.ReplaceTokens(String pattern, Dictionary`2 tokenHandlers, NamingConfig namingConfig) in ./Whisparr.Core/Organizer/FileNameBuilder.cs:line 583
   at NzbDrone.Core.Organizer.FileNameBuilder.GetMovieFolder(Movie movie, NamingConfig namingConfig) in ./Whisparr.Core/Organizer/FileNameBuilder.cs:line 221
   at Readarr.Api.V1.Search.SearchController.MapToResource(IEnumerable`1 results)+MoveNext() in ./Whisparr.Api.V3/Search/SearchController.cs:line 78
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncObjectResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeActionMethodAsync()
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeNextActionFilterAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|20_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
   at Whisparr.Http.Middleware.BufferingMiddleware.InvokeAsync(HttpContext context) in ./Whisparr.Http/Middleware/BufferingMiddleware.cs:line 28
   at Whisparr.Http.Middleware.IfModifiedMiddleware.InvokeAsync(HttpContext context) in ./Whisparr.Http/Middleware/IfModifiedMiddleware.cs:line 41
   at Whisparr.Http.Middleware.CacheHeaderMiddleware.InvokeAsync(HttpContext context) in ./Whisparr.Http/Middleware/CacheHeaderMiddleware.cs:line 33
   at Whisparr.Http.Middleware.StartingUpMiddleware.InvokeAsync(HttpContext context) in ./Whisparr.Http/Middleware/StartingUpMiddleware.cs:line 38
   at Whisparr.Http.Middleware.UrlBaseMiddleware.InvokeAsync(HttpContext context) in ./Whisparr.Http/Middleware/UrlBaseMiddleware.cs:line 27
   at Whisparr.Http.Middleware.VersionMiddleware.InvokeAsync(HttpContext context) in ./Whisparr.Http/Middleware/VersionMiddleware.cs:line 29
   at Microsoft.AspNetCore.ResponseCompression.ResponseCompressionMiddleware.InvokeCore(HttpContext context)
   at Microsoft.AspNetCore.Authorization.Policy.AuthorizationMiddlewareResultHandler.HandleAsync(RequestDelegate next, HttpContext context, AuthorizationPolicy policy, PolicyAuthorizationResult authorizeResult)



#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX