### PR TITLE
Fixed: Sorting all sortable columns in studio/performer details

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetailsStudioConnector.js
+++ b/frontend/src/Performer/Details/PerformerDetailsStudioConnector.js
@@ -7,7 +7,7 @@ import { executeCommand } from 'Store/Actions/commandActions';
 import { toggleMovieMonitored } from 'Store/Actions/movieActions';
 import { setPerformerScenesSort, setPerformerScenesTableOption } from 'Store/Actions/performerScenesActions';
 import { toggleStudioMonitored } from 'Store/Actions/studioActions';
-import createAllScenesSelector from 'Store/Selectors/createAllScenesSelector';
+import createClientSideCollectionSelector from 'Store/Selectors/createClientSideCollectionSelector';
 import createDimensionsSelector from 'Store/Selectors/createDimensionsSelector';
 import createPerformerSelector from 'Store/Selectors/createPerformerSelector';
 import PerformerDetailsStudio from './PerformerDetailsStudio';
@@ -29,28 +29,20 @@ function createStudioByForeignIdSelector() {
 function createMapStateToProps() {
   return createSelector(
     (state, { studioForeignId }) => studioForeignId,
-    (state) => state.performerScenes,
     createStudioByForeignIdSelector(),
-    createAllScenesSelector(),
+    createClientSideCollectionSelector('movies', 'performerScenes'),
     createPerformerSelector(),
     createDimensionsSelector(),
-    (studioForeignId, performerScenes, studio, scenes, performer, dimensions) => {
+    (studioForeignId, studio, scenes, performer, dimensions) => {
 
-      const scenesInStudio = scenes.filter((scene) => scene.studioForeignId === studioForeignId && scene.credits.some((credit) => credit.performer.foreignId === performer.foreignId));
-      const sortedScenes =scenesInStudio.sort(
-        (a, b) => {
-          if (performerScenes.sortDirection === 'ascending') {
-            return new Date(a.releaseDate) - new Date(b.releaseDate);
-          }
-          return new Date(b.releaseDate) - new Date(a.releaseDate);
-        });
+      const scenesInStudio = scenes.items.filter((scene) => scene.studioForeignId === studioForeignId && scene.credits.some((credit) => credit.performer.foreignId === performer.foreignId));
 
       return {
         ...studio,
-        items: sortedScenes,
-        columns: performerScenes.columns,
-        sortKey: performerScenes.sortKey,
-        sortDirection: performerScenes.sortDirection,
+        items: scenesInStudio,
+        columns: scenes.columns,
+        sortKey: scenes.sortKey,
+        sortDirection: scenes.sortDirection,
         performerMonitored: performer.monitored,
         path: performer.path,
         isSmallScreen: dimensions.isSmallScreen,

--- a/frontend/src/Studio/Details/StudioDetailsYearConnector.js
+++ b/frontend/src/Studio/Details/StudioDetailsYearConnector.js
@@ -6,7 +6,7 @@ import * as commandNames from 'Commands/commandNames';
 import { executeCommand } from 'Store/Actions/commandActions';
 import { toggleMovieMonitored } from 'Store/Actions/movieActions';
 import { setStudioScenesSort, setStudioScenesTableOption } from 'Store/Actions/studioScenesActions';
-import createAllScenesSelector from 'Store/Selectors/createAllScenesSelector';
+import createClientSideCollectionSelector from 'Store/Selectors/createClientSideCollectionSelector';
 import createDimensionsSelector from 'Store/Selectors/createDimensionsSelector';
 import createStudioSelector from 'Store/Selectors/createStudioSelector';
 import StudioDetailsYear from './StudioDetailsYear';
@@ -15,27 +15,19 @@ function createMapStateToProps() {
   return createSelector(
     (state, { year }) => year,
     (state, { studioForeignId }) => studioForeignId,
-    (state) => state.studioScenes,
-    createAllScenesSelector(),
+    createClientSideCollectionSelector('movies', 'studioScenes'),
     createStudioSelector(),
     createDimensionsSelector(),
-    (year, studioForeignId, studioScenes, scenes, studio, dimensions) => {
+    (year, studioForeignId, scenes, studio, dimensions) => {
 
-      const scenesInYear = scenes.filter((scene) => scene.studioForeignId === studioForeignId && scene.year === year);
-      const sortedScenes =scenesInYear.sort(
-        (a, b) => {
-          if (studioScenes.sortDirection === 'ascending') {
-            return new Date(a.releaseDate) - new Date(b.releaseDate);
-          }
-          return new Date(b.releaseDate) - new Date(a.releaseDate);
-        });
+      const scenesInYear = scenes.items.filter((scene) => scene.studioForeignId === studioForeignId && scene.year === year);
 
       return {
         year,
-        items: sortedScenes,
-        columns: studioScenes.columns,
-        sortKey: studioScenes.sortKey,
-        sortDirection: studioScenes.sortDirection,
+        items: scenesInYear,
+        columns: scenes.columns,
+        sortKey: scenes.sortKey,
+        sortDirection: scenes.sortDirection,
         studioMonitored: studio.monitored,
         path: studio.path,
         isSmallScreen: dimensions.isSmallScreen,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes all sortable columns in studio/performer details table

#### Screenshot (if UI related)
_performer studio sort releasedate desc_
![performer studio sort releasedate desc](https://github.com/Whisparr/Whisparr/assets/79065505/747959e8-de8b-4e64-a9f8-5da319a02d0d)
_performer studio sort title desc_
![performer studio sort title desc](https://github.com/Whisparr/Whisparr/assets/79065505/4f9bd693-e477-4b7c-9a7a-31a9117db5c2)
_studio year sort releasedate desc_
![studio year sort releasedate desc](https://github.com/Whisparr/Whisparr/assets/79065505/c194020d-6622-4a29-b978-1a83f0db742d)
studio year sort title _desc_
![studio year sort title desc](https://github.com/Whisparr/Whisparr/assets/79065505/cdaf76b1-39ee-4afd-a633-5e9c999324aa)

