### PR TITLE
Match using character

### DIFF
--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
@@ -19,10 +19,17 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
         public void Setup()
         {
             var credits = new List<Credit> { new Credit { Character = "Quinn", Performer = new CreditPerformer { Name = "Quinn Waters", Gender = Gender.Female } } };
-            var othercredits = new List<Credit> { new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
-            var dualcredits = new List<Credit> { new Credit { Character = "Quinn", Performer = new CreditPerformer { Name = "Quinn WatersName", Gender = Gender.Female } }, new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
+            var otherCredits = new List<Credit> { new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
+            var dualCredits = new List<Credit> { new Credit { Character = "Quinn", Performer = new CreditPerformer { Name = "Quinn Waters", Gender = Gender.Female } }, new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
+            var differentCredits = new List<Credit> { new Credit { Character = "Angie", Performer = new CreditPerformer { Name = "Angela White", Gender = Gender.Female } } };
+            var invalidCredits = new List<Credit> { new Credit { Character = "Invalid", Performer = new CreditPerformer { Name = "Invalid Name", Gender = Gender.Female } } };
+
             var scenes = Builder<Movie>.CreateListOfSize(2000)
                                         .TheFirst(1)
+                                        .With(x => x.Title = "Invalid")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-01-01")
+                                        .With(x => x.MovieMetadata.Value.Credits = invalidCredits)
+                                        .TheNext(1)
                                         .With(x => x.Title = "Title Vol 1 E2")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-05-29")
                                         .TheNext(1)
@@ -48,11 +55,15 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
                                         .TheNext(1)
                                         .With(x => x.Title = "Other Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-09")
-                                        .With(x => x.MovieMetadata.Value.Credits = dualcredits)
+                                        .With(x => x.MovieMetadata.Value.Credits = dualCredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "White Winter")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-09")
+                                        .With(x => x.MovieMetadata.Value.Credits = differentCredits)
                                         .TheNext(1)
                                         .With(x => x.Title = "Another Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-08")
-                                        .With(x => x.MovieMetadata.Value.Credits = othercredits)
+                                        .With(x => x.MovieMetadata.Value.Credits = otherCredits)
                                         .TheNext(1)
                                         .With(x => x.Title = "Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
@@ -60,7 +71,7 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
                                         .TheNext(1)
                                         .With(x => x.Title = "Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
-                                        .With(x => x.MovieMetadata.Value.Credits = dualcredits)
+                                        .With(x => x.MovieMetadata.Value.Credits = dualCredits)
                                         .TheNext(1)
                                         .With(x => x.Title = "Other Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
@@ -68,7 +79,7 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
                                         .TheNext(1)
                                         .With(x => x.Title = "Another Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
-                                        .With(x => x.MovieMetadata.Value.Credits = othercredits)
+                                        .With(x => x.MovieMetadata.Value.Credits = otherCredits)
                                         .TheNext(1)
                                         .With(x => x.Title = "Other Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
@@ -86,31 +97,31 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
 
             Mocker.GetMock<IMovieRepository>()
                 .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2021-01-08"))))
-                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2021-01-08")).ToList());
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2021-01-08")).Append(scenes.First()).ToList());
 
             Mocker.GetMock<IMovieRepository>()
                 .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2021-01-09"))))
-                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2021-01-09")).ToList());
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2021-01-09")).Append(scenes.First()).ToList());
 
             Mocker.GetMock<IMovieRepository>()
                 .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2020-05-29"))))
-                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2020-05-29")).ToList());
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2020-05-29")).Append(scenes.First()).ToList());
 
             Mocker.GetMock<IMovieRepository>()
                 .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2020-04-01"))))
-                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2020-04-01")).ToList());
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2020-04-01")).Append(scenes.First()).ToList());
 
             Mocker.GetMock<IMovieRepository>()
                 .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2024-06-11"))))
-                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2024-06-11")).ToList());
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2024-06-11")).Append(scenes.First()).ToList());
 
             Mocker.GetMock<IMovieRepository>()
                 .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2024-07-30"))))
-                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2024-07-30")).ToList());
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2024-07-30")).Append(scenes.First()).ToList());
 
             Mocker.GetMock<IMovieRepository>()
                 .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2019-05-18"))))
-                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2019-05-18")).ToList());
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2019-05-18")).Append(scenes.First()).ToList());
 
             _candidates = Builder<Movie>.CreateListOfSize(3)
                                         .TheFirst(1)
@@ -135,18 +146,16 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
             movie.Year.Should().Be(2000);
         }
 
-        // [TestCase("Studio.E1224.Episode Title.XXX.720p.HEVC.x265.PRT[XvX]", 3)]
-        // [TestCase("[Studio.com] Performer Name & Other Performer - Title (18.05.2019)", 7)]
-
-        [TestCase("Studio 2020-05-29 Title Vol 1 E2", 1)]
-        [TestCase("[Studio] Quinn Waters (Title / 08.01.2021) [2021 г., Big Tits, Blowjob, Brunette, Chubby, Curvy, Cowgirl, Reverse Cowgirl, Cumshots, Facials, Long Hair, Doggy Style, Hardcore, Missionary, PAWG, POV, Trimmed Pussy, Tattoo, Czech, VR, 8K, 3840p] [Oculus Rift / Vive]", 6)]
-        [TestCase("Studio.21.01.08.Title", 6)]
-        [TestCase("Studio.21.01.08.Quinn Waters", 6)]
-        [TestCase("Studio.21.01.08.Quinn", 6)]
-        [TestCase("Studio.21.01.09.Quinn & Carrie", 7)]
-        [TestCase("Studio.21.01.08.Carrie", 8)]
-        [TestCase("Studio.21.01.08.Carrie Sage", 8)]
-        [TestCase("Studio - 2024-07-30 - Milk & Chocolate Before Bed", 5)]
+        [TestCase("Studio 2020-05-29 Title Vol 1 E2", 2)]
+        [TestCase("[Studio] Quinn Waters (Title / 08.01.2021) [2021 г., Big Tits, Blowjob, Brunette, Chubby, Curvy, Cowgirl, Reverse Cowgirl, Cumshots, Facials, Long Hair, Doggy Style, Hardcore, Missionary, PAWG, POV, Trimmed Pussy, Tattoo, Czech, VR, 8K, 3840p] [Oculus Rift / Vive]", 7)]
+        [TestCase("Studio.21.01.08.Title", 7)]
+        [TestCase("Studio.21.01.08.Quinn Waters", 7)]
+        [TestCase("Studio.21.01.08.Quinn", 7)]
+        [TestCase("Studio.21.01.09.Quinn & Carrie", 8)]
+        [TestCase("Studio.21.01.09.Quinn & Carrie - Other Title", 8)]
+        [TestCase("Studio.21.01.08.Carrie", 10)]
+        [TestCase("Studio.21.01.08.Carrie Sage", 10)]
+        [TestCase("Studio - 2024-07-30 - Milk & Chocolate Before Bed", 6)]
         public void should_find_by_studio_and_release_date(string title, int id)
         {
             var parsedMovieInfo = Parser.Parser.ParseMovieTitle(title);

--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
@@ -2,8 +2,10 @@ using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
+using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
@@ -16,6 +18,100 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
         [SetUp]
         public void Setup()
         {
+            var credits = new List<Credit> { new Credit { Character = "Quinn", Performer = new CreditPerformer { Name = "Quinn Waters", Gender = Gender.Female } } };
+            var othercredits = new List<Credit> { new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
+            var dualcredits = new List<Credit> { new Credit { Character = "Quinn", Performer = new CreditPerformer { Name = "Quinn WatersName", Gender = Gender.Female } }, new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
+            var scenes = Builder<Movie>.CreateListOfSize(2000)
+                                        .TheFirst(1)
+                                        .With(x => x.Title = "Title Vol 1 E2")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-05-29")
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-04-01")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Episode Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-04-02")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Episode Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-06-11")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Milk & Chocolate Before Bed🥛🕟😵‍💫🕦🥛")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-07-30")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-08")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Other Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-09")
+                                        .With(x => x.MovieMetadata.Value.Credits = dualcredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Another Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-08")
+                                        .With(x => x.MovieMetadata.Value.Credits = othercredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
+                                        .With(x => x.MovieMetadata.Value.Credits = dualcredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Other Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Another Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
+                                        .With(x => x.MovieMetadata.Value.Credits = othercredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Other Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheRest()
+                                        .With(x => x.Title = "Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-06-12")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .Build()
+                                        .ToList();
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.GetByStudioForeignId(It.Is<string>(s => s.Equals("Studio"))))
+                .Returns(scenes);
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2021-01-08"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2021-01-08")).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2021-01-09"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2021-01-09")).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2020-05-29"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2020-05-29")).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2020-04-01"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2020-04-01")).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2024-06-11"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2024-06-11")).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2024-07-30"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2024-07-30")).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2019-05-18"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2019-05-18")).ToList());
+
             _candidates = Builder<Movie>.CreateListOfSize(3)
                                         .TheFirst(1)
                                         .With(x => x.MovieMetadata.Value.CleanTitle = "batman")
@@ -37,6 +133,31 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
 
             movie.Should().NotBeNull();
             movie.Year.Should().Be(2000);
+        }
+
+        // [TestCase("Studio.E1224.Episode Title.XXX.720p.HEVC.x265.PRT[XvX]", 3)]
+        // [TestCase("[Studio.com] Performer Name & Other Performer - Title (18.05.2019)", 7)]
+
+        [TestCase("Studio 2020-05-29 Title Vol 1 E2", 1)]
+        [TestCase("[Studio] Quinn Waters (Title / 08.01.2021) [2021 г., Big Tits, Blowjob, Brunette, Chubby, Curvy, Cowgirl, Reverse Cowgirl, Cumshots, Facials, Long Hair, Doggy Style, Hardcore, Missionary, PAWG, POV, Trimmed Pussy, Tattoo, Czech, VR, 8K, 3840p] [Oculus Rift / Vive]", 6)]
+        [TestCase("Studio.21.01.08.Title", 6)]
+        [TestCase("Studio.21.01.08.Quinn Waters", 6)]
+        [TestCase("Studio.21.01.08.Quinn", 6)]
+        [TestCase("Studio.21.01.09.Quinn & Carrie", 7)]
+        [TestCase("Studio.21.01.08.Carrie", 8)]
+        [TestCase("Studio.21.01.08.Carrie Sage", 8)]
+        [TestCase("Studio - 2024-07-30 - Milk & Chocolate Before Bed", 5)]
+        public void should_find_by_studio_and_release_date(string title, int id)
+        {
+            var parsedMovieInfo = Parser.Parser.ParseMovieTitle(title);
+
+            if (parsedMovieInfo.IsScene)
+            {
+                var movie = Subject.FindByStudioAndReleaseDate(parsedMovieInfo.StudioTitle, parsedMovieInfo.ReleaseDate, parsedMovieInfo.ReleaseTokens);
+
+                movie.Should().NotBeNull();
+                movie.Id.Should().Be(id);
+            }
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
@@ -2,8 +2,10 @@ using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
+using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
@@ -16,6 +18,111 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
         [SetUp]
         public void Setup()
         {
+            var credits = new List<Credit> { new Credit { Character = "Quinn", Performer = new CreditPerformer { Name = "Quinn Waters", Gender = Gender.Female } } };
+            var otherCredits = new List<Credit> { new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
+            var dualCredits = new List<Credit> { new Credit { Character = "Quinn", Performer = new CreditPerformer { Name = "Quinn Waters", Gender = Gender.Female } }, new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
+            var differentCredits = new List<Credit> { new Credit { Character = "Angie", Performer = new CreditPerformer { Name = "Angela White", Gender = Gender.Female } } };
+            var invalidCredits = new List<Credit> { new Credit { Character = "Invalid", Performer = new CreditPerformer { Name = "Invalid Name", Gender = Gender.Female } } };
+
+            var scenes = Builder<Movie>.CreateListOfSize(2000)
+                                        .TheFirst(1)
+                                        .With(x => x.Title = "Invalid")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-01-01")
+                                        .With(x => x.MovieMetadata.Value.Credits = invalidCredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Title Vol 1 E2")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-05-29")
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-04-01")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Episode Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-04-02")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Episode Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-06-11")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Milk & Chocolate Before Bed🥛🕟😵‍💫🕦🥛")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-07-30")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-08")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Other Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-09")
+                                        .With(x => x.MovieMetadata.Value.Credits = dualCredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "White Winter")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-09")
+                                        .With(x => x.MovieMetadata.Value.Credits = differentCredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Another Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-08")
+                                        .With(x => x.MovieMetadata.Value.Credits = otherCredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
+                                        .With(x => x.MovieMetadata.Value.Credits = dualCredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Other Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Another Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
+                                        .With(x => x.MovieMetadata.Value.Credits = otherCredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Other Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .TheRest()
+                                        .With(x => x.Title = "Title")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-06-12")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .Build()
+                                        .ToList();
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.GetByStudioForeignId(It.Is<string>(s => s.Equals("Studio"))))
+                .Returns(scenes);
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2021-01-08"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2021-01-08")).Append(scenes.First()).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2021-01-09"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2021-01-09")).Append(scenes.First()).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2020-05-29"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2020-05-29")).Append(scenes.First()).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2020-04-01"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2020-04-01")).Append(scenes.First()).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2024-06-11"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2024-06-11")).Append(scenes.First()).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2024-07-30"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2024-07-30")).Append(scenes.First()).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2019-05-18"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2019-05-18")).Append(scenes.First()).ToList());
+
             _candidates = Builder<Movie>.CreateListOfSize(3)
                                         .TheFirst(1)
                                         .With(x => x.MovieMetadata.Value.CleanTitle = "batman")
@@ -37,6 +144,29 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
 
             movie.Should().NotBeNull();
             movie.Year.Should().Be(2000);
+        }
+
+        [TestCase("Studio 2020-05-29 Title Vol 1 E2", 2)]
+        [TestCase("[Studio] Quinn Waters (Title / 08.01.2021) [2021 г., Big Tits, Blowjob, Brunette, Chubby, Curvy, Cowgirl, Reverse Cowgirl, Cumshots, Facials, Long Hair, Doggy Style, Hardcore, Missionary, PAWG, POV, Trimmed Pussy, Tattoo, Czech, VR, 8K, 3840p] [Oculus Rift / Vive]", 7)]
+        [TestCase("Studio.21.01.08.Title", 7)]
+        [TestCase("Studio.21.01.08.Quinn Waters", 7)]
+        [TestCase("Studio.21.01.08.Quinn", 7)]
+        [TestCase("Studio.21.01.09.Quinn & Carrie", 8)]
+        [TestCase("Studio.21.01.09.Quinn & Carrie - Other Title", 8)]
+        [TestCase("Studio.21.01.08.Carrie", 10)]
+        [TestCase("Studio.21.01.08.Carrie Sage", 10)]
+        [TestCase("Studio - 2024-07-30 - Milk & Chocolate Before Bed", 6)]
+        public void should_find_by_studio_and_release_date(string title, int id)
+        {
+            var parsedMovieInfo = Parser.Parser.ParseMovieTitle(title);
+
+            if (parsedMovieInfo.IsScene)
+            {
+                var movie = Subject.FindByStudioAndReleaseDate(parsedMovieInfo.StudioTitle, parsedMovieInfo.ReleaseDate, parsedMovieInfo.ReleaseTokens);
+
+                movie.Should().NotBeNull();
+                movie.Id.Should().Be(id);
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -422,12 +422,33 @@ namespace NzbDrone.Core.Movies
                         continue;
                     }
 
+                    var cleanCharacters = movie.MovieMetadata.Value.Credits.Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
+                                                                            .Where(x => x.IsNotNullOrWhiteSpace());
+
+                    // If parsed title matches character, consider a match
+                    if (cleanCharacters.Any() && cleanCharacters.Any(c => c.IsNotNullOrWhiteSpace() && parsedMovieTitle.Equals(c)))
+                    {
+                        matches.Add(movie);
+                        continue;
+                    }
+
                     var cleanFemalePerformers = movie.MovieMetadata.Value.Credits.Where(a => a.Performer.Gender == Gender.Female)
                                                                                  .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Performer.Name))
                                                                                  .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
 
                     // If all female performers are in title, consider a match
                     if (cleanFemalePerformers.Any() && cleanFemalePerformers.All(x => parsedMovieTitle.Contains(x)))
+                    {
+                        matches.Add(movie);
+                        continue;
+                    }
+
+                    var cleanFemaleCharacters = movie.MovieMetadata.Value.Credits.Where(a => a.Performer.Gender == Gender.Female)
+                                                                                 .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
+                                                                                 .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
+
+                    // If all female characters are in title, consider a match
+                    if (cleanFemaleCharacters.Any() && cleanFemalePerformers.All(x => parsedMovieTitle.Contains(x)))
                     {
                         matches.Add(movie);
                         continue;
@@ -440,6 +461,27 @@ namespace NzbDrone.Core.Movies
 
                     // If parsed title contains a performer and the title then consider a match
                     if (cleanPerformers.Any(x => parsedMovieTitle.Contains(x)) && parsedMovieTitle.Contains(cleanTitle))
+                    {
+                        matches.Add(movie);
+                        continue;
+                    }
+
+                    // If parsed title contains a character and the title then consider a match
+                    if (cleanCharacters.Any() && cleanCharacters.Any(x => parsedMovieTitle.Contains(x)) && parsedMovieTitle.Contains(cleanTitle))
+                    {
+                        matches.Add(movie);
+                        continue;
+                    }
+
+                    // If parsed title contains all performer and the not title then consider a match
+                    if (cleanPerformers.All(x => parsedMovieTitle.Contains(x)) && !parsedMovieTitle.Contains(cleanTitle))
+                    {
+                        matches.Add(movie);
+                        continue;
+                    }
+
+                    // If parsed title contains all character and the not title then consider a match
+                    if (cleanCharacters.Any() && cleanCharacters.All(x => parsedMovieTitle.Contains(x)) && !parsedMovieTitle.Contains(cleanTitle))
                     {
                         matches.Add(movie);
                         continue;

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -447,7 +447,7 @@ namespace NzbDrone.Core.Movies
                                                                                  .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
                                                                                  .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
 
-                    // If all female performers are in title, consider a match
+                    // If all female characters are in title, consider a match
                     if (cleanFemaleCharacters.Any() && cleanFemalePerformers.All(x => parsedMovieTitle.Contains(x)))
                     {
                         matches.Add(movie);
@@ -466,8 +466,22 @@ namespace NzbDrone.Core.Movies
                         continue;
                     }
 
-                    // If parsed title contains a performer and the title then consider a match
+                    // If parsed title contains a character and the title then consider a match
                     if (cleanCharacters.Any() && cleanCharacters.Any(x => parsedMovieTitle.Contains(x)) && parsedMovieTitle.Contains(cleanTitle))
+                    {
+                        matches.Add(movie);
+                        continue;
+                    }
+
+                    // If parsed title contains all performer and the not title then consider a match
+                    if (cleanPerformers.All(x => parsedMovieTitle.Contains(x)) && !parsedMovieTitle.Contains(cleanTitle))
+                    {
+                        matches.Add(movie);
+                        continue;
+                    }
+
+                    // If parsed title contains all character and the not title then consider a match
+                    if (cleanCharacters.Any() && cleanCharacters.All(x => parsedMovieTitle.Contains(x)) && !parsedMovieTitle.Contains(cleanTitle))
                     {
                         matches.Add(movie);
                         continue;

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -422,12 +422,33 @@ namespace NzbDrone.Core.Movies
                         continue;
                     }
 
+                    var cleanCharacters = movie.MovieMetadata.Value.Credits.Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
+                                                                            .Where(x => x.IsNotNullOrWhiteSpace());
+
+                    // If parsed title matches character, consider a match
+                    if (cleanCharacters.Any() && cleanCharacters.Any(c => c.IsNotNullOrWhiteSpace() && parsedMovieTitle.Equals(c)))
+                    {
+                        matches.Add(movie);
+                        continue;
+                    }
+
                     var cleanFemalePerformers = movie.MovieMetadata.Value.Credits.Where(a => a.Performer.Gender == Gender.Female)
                                                                                  .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Performer.Name))
                                                                                  .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
 
                     // If all female performers are in title, consider a match
                     if (cleanFemalePerformers.Any() && cleanFemalePerformers.All(x => parsedMovieTitle.Contains(x)))
+                    {
+                        matches.Add(movie);
+                        continue;
+                    }
+
+                    var cleanFemaleCharacters = movie.MovieMetadata.Value.Credits.Where(a => a.Performer.Gender == Gender.Female)
+                                                                                 .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
+                                                                                 .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
+
+                    // If all female performers are in title, consider a match
+                    if (cleanFemaleCharacters.Any() && cleanFemalePerformers.All(x => parsedMovieTitle.Contains(x)))
                     {
                         matches.Add(movie);
                         continue;
@@ -440,6 +461,13 @@ namespace NzbDrone.Core.Movies
 
                     // If parsed title contains a performer and the title then consider a match
                     if (cleanPerformers.Any(x => parsedMovieTitle.Contains(x)) && parsedMovieTitle.Contains(cleanTitle))
+                    {
+                        matches.Add(movie);
+                        continue;
+                    }
+
+                    // If parsed title contains a performer and the title then consider a match
+                    if (cleanCharacters.Any() && cleanCharacters.Any(x => parsedMovieTitle.Contains(x)) && parsedMovieTitle.Contains(cleanTitle))
                     {
                         matches.Add(movie);
                         continue;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The title can match based on the Performers name as some items are listed with the performers name in the title section [studio] [date] [performers] and maybe the title [title]. For an older scenes this could be the character name as the performer has changed there name at a later date.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #244 