### PR TITLE
Fixed: Scene search returns no results if studio name has spaces

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -71,6 +71,11 @@ namespace NzbDrone.Core.IndexerSearch
                     sceneSearchSpec.SceneTitles.Add(sceneSearchSpec.SiteTitle);
                 }
 
+                if (sceneSearchSpec.SiteTitle.Contains(' ', StringComparison.Ordinal))
+                {
+                    sceneSearchSpec.SceneTitles.Add(sceneSearchSpec.SiteTitle.Replace(" ", "", StringComparison.Ordinal));
+                }
+
                 decisions = await Dispatch(indexer => indexer.Fetch(sceneSearchSpec), sceneSearchSpec);
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This change simply aims to let users better manually search for content.  Often, Skyhook data is trailing releases, so by the time it's available to Whisparr, it will no longer be picked up other than by manual search or search-on-add, which use different rules than the release parser.  One of those cases is when the studio name has a space in it, in the metadata, but not the indexer/release filename.  This change allows Whisparr to search for both.

This is a re-submit of #215, as the previous one was rolled back due to unrelated build issues.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #213 