### PR TITLE
Fixed: Studio link CSS in performer detail

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetailsStudio.css
+++ b/frontend/src/Performer/Details/PerformerDetailsStudio.css
@@ -18,7 +18,7 @@
 .studioLink>a:visited,
 .studioLink>a:hover,
 .studioLink>a:active {
-  color: var(--white);
+  color: inherit;
 }
 
 .header {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Previous PR had CSS forcing studio links to white.  This reverses that.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX