### PR TITLE
Parse JSON in smaller chunks to overcome memory limitations

### DIFF
--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -22,6 +22,7 @@ namespace NzbDrone.Core.Movies
         PagingSpec<Movie> Paged(PagingSpec<Movie> pagingSpec);
         Movie AddMovie(Movie newMovie);
         List<Movie> AddMovies(List<Movie> newMovies);
+        List<Movie> FindByIds(List<int> ids);
         Movie FindByImdbId(string imdbid);
         Movie FindByTmdbId(int tmdbid);
         Movie FindByForeignId(string foreignId);
@@ -34,6 +35,7 @@ namespace NzbDrone.Core.Movies
         List<Movie> GetByPerformerForeignId(string performerForeignId);
         Movie FindByPath(string path);
         Dictionary<int, string> AllMoviePaths();
+        List<int> AllMovieIds();
         List<int> AllMovieTmdbIds();
         List<string> AllMovieForeignIds();
         bool MovieExists(Movie movie);
@@ -167,6 +169,11 @@ namespace NzbDrone.Core.Movies
             return _movieRepository.FindByTitles(lookupTitles);
         }
 
+        public List<Movie> FindByIds(List<int> ids)
+        {
+            return _movieRepository.FindByIds(ids).ToList();
+        }
+
         public Movie FindByImdbId(string imdbid)
         {
             return _movieRepository.FindByImdbId(imdbid);
@@ -190,6 +197,11 @@ namespace NzbDrone.Core.Movies
         public Dictionary<int, string> AllMoviePaths()
         {
             return _movieRepository.AllMoviePaths();
+        }
+
+        public List<int> AllMovieIds()
+        {
+            return _movieRepository.AllMovieIds();
         }
 
         public List<int> AllMovieTmdbIds()

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -157,6 +157,32 @@ namespace Whisparr.Api.V3.Movies
             return MapToResource(movie);
         }
 
+        [HttpGet("list")]
+        public List<int> ListMovies()
+        {
+            var moviesResources = new List<MovieResource>();
+
+            var movieTask = Task.Run(() => _moviesService.AllMovieIds());
+
+            return movieTask.GetAwaiter().GetResult();
+        }
+
+        [HttpPost("bulk")]
+        public List<MovieResource> GetResourceByIds([FromBody] List<int> ids)
+        {
+            var moviesResources = new List<MovieResource>();
+
+            var availDelay = _configService.AvailabilityDelay;
+            var movies = _moviesService.FindByIds(ids);
+
+            foreach (var movie in movies)
+            {
+                moviesResources.Add(movie.ToResource(availDelay, _qualityUpgradableSpecification));
+            }
+
+            return moviesResources;
+        }
+
         protected MovieResource MapToResource(Movie movie)
         {
             if (movie == null)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
There is a limitation on the amount of data that can be parsed to JSON. A workaround is to retrieve the complete dataset in smaller chunks and then join it together.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #209 