### PR TITLE
Fix: Reorder the ReportTitleRegex so that the date is extracted

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
@@ -7,6 +7,8 @@ namespace NzbDrone.Core.Test.ParserTests
     [TestFixture]
     public class ParseMovieTitleFixture : CoreTest
     {
+        [TestCase("Studio 2020-05-29 Title Vol 1 E2", true)]
+        [TestCase("LoveHerBoobs 24 06 11 Peachy Alice Successful Provocation XXX 720p AV1 XLeech.mkv", true)]
         [TestCase("Studio.E1224.Title.XXX.720p.HEVC.x265.PRT[XvX]", true)]
         [TestCase("[Studio] Performer Name (Title / 08.01.2021) [2021 г., Big Tits, Blowjob, Brunette, Chubby, Curvy, Cowgirl, Reverse Cowgirl, Cumshots, Facials, Long Hair, Doggy Style, Hardcore, Missionary, PAWG, POV, Trimmed Pussy, Tattoo, Czech, VR, 8K, 3840p] [Oculus Rift / Vive]", true)]
         [TestCase("[Studio.com] Performer & Performer - Studio Title (18.05.2019) [2019 г., Anal, IR, Rim Job, Ass To Mouth, Big Cocks, Black, Blowjobs, Brunettes, Deep Throat, Facial, Gaping, Natural, Teen, 1080p]", true)]
@@ -24,6 +26,8 @@ namespace NzbDrone.Core.Test.ParserTests
             Parser.Parser.ParseMovieTitle(title).IsScene.Should().Be(expected);
         }
 
+        [TestCase("Studio 2020-05-29 Title Vol 1 E2", "Studio")]
+        [TestCase("LoveHerBoobs 24 06 11 Peachy Alice Successful Provocation XXX 720p AV1 XLeech.mkv", "LoveHerBoobs")]
         [TestCase("Studio.E1224.Title.XXX.720p.HEVC.x265.PRT[XvX]", "Studio")]
         [TestCase("[Studio] Performer Name (Title / 08.01.2021) [2021 г., Big Tits, Blowjob, Brunette, Chubby, Curvy, Cowgirl, Reverse Cowgirl, Cumshots, Facials, Long Hair, Doggy Style, Hardcore, Missionary, PAWG, POV, Trimmed Pussy, Tattoo, Czech, VR, 8K, 3840p] [Oculus Rift / Vive]", "Studio")]
         [TestCase("[Studio.com] Performer & Performer - Studio Title (18.05.2019) [2019 г., Anal, IR, Rim Job, Ass To Mouth, Big Cocks, Black, Blowjobs, Brunettes, Deep Throat, Facial, Gaping, Natural, Teen, 1080p]", "Studio")]
@@ -40,6 +44,8 @@ namespace NzbDrone.Core.Test.ParserTests
             Parser.Parser.ParseMovieTitle(title).StudioTitle.Should().Be(result);
         }
 
+        [TestCase("Studio 2020-05-29 Title Vol 1 E2", "2020-05-29")]
+        [TestCase("LoveHerBoobs 24 06 11 Peachy Alice Successful Provocation XXX 720p AV1 XLeech.mkv", "2024-06-11")]
         [TestCase("[Studio] Performer Name (Title / 08.01.2021) [2021 г., Big Tits, Blowjob, Brunette, Chubby, Curvy, Cowgirl, Reverse Cowgirl, Cumshots, Facials, Long Hair, Doggy Style, Hardcore, Missionary, PAWG, POV, Trimmed Pussy, Tattoo, Czech, VR, 8K, 3840p] [Oculus Rift / Vive]", "2021-01-08")]
         [TestCase("[Studio.com] Performer & Performer - Studio Title (18.05.2019) [2019 г., Anal, IR, Rim Job, Ass To Mouth, Big Cocks, Black, Blowjobs, Brunettes, Deep Throat, Facial, Gaping, Natural, Teen, 1080p]", "2019-05-18")]
         [TestCase("[random.com][Studio] Performer name - Title(01.04.2020) rq.mp4", "2020-04-01")]
@@ -55,6 +61,8 @@ namespace NzbDrone.Core.Test.ParserTests
             Parser.Parser.ParseMovieTitle(title).ReleaseDate.Should().Be(result);
         }
 
+        [TestCase("Studio 2020-05-29 Title Vol 1 E2", "title vol 1 e2")]
+        [TestCase("LoveHerBoobs 24 06 11 Peachy Alice Successful Provocation XXX 720p AV1 XLeech.mkv", "peachy alice successful provocation")]
         [TestCase("Studio.E1224.Title.XXX.720p.HEVC.x265.PRT[XvX]", "title")]
         [TestCase("[Studio] Performer Name (Title / 08.01.2021) [2021 г., Big Tits, Blowjob, Brunette, Chubby, Curvy, Cowgirl, Reverse Cowgirl, Cumshots, Facials, Long Hair, Doggy Style, Hardcore, Missionary, PAWG, POV, Trimmed Pussy, Tattoo, Czech, VR, 8K, 3840p] [Oculus Rift / Vive]", "performer name title")]
         [TestCase("[Studio.com] Performer & Performer - Studio Title (18.05.2019) [2019 г., Anal, IR, Rim Job, Ass To Mouth, Big Cocks, Black, Blowjobs, Brunettes, Deep Throat, Facial, Gaping, Natural, Teen, 1080p]", "performer performer studio title")]

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -49,10 +49,6 @@ namespace NzbDrone.Core.Parser
             new Regex(@"(?<studiotitle>.+?)?[-]+(?<releasetoken>.+?)\((?<airday>[0-3][0-9])\.(?<airmonth>[0-1][0-9])\.(?<airyear>(19|20)\d{2})\)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
-            // SCENE with Episode numbers after studio E1234 title
-            new Regex(@"(?<studiotitle>.+?)?[-_. ]+(?<episode>[eE]+\d{1,6})",
-                RegexOptions.IgnoreCase | RegexOptions.Compiled),
-
             // SCENE with airdate (18.04.28, 2018.04.28, 18-04-28, 18 04 28, 18_04_28)
             new Regex(@"^(?<studiotitle>.+?)?[-_. ]+(?<airyear>\d{2}|\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
@@ -92,6 +88,10 @@ namespace NzbDrone.Core.Parser
 
             // That did not work? Maybe some tool uses [] for years. Who would do that?
             new Regex(@"^(?<title>(?![(\[]).+?)?(?:(?:[-_\W](?<![)!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\W\d+)))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+            // SCENE with Episode numbers after studio E1234 title
+            new Regex(@"(?<studiotitle>.+?)?[-_. ]+(?<episode>[eE]+\d{1,6})",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
             // As a last resort for movies that have ( or [ in their title.
             new Regex(@"^(?<title>.+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),


### PR DESCRIPTION
#### Database Migration
NO

#### Description
"Studio 2020-05-29 Title Vol 1 E2" would fail to extract the components correctly as another regex was matching before the expected. SCENE with airdate (18.04.28, 2018.04.28, 18-04-28, 18 04 28, 18_04_28)

Add new unit test value for this pattern and alter the order of regex's in ReportTitleRegex.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX