### PR TITLE
Fixed: Omit special characters when using filters that are not expecting them

### DIFF
--- a/frontend/src/Components/Page/Header/MovieSearchInput.js
+++ b/frontend/src/Components/Page/Header/MovieSearchInput.js
@@ -134,7 +134,9 @@ class MovieSearchInput extends Component {
       return;
     }
 
-    this.setState({ value: newValue });
+    this.setState({
+      value: newValue.replace(/[^a-zA-Z ]/g, '')
+    });
   };
 
   onKeyDown = (event) => {

--- a/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
+++ b/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
@@ -172,9 +172,9 @@ function SelectMovieModalContent(props: SelectMovieModalContentProps) {
 
     return sorted.filter(
       (item) =>
-        item.title.toLowerCase().includes(filter.toLowerCase()) ||
-        item.tmdbId.toString().includes(filter) ||
-        item.imdbId?.includes(filter)
+        item.sortTitle.includes(
+          filter.toLowerCase().replace(/[^a-zA-Z ]/g, '')
+        ) || item.tmdbId.toString() === filter
     );
   }, [allMovies, filter]);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Previously, the SelectMovieModalContent and MovieSearchInput compoents both allows for special characters, which could pollute, and in the case of the former, negate desired filtering results.  This change employs string redaction to remove the special characters before they would execute a filter.

I will note that the MovieSearchInput (top bar) filtering is happening in realtime, so it has the effect of ignoring special characters from the input, even if pasted.  The SeelctMovieModalContent simply ignores them silently.  these two mechanisms are implemented in completely different ways, and I didn't want to rewire one of them for an edge case.  I did not employ a trim() on either as it would cause inconsistent handling of trailing spaces and in testing, actually prevented spaces on the top bar filter.

Also, I made an attempt to improve filtering performance on larger (100K+) libraries in the import modal, pending feedback from #178 .

#### Screenshot (if UI related)
![image](https://github.com/Whisparr/Whisparr/assets/132735020/ad97a14b-28bb-4a7f-8246-012a764dc5ef)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #178 