### PR TITLE
Fixed: Links for TMDB or StashDB on Movie/Scene Detail page

### DIFF
--- a/frontend/src/Movie/Details/MovieDetails.js
+++ b/frontend/src/Movie/Details/MovieDetails.js
@@ -227,7 +227,7 @@ class MovieDetails extends Component {
     const {
       id,
       tmdbId,
-      imdbId,
+      stashId,
       title,
       year,
       releaseDate,
@@ -455,7 +455,7 @@ class MovieDetails extends Component {
                           tooltip={
                             <MovieDetailsLinks
                               tmdbId={tmdbId}
-                              imdbId={imdbId}
+                              stashId={stashId}
                             />
                           }
                           position={tooltipPositions.BOTTOM}
@@ -665,7 +665,7 @@ class MovieDetails extends Component {
 MovieDetails.propTypes = {
   id: PropTypes.number.isRequired,
   tmdbId: PropTypes.number.isRequired,
-  imdbId: PropTypes.string,
+  stashId: PropTypes.string,
   title: PropTypes.string.isRequired,
   year: PropTypes.number.isRequired,
   runtime: PropTypes.number.isRequired,

--- a/frontend/src/Movie/Details/MovieDetailsLinks.js
+++ b/frontend/src/Movie/Details/MovieDetailsLinks.js
@@ -9,80 +9,39 @@ import styles from './MovieDetailsLinks.css';
 function MovieDetailsLinks(props) {
   const {
     tmdbId,
-    imdbId
+    stashId
   } = props;
 
   return (
     <div className={styles.links}>
-      <Link
-        className={styles.link}
-        to={`https://www.themoviedb.org/movie/${tmdbId}`}
-      >
-        <Label
-          className={styles.linkLabel}
-          kind={kinds.INFO}
-          size={sizes.LARGE}
+      {!!tmdbId &&
+        <Link
+          className={styles.link}
+          to={`https://www.themoviedb.org/movie/${tmdbId}`}
         >
-          {translate('TMDb')}
-        </Label>
-      </Link>
-
-      <Link
-        className={styles.link}
-        to={`https://trakt.tv/search/tmdb/${tmdbId}?id_type=movie`}
-      >
-        <Label
-          className={styles.linkLabel}
-          kind={kinds.INFO}
-          size={sizes.LARGE}
-        >
-          {translate('Trakt')}
-        </Label>
-      </Link>
-
-      <Link
-        className={styles.link}
-        to={`https://letterboxd.com/tmdb/${tmdbId}`}
-      >
-        <Label
-          className={styles.linkLabel}
-          kind={kinds.INFO}
-          size={sizes.LARGE}
-        >
-          {translate('Letterboxd')}
-        </Label>
-      </Link>
-
-      {
-        !!imdbId &&
-          <Link
-            className={styles.link}
-            to={`https://imdb.com/title/${imdbId}/`}
+          <Label
+            className={styles.linkLabel}
+            kind={kinds.INFO}
+            size={sizes.LARGE}
           >
-            <Label
-              className={styles.linkLabel}
-              kind={kinds.INFO}
-              size={sizes.LARGE}
-            >
-              {translate('IMDb')}
-            </Label>
-          </Link>
+            {translate('TMDb')}
+          </Label>
+        </Link>
       }
 
-      {
-        !!imdbId &&
-          <Link
-            className={styles.link}
-            to={`https://moviechat.org/${imdbId}/`}
+      {!!stashId &&
+        <Link
+          className={styles.link}
+          to={`https://stashdb.org/scenes/${stashId}/`}
+        >
+          <Label
+            className={styles.linkLabel}
+            kind={kinds.INFO}
+            size={sizes.LARGE}
           >
-            <Label
-              className={styles.linkLabel}
-              kind={kinds.INFO}
-              size={sizes.LARGE}
-            >
-              {translate('MovieChat')}
-            </Label>
-          </Link>
+            {translate('StashDB')}
+          </Label>
+        </Link>
       }
     </div>
   );
@@ -90,7 +49,7 @@ function MovieDetailsLinks(props) {
 
 MovieDetailsLinks.propTypes = {
   tmdbId: PropTypes.number.isRequired,
-  imdbId: PropTypes.string
+  stashId: PropTypes.string
 };
 
 export default MovieDetailsLinks;

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
@@ -76,7 +76,6 @@ function MovieIndexOverview(props: MovieIndexOverviewProps) {
     isAvailable,
     foreignId,
     tmdbId,
-    imdbId,
     studioTitle,
     sizeOnDisk,
     added,
@@ -179,7 +178,7 @@ function MovieIndexOverview(props: MovieIndexOverviewProps) {
                 <Popover
                   anchor={<Icon name={icons.EXTERNAL_LINK} size={12} />}
                   title={translate('Links')}
-                  body={<MovieDetailsLinks tmdbId={tmdbId} imdbId={imdbId} />}
+                  body={<MovieDetailsLinks tmdbId={tmdbId} />}
                 />
               </span>
 

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.tsx
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.tsx
@@ -65,7 +65,6 @@ function MovieIndexPoster(props: MovieIndexPosterProps) {
     images,
     foreignId,
     tmdbId,
-    imdbId,
     hasFile,
     isAvailable,
     studioTitle,
@@ -167,7 +166,7 @@ function MovieIndexPoster(props: MovieIndexPosterProps) {
             <Popover
               anchor={<Icon name={icons.EXTERNAL_LINK} size={12} />}
               title={translate('Links')}
-              body={<MovieDetailsLinks tmdbId={tmdbId} imdbId={imdbId} />}
+              body={<MovieDetailsLinks tmdbId={tmdbId} />}
             />
           </span>
         </Label>

--- a/frontend/src/Movie/Index/Table/MovieIndexRow.tsx
+++ b/frontend/src/Movie/Index/Table/MovieIndexRow.tsx
@@ -64,7 +64,6 @@ function MovieIndexRow(props: MovieIndexRowProps) {
     ratings,
     tags = [],
     tmdbId,
-    imdbId,
     isAvailable,
     hasFile,
     movieFile,
@@ -309,9 +308,7 @@ function MovieIndexRow(props: MovieIndexRowProps) {
               <span className={styles.externalLinks}>
                 <Tooltip
                   anchor={<Icon name={icons.EXTERNAL_LINK} size={12} />}
-                  tooltip={
-                    <MovieDetailsLinks tmdbId={tmdbId} imdbId={imdbId} />
-                  }
+                  tooltip={<MovieDetailsLinks tmdbId={tmdbId} />}
                   canFlip={true}
                   kind={kinds.INVERSE}
                 />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This change got reverted somehow, so re-pushing.  Reconfigured the MovieDetailsLinks hover section to show either TMDB or StashDB as appropriate.  I removed IMDB as well, since it's not a source in this version of the app.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)