### PR TITLE
Filter Performer/Studio SearchCommands to only monitored

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/PerformersSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/PerformersSearchService.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.IndexerSearch
                 var performer = _performerService.GetById(performerId);
                 var userInvokedSearch = message.Trigger == CommandTrigger.Manual;
 
-                var items = _movieService.GetByPerformerForeignId(performer.ForeignId);
+                var items = _movieService.GetByPerformerForeignId(performer.ForeignId).Where(m => m.Monitored).ToList();
 
                 if (message.StudioIds.Count > 0)
                 {

--- a/src/NzbDrone.Core/IndexerSearch/StudiosSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/StudiosSearchService.cs
@@ -37,7 +37,7 @@ namespace NzbDrone.Core.IndexerSearch
                 var studio = _studioService.GetById(studioId);
                 var userInvokedSearch = message.Trigger == CommandTrigger.Manual;
 
-                var items = _movieService.GetByStudioForeignId(studio.ForeignId);
+                var items = _movieService.GetByStudioForeignId(studio.ForeignId).Where(m => m.Monitored).ToList();
 
                 if (message.Years.Count > 0)
                 {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Whisparr only searches for scenes that are monitored. On the Studio and Performers page. A non-monitored scene should only be searched if a user clicks on the search for the scene.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #200