### PR TITLE
Fixed: Moved ability to monitor Studio away from Performer view

### DIFF
--- a/frontend/src/Components/MonitorToggleButton.js
+++ b/frontend/src/Components/MonitorToggleButton.js
@@ -5,7 +5,10 @@ import SpinnerIconButton from 'Components/Link/SpinnerIconButton';
 import { icons } from 'Helpers/Props';
 import styles from './MonitorToggleButton.css';
 
-function getTooltip(monitored, isDisabled) {
+function getTooltip(monitored, isDisabled, tooltip) {
+  if (tooltip) {
+    return tooltip;
+  }
   if (isDisabled) {
     return 'Cannot toggle monitored state when movie is unmonitored';
   }
@@ -36,6 +39,7 @@ class MonitorToggleButton extends Component {
       className,
       monitored,
       isDisabled,
+      tooltip,
       isSaving,
       size,
       ...otherProps
@@ -51,7 +55,7 @@ class MonitorToggleButton extends Component {
         )}
         name={iconName}
         size={size}
-        title={getTooltip(monitored, isDisabled)}
+        title={getTooltip(monitored, isDisabled, tooltip)}
         isDisabled={isDisabled}
         isSpinning={isSaving}
         {...otherProps}
@@ -66,6 +70,7 @@ MonitorToggleButton.propTypes = {
   monitored: PropTypes.bool.isRequired,
   size: PropTypes.number,
   isDisabled: PropTypes.bool.isRequired,
+  tooltip: PropTypes.string,
   isSaving: PropTypes.bool.isRequired,
   onPress: PropTypes.func.isRequired
 };

--- a/frontend/src/Performer/Details/PerformerDetailsStudio.css
+++ b/frontend/src/Performer/Details/PerformerDetailsStudio.css
@@ -9,17 +9,24 @@
   }
 }
 
+.studioLink {
+  margin-right: 10px;
+  margin-left: 5px;
+}
+
+.studioLink>a:link,
+.studioLink>a:visited,
+.studioLink>a:hover,
+.studioLink>a:active {
+  color: var(--white);
+}
+
 .header {
   position: relative;
   display: flex;
   align-items: center;
   width: 100%;
   font-size: 24px;
-}
-
-.seasonNumber {
-  margin-right: 10px;
-  margin-left: 5px;
 }
 
 .movieCountTooltip {

--- a/frontend/src/Performer/Details/PerformerDetailsStudio.css.d.ts
+++ b/frontend/src/Performer/Details/PerformerDetailsStudio.css.d.ts
@@ -16,9 +16,9 @@ interface CssExports {
   'movieCountTooltip': string;
   'noEpisodes': string;
   'season': string;
-  'seasonNumber': string;
   'sizeOnDisk': string;
   'studio': string;
+  'studioLink': string;
 }
 export const cssExports: CssExports;
 export default cssExports;

--- a/frontend/src/Performer/Details/PerformerDetailsStudio.js
+++ b/frontend/src/Performer/Details/PerformerDetailsStudio.js
@@ -62,7 +62,7 @@ function getMovieCountKind(monitored, movieFileCount, movieCount) {
     return kinds.SUCCESS;
   }
 
-  if (!monitored) {
+  if (!movieCount) {
     return kinds.WARNING;
   }
 
@@ -162,6 +162,7 @@ class PerformerDetailsStudio extends Component {
     const {
       monitored,
       title,
+      foreignId,
       items,
       isSaving,
       isExpanded,
@@ -185,6 +186,7 @@ class PerformerDetailsStudio extends Component {
     } = getStudioStatistics(items);
 
     const sizeOnDisk = _.sumBy(items, 'sizeOnDisk');
+    const studioLink = `/studio/${foreignId}`;
 
     return (
       <div
@@ -194,13 +196,17 @@ class PerformerDetailsStudio extends Component {
           <div className={styles.left}>
             <MonitorToggleButton
               monitored={monitored}
+              isDisabled={true}
+              tooltip={translate('PerformerStudioLinkTooltip')}
               isSaving={isSaving}
               size={24}
               onPress={onMonitorStudioPress}
             />
 
-            <span className={styles.seasonNumber}>
-              {title}
+            <span className={styles.studioLink}>
+              <Link to={studioLink} title={title}>
+                {title}
+              </Link>
             </span>
 
             <Popover
@@ -247,9 +253,8 @@ class PerformerDetailsStudio extends Component {
               title={isExpanded ? translate('HideMovies') : translate('ShowMovies')}
               size={24}
             />
-            {
-              !isSmallScreen &&
-                <span>&nbsp;</span>
+            {!isSmallScreen &&
+              <span>&nbsp;</span>
             }
           </Link>
 
@@ -320,48 +325,47 @@ class PerformerDetailsStudio extends Component {
         </div>
 
         <div>
-          {
-            isExpanded &&
-              <div className={styles.movies}>
-                {
-                  items.length ?
-                    <Table
-                      columns={columns}
-                      sortKey={sortKey}
-                      sortDirection={sortDirection}
-                      onSortPress={onSortPress}
-                      onTableOptionChange={onTableOptionChange}
-                    >
-                      <TableBody>
-                        {
-                          items.map((item) => {
-                            return (
-                              <SceneRowConnector
-                                key={item.id}
-                                columns={columns}
-                                {...item}
-                                onMonitorMoviePress={this.onMonitorMoviePress}
-                              />
-                            );
-                          })
-                        }
-                      </TableBody>
-                    </Table> :
+          {isExpanded &&
+            <div className={styles.movies}>
+              {
+                items.length ?
+                  <Table
+                    columns={columns}
+                    sortKey={sortKey}
+                    sortDirection={sortDirection}
+                    onSortPress={onSortPress}
+                    onTableOptionChange={onTableOptionChange}
+                  >
+                    <TableBody>
+                      {
+                        items.map((item) => {
+                          return (
+                            <SceneRowConnector
+                              key={item.id}
+                              columns={columns}
+                              {...item}
+                              onMonitorMoviePress={this.onMonitorMoviePress}
+                            />
+                          );
+                        })
+                      }
+                    </TableBody>
+                  </Table> :
 
-                    <div className={styles.noMovies}>
-                      {translate('NoMoviesInThisSeason')}
-                    </div>
-                }
-                <div className={styles.collapseButtonContainer}>
-                  <IconButton
-                    iconClassName={styles.collapseButtonIcon}
-                    name={icons.COLLAPSE}
-                    size={20}
-                    title={translate('HideMovies')}
-                    onPress={this.onExpandPress}
-                  />
-                </div>
+                  <div className={styles.noMovies}>
+                    {translate('NoMoviesInThisSeason')}
+                  </div>
+              }
+              <div className={styles.collapseButtonContainer}>
+                <IconButton
+                  iconClassName={styles.collapseButtonIcon}
+                  name={icons.COLLAPSE}
+                  size={20}
+                  title={translate('HideMovies')}
+                  onPress={this.onExpandPress}
+                />
               </div>
+            </div>
           }
         </div>
       </div>

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1043,6 +1043,7 @@
   "Performer": "Performer",
   "PerformerName": "Name",
   "PerformersSelectedInterp": "{count} Performer(s) Selected",
+  "PerformerStudioLinkTooltip": "Click Studio name to toggle from Details view",
   "Permissions": "Permissions",
   "PhysicalRelease": "Physical Release",
   "PhysicalReleaseDate": "Physical Release Date",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
It was too easy to conflate monitoring scenss vs. entire studios from the Performer view.  This change makes the mointor flag read-only, adds a tooltip to it indicating where to go, and links the Studio's name to go there.

#### Screenshot (if UI related)
<img width="371" alt="image" src="https://github.com/Whisparr/Whisparr/assets/132735020/95a7d2fc-d1e6-4c19-b0e4-4fb3d08bcdf4"> 
<img width="332" alt="image" src="https://github.com/Whisparr/Whisparr/assets/132735020/21dc8c1c-c8a5-4429-b799-c2fe6f269487">


#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #180 