### PR TITLE
UnitTest for ParseMovieTitle

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/NormalizeTitleFixture.cs
@@ -186,5 +186,14 @@ namespace NzbDrone.Core.Test.ParserTests
         {
             "Tokyo Ghoul A".CleanMovieTitle().Should().Be("tokyoghoula");
         }
+
+        [Test]
+        public void should_parse_null_string()
+        {
+            string test = null;
+
+            test.CleanMovieTitle().Should().Be("");
+            "".CleanMovieTitle().Should().Be("");
+        }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ParserTests
+{
+    [TestFixture]
+    public class ParseMovieTitleFixture : CoreTest
+    {
+        [TestCase("Studio - Performer Name - Some Title (10.01.2024)", true)]
+        [TestCase("Reflective Desire - 2022-12-01 - Chuck Faerie Vespa - Pussyfootin' - WEBDL-2160p h264", true)]
+        [TestCase("MollyRedWolf - 2022-04-14 - MollyRedWolf - Komi-San.I want you - WEBDL-720p x265", true)]
+        [TestCase("Studio.19.07.01.Title..480p.MP4-XXX", true)]
+        [TestCase("Studio.21.04.09.Title.XXX.480p.MP4-XXX", true)]
+        [TestCase("Studio.22.10.18.Title.XXX.720p.HEVC.x265.PRT[XvX]", true)]
+        [TestCase("Studio - 2017-08-04 - Some Title. [WEBDL-480p]", true)]
+        [TestCase("Movie.2009.S01E14.English.HDTV.XviD-LOL", false)] // Movie
+        public void should_parse_as_scene(string title, bool expected)
+        {
+            Parser.Parser.ParseMovieTitle(title).IsScene.Should().Be(expected);
+        }
+
+        [TestCase("Reflective Desire - 2022-12-01 - Chuck Faerie Vespa - Pussyfootin' - WEBDL-2160p h264", "Reflective Desire")]
+        [TestCase("MollyRedWolf - 2022-04-14 - MollyRedWolf - Komi-San.I want you - WEBDL-720p x265", "MollyRedWolf")]
+        [TestCase("Studio.19.07.01.Title..480p.MP4-XXX", "Studio")]
+        [TestCase("Studio.21.04.09.Title.XXX.480p.MP4-XXX", "Studio")]
+        [TestCase("Studio.22.10.18.Title.XXX.720p.HEVC.x265.PRT[XvX]", "Studio")]
+        [TestCase("Studio - 2017-08-04 - Some Title. [WEBDL-480p]", "Studio")]
+        [TestCase("Studio - Performer Name - Some Title (10.01.2024)", "Studio")]
+        public void should_correctly_parse_studio_names(string title, string result)
+        {
+            Parser.Parser.ParseMovieTitle(title).StudioTitle.Should().Be(result);
+        }
+
+        [TestCase("Reflective Desire - 2022-12-01 - Chuck Faerie Vespa - Pussyfootin' - WEBDL-2160p h264", "2022-12-01")]
+        [TestCase("MollyRedWolf - 2022-04-14 - MollyRedWolf - Komi-San.I want you - WEBDL-720p x265", "2022-04-14")]
+        [TestCase("Studio.19.07.01.Title..480p.MP4-XXX", "2019-07-01")]
+        [TestCase("Studio.21.04.09.Title.XXX.480p.MP4-XXX", "2021-04-09")]
+        [TestCase("Studio.22.10.18.Title.XXX.720p.HEVC.x265.PRT[XvX]", "2022-10-18")]
+        [TestCase("Studio - 2017-08-04 - Some Title. [WEBDL-480p]", "2017-08-04")]
+        [TestCase("Studio - Performer Name - Some Title (10.01.2024)", "2024-01-10")]
+        public void should_correctly_parse_release_date(string title, string result)
+        {
+            Parser.Parser.ParseMovieTitle(title).ReleaseDate.Should().Be(result);
+        }
+
+        [TestCase("Reflective Desire - 2022-12-01 - Chuck Faerie Vespa - Pussyfootin' - WEBDL-2160p h264", "chuck faerie vespa pussyfootin")]
+        [TestCase("MollyRedWolf - 2022-04-14 - MollyRedWolf - Komi-San.I want you - WEBDL-720p x265", "mollyredwolf komi san i want you")]
+        [TestCase("Studio.22.10.18.This.is.a.XXX.Parody - Scene 1.XXX.720p.HEVC.x265.PRT[XvX]", "this is a xxx parody scene 1")]
+        [TestCase("Studio.19.07.01.Title..480p.MP4-XXX", "title")]
+        [TestCase("Studio.21.04.09.Title.XXX.480p.MP4-XXX", "title")]
+        [TestCase("Studio.22.10.18.Title.XXX.720p.HEVC.x265.PRT[XvX]", "title")]
+        [TestCase("Studio - 2017-08-04 - Some Title. [WEBDL-480p]", "some title")]
+        [TestCase("Studio - Performer Name - Some Title (10.01.2024)", "performer name some title")]
+        public void should_correctly_parse_normalize_release_token(string title, string result)
+        {
+            var releaseTokens = Parser.Parser.ParseMovieTitle(title).ReleaseTokens;
+            var cleanReleaseToken = Parser.Parser.NormalizeEpisodeTitle(releaseTokens);
+            cleanReleaseToken.Should().Be(result);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -41,6 +41,10 @@ namespace NzbDrone.Core.Parser
             new Regex(@"^(?<studiotitle>.+?)?[-_. ]+(?<airyear>(19|20)\d{2})(?<airmonth>[0-1][0-9])(?<airday>[0-3][0-9])",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
+            // SCENE with airdate after title studio - title (dd.mm.yyyy)
+            new Regex(@"^(?<studiotitle>.+?)?[-_. ]+(?<releasetoken>.+?)\((?<airday>[0-3][0-9])\.(?<airmonth>[0-1][0-9])\.(?<airyear>(19|20)\d{2})",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
             // SCENE with airdate (18.04.28, 2018.04.28, 18-04-28, 18 04 28, 18_04_28)
             new Regex(@"^(?<studiotitle>.+?)?[-_. ]+(?<airyear>\d{2}|\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
@@ -143,6 +147,9 @@ namespace NzbDrone.Core.Parser
         private static readonly RegexReplace SimpleTitleRegex = new RegexReplace(@"(?:(480|540|576|720|1080|2160)[ip]|[xh][\W_]?26[45]|DD\W?5\W1|[<>?*]|848x480|1280x720|1920x1080|3840x2160|4096x2160|(8|10)b(it)?|10-bit)\s*?(?![a-b0-9])",
                                                                 string.Empty,
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex SpecialEpisodeTitleRegex = new Regex(@"(?<episodetitle>.+?)(?:\[.*(?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL).*\]|\.XXX\.(?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL).*|(?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL)|$)",
+                          RegexOptions.Compiled);
 
         private static readonly Regex SimpleReleaseTitleRegex = new Regex(@"\s*(?:[<>?*|])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
@@ -495,6 +502,40 @@ namespace NzbDrone.Core.Parser
             return ReplaceGermanUmlauts(NormalizeRegex.Replace(title, string.Empty).ToLower()).RemoveAccent();
         }
 
+        public static string CleanEpisodeTitle(this string title)
+        {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
+            var allRegexes = ReportTitleRegex.ToList();
+
+            foreach (var regex in allRegexes)
+            {
+                if (title.IsNullOrWhiteSpace())
+                {
+                    return string.Empty;
+                }
+
+                var match = regex.Matches(title);
+
+                if (match.Count != 0)
+                {
+                    var result = ParseMatchCollection(match, title);
+
+                    if (result != null)
+                    {
+                        var simpleReleaseTitle = SimpleReleaseTitleRegex.Replace(title, string.Empty);
+
+                        title = result.PrimaryMovieTitle;
+                    }
+                }
+            }
+
+            return title;
+        }
+
         public static string NormalizeEpisodeTitle(this string title)
         {
             title = SpecialEpisodeWordRegex.Replace(title, string.Empty);
@@ -764,14 +805,28 @@ namespace NzbDrone.Core.Parser
 
                 if (result.ReleaseTokens.IsNullOrWhiteSpace())
                 {
+                    var releaseTokens = releaseTitle;
+                    var matchstart = releaseTitle.IndexOf(matchCollection[0].Value);
+                    if (studioTitle.IsNullOrWhiteSpace() && matchstart > 0)
+                    {
+                        studioTitle = releaseTitle.Substring(0, matchstart);
+                        lastSeasonEpisodeStringIndex += matchstart;
+                        studioTitle = RequestInfoRegex.Replace(studioTitle, "").Trim(' ');
+                    }
+
                     if (lastSeasonEpisodeStringIndex != releaseTitle.Length)
                     {
-                        result.ReleaseTokens = releaseTitle.Substring(lastSeasonEpisodeStringIndex);
+                        releaseTokens = releaseTitle.Substring(lastSeasonEpisodeStringIndex);
                     }
-                    else
+
+                    var match = SpecialEpisodeTitleRegex.Match(releaseTokens);
+
+                    if (match != null && match.Groups["episodetitle"].Value.IsNotNullOrWhiteSpace())
                     {
-                        result.ReleaseTokens = releaseTitle;
+                        releaseTokens = match.Groups["episodetitle"].Value;
                     }
+
+                    result.ReleaseTokens = releaseTokens;
                 }
 
                 result.StudioTitle = studioTitle;

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -493,6 +493,11 @@ namespace NzbDrone.Core.Parser
 
         public static string CleanMovieTitle(this string title)
         {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
             // If Title only contains numbers return it as is.
             if (long.TryParse(title, out _))
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Create a unit test for ParseMovieTitle to verify what a manual import, RSS feed, etc, will be using to match a scene.

 Improve the normalize version of the release token, using regEx from V2.

additional format added 
studio - title (dd.mm.yyyy)

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #177