### PR TITLE
Find All the studios that match a value

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/StudioFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/StudioFixture.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ParserTests
+{
+    [TestFixture]
+    public class StudioFixture : CoreTest
+    {
+        [TestCase("Brazzers Exxtra", "Brazzers Exxtra")]
+        [TestCase("Brazzers Exxtra", "BrazzersExxtra")]
+        [TestCase("Hot and Mean", "Hot And Mean")]
+        [TestCase("Hot and Mean", "HotAndMean")]
+        [TestCase("Monsters of Cock", "MonstersOfCock")]
+        [TestCase("In the VIP", "InTheVIP")]
+        public void should_match_studio_names(string stashDB, string external)
+        {
+            // The Clean Title is used to match the record within the DB
+            // Test that the sudio name can be found for an external source:
+            // FileName
+            // Indexer
+            stashDB.CleanStudioTitle().Should().Be(external.CleanStudioTitle());
+        }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -891,7 +891,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             var newPerformer = new Studio
             {
                 Title = studio.Title,
-                CleanTitle = studio.Title.CleanMovieTitle(),
+                CleanTitle = studio.Title.CleanStudioTitle(),
                 SortTitle = Parser.Parser.NormalizeTitle(studio.Title),
                 Website = studio.Homepage,
                 ForeignId = studio.ForeignIds.StashId,

--- a/src/NzbDrone.Core/Movies/Studios/AddStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/AddStudioService.cs
@@ -123,7 +123,7 @@ namespace NzbDrone.Core.Movies.Studios
 
         private Studio SetPropertiesAndValidate(Studio newStudio)
         {
-            newStudio.CleanTitle = newStudio.Title.CleanMovieTitle();
+            newStudio.CleanTitle = newStudio.Title.CleanStudioTitle();
             newStudio.SortTitle = MovieTitleNormalizer.Normalize(newStudio.Title, newStudio.ForeignId);
             newStudio.Added = DateTime.UtcNow;
 

--- a/src/NzbDrone.Core/Movies/Studios/StudioRepository.cs
+++ b/src/NzbDrone.Core/Movies/Studios/StudioRepository.cs
@@ -10,6 +10,7 @@ namespace NzbDrone.Core.Movies.Studios
     {
         Studio FindByForeignId(string foreignId);
         Studio FindByTitle(string title);
+        List<Studio> FindAllByTitle(string title);
         List<string> AllStudioForeignIds();
     }
 
@@ -22,7 +23,12 @@ namespace NzbDrone.Core.Movies.Studios
 
         public Studio FindByTitle(string title)
         {
-            return Query(x => x.CleanTitle == title).FirstOrDefault();
+            return FindAllByTitle(title).FirstOrDefault();
+        }
+
+        public List<Studio> FindAllByTitle(string title)
+        {
+            return Query(x => x.CleanTitle == title);
         }
 
         public Studio FindByForeignId(string foreignId)

--- a/src/NzbDrone.Core/Movies/Studios/StudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/StudioService.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Movies.Studios
         Studio Update(Studio performer);
         List<Studio> Update(List<Studio> studios);
         Studio FindByTitle(string title);
+        List<Studio> FindAllByTitle(string title);
         void RemoveStudio(Studio studio);
     }
 
@@ -84,9 +85,16 @@ namespace NzbDrone.Core.Movies.Studios
 
         public Studio FindByTitle(string title)
         {
-            var cleanTitle = title.CleanMovieTitle();
+            var cleanTitle = title.CleanStudioTitle();
 
             return _studioRepo.FindByTitle(cleanTitle);
+        }
+
+        public List<Studio> FindAllByTitle(string title)
+        {
+            var cleanTitle = title.CleanStudioTitle();
+
+            return _studioRepo.FindAllByTitle(cleanTitle);
         }
 
         public Studio FindByForeignId(string foreignId)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -484,6 +484,16 @@ namespace NzbDrone.Core.Parser
             return value;
         }
 
+        public static string CleanStudioTitle(this string title)
+        {
+            if (title.IsNotNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
+            return title.Replace(" ", "").CleanMovieTitle();
+        }
+
         public static string CleanMovieTitle(this string title)
         {
             // If Title only contains numbers return it as is.

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -73,11 +73,20 @@ namespace NzbDrone.Core.Parser
 
             if (parsedMovieInfo.IsScene)
             {
-                var studio = _studioService.FindByTitle(parsedMovieInfo.StudioTitle);
+                var studios = _studioService.FindAllByTitle(parsedMovieInfo.StudioTitle);
 
-                if (studio != null)
+                if (studios != null && studios.Count > 0)
                 {
-                    return _movieService.FindByStudioAndReleaseDate(studio.ForeignId, parsedMovieInfo.ReleaseDate, parsedMovieInfo.ReleaseTokens);
+                    Movie movie = null;
+                    foreach (var studio in studios)
+                    {
+                        if (movie == null)
+                        {
+                            movie = _movieService.FindByStudioAndReleaseDate(studio.ForeignId, parsedMovieInfo.ReleaseDate, parsedMovieInfo.ReleaseTokens);
+                        }
+                    }
+
+                    return movie;
                 }
             }
             else
@@ -141,11 +150,17 @@ namespace NzbDrone.Core.Parser
 
             if (parsedMovieInfo.IsScene)
             {
-                var studio = _studioService.FindByTitle(parsedMovieInfo.StudioTitle);
+                var studios = _studioService.FindAllByTitle(parsedMovieInfo.StudioTitle);
 
-                if (studio != null)
+                if (studios != null && studios.Count > 0)
                 {
-                    result = GetSceneMovie(studio, parsedMovieInfo.ReleaseDate, parsedMovieInfo.ReleaseTokens, searchCriteria);
+                    foreach (var studio in studios)
+                    {
+                        if (result == null)
+                        {
+                            result = GetSceneMovie(studio, parsedMovieInfo.ReleaseDate, parsedMovieInfo.ReleaseTokens, searchCriteria);
+                        }
+                    }
                 }
 
                 if (result == null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Find All the studios that match a value and then see if the scene is found. The scene can be in the second studio.

Validate that studio names will match known values for external sources. There is a unit test for some examples that currently fail.

The Studio.CleanTitle was altered and will repopulate when the studio is refreshed. This may update the value for a few studios.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #189