### PR TITLE
Fixed: Studio search on add not saving selection

### DIFF
--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1271,6 +1271,7 @@
   "SearchOnAddCollectionHelpText": "Search for movies on this collection when added to library",
   "SearchOnAddHelpText": "Search for movies on this list when added to library",
   "SearchOnAddPerformerHelpText": "Search for movies/scenes on this performer when added to library",
+  "SearchOnAddStudioHelpText": "Search for movies/scenes on this studio when added to library",
   "SearchPerformer": "Search Performer",
   "SearchSelected": "Search Selected",
   "Seconds": "Seconds",

--- a/src/NzbDrone.Core/Movies/Studios/Studio.cs
+++ b/src/NzbDrone.Core/Movies/Studios/Studio.cs
@@ -30,7 +30,7 @@ namespace NzbDrone.Core.Movies.Studios
         public void ApplyChanges(Studio otherStudio)
         {
             QualityProfileId = otherStudio.QualityProfileId;
-
+            SearchOnAdd = otherStudio.SearchOnAdd;
             Monitored = otherStudio.Monitored;
 
             RootFolderPath = otherStudio.RootFolderPath;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes not saving the selection input when selecting search on add for studios.