### PR TITLE
Adjusted search behavior to also return results by Studio+Scene combo, rather than relying on date match on those parts individually.

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovie/AddNewMovieSearchResult.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovie/AddNewMovieSearchResult.js
@@ -90,6 +90,8 @@ class AddNewMovieSearchResult extends Component {
     } = this.state;
 
     const linkProps = isExistingMovie ? { to: `/movie/${titleSlug}` } : { onPress: this.onPress };
+    const providerProps = itemType === 'movie' ? { tmdbId: foreignId } : { stashId: foreignId };
+
     let ImageItem = MoviePoster;
     let posterWidth = 167;
     let posterHeight = 250;
@@ -256,7 +258,7 @@ class AddNewMovieSearchResult extends Component {
                 }
                 tooltip={
                   <MovieDetailsLinks
-                    tmdbId={foreignId}
+                    {...providerProps}
                   />
                 }
                 canFlip={true}

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -185,7 +185,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             var page = results.GetTier(0).First().First();
 
-            page.Url.Query.Should().Contain("q=Some%20Movie%20and%20Title%20Words%202021");
+            page.Url.Query.Should().Contain("q=Some%20Movie%20and%20Title%20Words");
             page.Url.Query.Should().Contain("and");
             page.Url.Query.Should().NotContain(" & ");
             page.Url.Query.Should().NotContain("%26");

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         // (?<!\d{2}) is a negative lookbehind that ensures the dot is not preceded by two digits.
         // (?!\d{2}) is a negative lookahead that ensures the dot is not followed by two digits.
         private static readonly Regex Dots = new Regex(@"(?<!\d{2})\.(?!\d{2})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-        private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex NonWord = new Regex(@"[^\w\.]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         public Movie Movie { get; set; }

--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SearchCriteriaBase.cs
@@ -9,7 +9,13 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 {
     public abstract class SearchCriteriaBase
     {
-        private static readonly Regex SpecialCharacter = new Regex(@"[`'.]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex SpecialCharacter = new Regex(@"[`']", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Remove all dots not part of a date.
+        // The regex pattern @"(?<!\d{2})\.(?!\d{2})" is used to match dots that are not part of a date in the yy.MM.dd format.
+        // (?<!\d{2}) is a negative lookbehind that ensures the dot is not preceded by two digits.
+        // (?!\d{2}) is a negative lookahead that ensures the dot is not followed by two digits.
+        private static readonly Regex Dots = new Regex(@"(?<!\d{2})\.(?!\d{2})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex NonWord = new Regex(@"[\W]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex BeginningThe = new Regex(@"^the\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
@@ -29,6 +35,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
 
             cleanTitle = cleanTitle.Replace("&", "and");
             cleanTitle = SpecialCharacter.Replace(cleanTitle, "");
+            cleanTitle = Dots.Replace(cleanTitle, "");
             cleanTitle = NonWord.Replace(cleanTitle, "+");
 
             // remove any repeating +s

--- a/src/NzbDrone.Core/Indexers/FileList/FileListRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListRequestGenerator.cs
@@ -44,11 +44,9 @@ namespace NzbDrone.Core.Indexers.FileList
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            var releaseDate = searchCriteria.ReleaseDate?.ToString("yy.MM.dd") ?? string.Empty;
-
             foreach (var sceneTitle in searchCriteria.SceneTitles)
             {
-                pageableRequests.Add(GetRequest("search-torrents", string.Format("&type=name&query={0}{1}", Uri.EscapeDataString($"{sceneTitle.Trim()} {releaseDate}"))));
+                pageableRequests.Add(GetRequest("search-torrents", string.Format("&type=name&query={0}{1}", Uri.EscapeDataString($"{sceneTitle.Trim()}"))));
             }
 
             return pageableRequests;

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -106,8 +106,6 @@ namespace NzbDrone.Core.Indexers.Newznab
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            var releaseDate = searchCriteria.ReleaseDate?.ToString("yy.MM.dd") ?? string.Empty;
-
             if (SupportsSearch)
             {
                 var queryTitles = TextSearchEngine == "raw" ? searchCriteria.SceneTitles : searchCriteria.CleanSceneTitles;
@@ -116,7 +114,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                     pageableRequests.Add(GetPagedRequests(MaxPages,
                         Settings.Categories,
                         "search",
-                        $"&q={NewsnabifyTitle(queryTitle)}+{releaseDate}"));
+                        $"&q={NewsnabifyTitle(queryTitle)}"));
                 }
             }
 
@@ -156,8 +154,6 @@ namespace NzbDrone.Core.Indexers.Newznab
                 foreach (var queryTitle in queryTitles)
                 {
                     var searchQuery = queryTitle;
-
-                    searchQuery = $"{searchQuery} {searchCriteria.Movie.Year}";
 
                     chain.Add(GetPagedRequests(MaxPages,
                         Settings.Categories,


### PR DESCRIPTION
#### Database Migration
NO

#### Problem Statement 
The goal of this PR is to address the core issues raised in #132.   The general use case for this is to improve torrent results by avoiding the common situation where the date is not part of the tracker's title.  The goal is to provide more results by not forcing a date query.  That said, queries on the Studio name unbounded by date make little sense, requiring a bit of rewiring in how the dates are injected.

#### Description (edited)
This PR adds a non-date bound "scene name" plus "studio name" combination search.  This delivers much better results to the system to pick a good release.  It does this by modifying the SearchService to have a bit more sophisticated behavior.  To facilitate this, the Trackers no longer inject dates, this is done at the service level.  (The trackers seem to be consistent in their implementation.)

The affect of this change is that user will see more results in interactive mode.  **This does not affect the parsing behavior yet**, so we shouldn't see a flood of mismatches.

##### Example Searches
- `Studio Name 12.09.22` > _Same as before_
- `StudioName 12.09.22` > _Same as before_
- `Scene Name 12.09.22` > _Same as before_
-  `Scene Name StudioName` > _New_
-  `Scene Name Studio Name` > _New_

##### Future work
- This changes does not affect release parsing, so it will not enable automatic downloads, even if there is an exact match on the title and studio.  This will need to be handed with a config option (due to higher risk of mismatch), and a different PR.
- This change does not allow aliasing or other data which may represent the studio name.   Conceivably this is the type of metadata which would be in the stashdb or local stash instance.  Executing searches with this metadata would pull back more results and might make sense.

#### Todos
- [x] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #115 