### PR TITLE
Fix: Release Groups for movie table index add to movie/bulk

### DIFF
--- a/src/NzbDrone.Core/MovieStats/MovieStatisticsRepository.cs
+++ b/src/NzbDrone.Core/MovieStats/MovieStatisticsRepository.cs
@@ -10,6 +10,8 @@ namespace NzbDrone.Core.MovieStats
     public interface IMovieStatisticsRepository
     {
         List<MovieStatistics> MovieStatistics();
+
+        List<MovieStatistics> MovieStatistics(List<int> ids);
         List<MovieStatistics> MovieStatistics(int movieId);
     }
 
@@ -29,6 +31,12 @@ namespace NzbDrone.Core.MovieStats
         {
             return MapResults(Query(MoviesBuilder(), _selectMoviesTemplate),
                 Query(MovieFilesBuilder(), _selectMovieFilesTemplate));
+        }
+
+        public List<MovieStatistics> MovieStatistics(List<int> ids)
+        {
+            return MapResults(Query(MoviesBuilder().Where<Movie>(m => ids.Contains(m.Id)), _selectMoviesTemplate),
+                Query(MovieFilesBuilder().Where<MovieFile>(m => ids.Contains(m.Id)), _selectMovieFilesTemplate));
         }
 
         public List<MovieStatistics> MovieStatistics(int movieId)

--- a/src/NzbDrone.Core/MovieStats/MovieStatisticsService.cs
+++ b/src/NzbDrone.Core/MovieStats/MovieStatisticsService.cs
@@ -6,6 +6,7 @@ namespace NzbDrone.Core.MovieStats
     public interface IMovieStatisticsService
     {
         List<MovieStatistics> MovieStatistics();
+        List<MovieStatistics> MovieStatistics(List<int> ids);
         MovieStatistics MovieStatistics(int movieId);
     }
 
@@ -21,6 +22,13 @@ namespace NzbDrone.Core.MovieStats
         public List<MovieStatistics> MovieStatistics()
         {
             var movieStatistics = _movieStatisticsRepository.MovieStatistics();
+
+            return movieStatistics.GroupBy(m => m.MovieId).Select(m => m.First()).ToList();
+        }
+
+        public List<MovieStatistics> MovieStatistics(List<int> ids)
+        {
+            var movieStatistics = _movieStatisticsRepository.MovieStatistics(ids);
 
             return movieStatistics.GroupBy(m => m.MovieId).Select(m => m.First()).ToList();
         }

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -182,6 +182,8 @@ namespace Whisparr.Api.V3.Movies
         {
             var moviesResources = new List<MovieResource>();
 
+            var movieStats = _movieStatisticsService.MovieStatistics(ids);
+            var sdict = movieStats.ToDictionary(x => x.MovieId);
             var availDelay = _configService.AvailabilityDelay;
             var movies = _moviesService.FindByIds(ids);
 
@@ -189,6 +191,8 @@ namespace Whisparr.Api.V3.Movies
             {
                 moviesResources.Add(movie.ToResource(availDelay, _qualityUpgradableSpecification));
             }
+
+            LinkMovieStatistics(moviesResources, sdict);
 
             return moviesResources;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
https://github.com/Whisparr/Whisparr/commit/99c5251f80424403fcfc64a6c396bf6f194159cc
added Release Groups for movie table index but it needs to be added to the movie/bulk method on the API controller so that all the data is populated.

If the data is not populated the client will show a scene is missing

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX