### PR TITLE
Fixed: V3 No results in Scene Search if studio name contains a space

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -71,6 +71,11 @@ namespace NzbDrone.Core.IndexerSearch
                     sceneSearchSpec.SceneTitles.Add(sceneSearchSpec.SiteTitle);
                 }
 
+                if (sceneSearchSpec.SiteTitle.Contains(' ', StringComparison.Ordinal))
+                {
+                    sceneSearchSpec.SceneTitles.Add(sceneSearchSpec.SiteTitle.Replace(" ", "", StringComparison.Ordinal));
+                }
+
                 decisions = await Dispatch(indexer => indexer.Fetch(sceneSearchSpec), sceneSearchSpec);
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When searching for a Scene using either Interactive or Automatic search, there would be no results if the Studio the scene belongs to had a space in it.  This was fixed in V2 by also searching `TitleSlug` in the same .NET class, but the code in V3 was a bit different.  I used the same strategy, though, by adding an additional search string if the Studio has a space in the name.

This was only an issue with user-triggered searches, not RSS grabs.  The release title parser is more robust in the RSS pulls.  I wanted to get this fix in because we still have quite a bit of lag in the SkyHook sync to StashDB, to the point where RSS may roll past desired releases before Whisparr can add them.  This fix allows the user to manually add and search a specific scene more reliably than without the de-spaced Studio title.

#### Screenshot (if UI related)

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #213 