### PR TITLE
New: Import Lists support TPDb Scene Advanced List

### DIFF
--- a/src/NzbDrone.Common/Http/TPDbApiResponse.cs
+++ b/src/NzbDrone.Common/Http/TPDbApiResponse.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace NzbDrone.Common.Http
+{
+    public class TPDbAPIResponse<TResource>
+    {
+        public List<TResource> Data { get; set; }
+
+        // public Dictionary<string, string> Links { get; set; }
+
+        // public Dictionary<string, string> Meta { get; set; }
+    }
+}

--- a/src/NzbDrone.Core.Test/ImportListTests/TPDb/TPDbSceneSettingsValidatorFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/TPDb/TPDbSceneSettingsValidatorFixture.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using NzbDrone.Core.ImportLists.ThePornDb;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ImportListTests.TPDb
+{
+    public class TPDbSceneSettingsValidatorFixture : CoreTest
+    {
+        [TestCase("", TestName = "Invalid_ApiKey_Empty")]
+        [TestCase("validApiKey", TestName = "Valid_ApiKey")]
+        public void Validate_ApiKey_Should_Contain_Errors(string apiKey)
+        {
+            var settings = new TPDbSceneSettings
+            {
+                ApiKey = apiKey,
+                OrderBy = "SomeOrderBy",
+                Date = "2023-12-01",
+                DateContext = "SomeContext"
+            };
+
+            var result = settings.Validate();
+            Assert.AreEqual(string.IsNullOrEmpty(apiKey), result.Errors.Any(e => e.PropertyName == nameof(settings.ApiKey)));
+        }
+
+        [TestCase("", TestName = "Invalid_OrderBy_Empty")]
+        [TestCase("SomeOrderBy", TestName = "Valid_OrderBy")]
+        public void Validate_OrderBy_Should_Contain_Errors(string orderBy)
+        {
+            var settings = new TPDbSceneSettings
+            {
+                ApiKey = "validApiKey",
+                OrderBy = orderBy,
+                Date = "2023-12-01",
+                DateContext = "SomeContext"
+            };
+
+            var result = settings.Validate();
+            Assert.AreEqual(string.IsNullOrEmpty(orderBy), result.Errors.Any(e => e.PropertyName == nameof(settings.OrderBy)));
+        }
+
+        [TestCase("2023-02-30", "SomeContext", TestName = "Invalid_Non_Existent_Date")]
+        [TestCase("2023-12-01", "SomeContext", TestName = "Valid_Date")]
+        [TestCase("2023-13-01", "SomeContext", TestName = "Invalid_Invalid_Date_Format")]
+        [TestCase("2023-02-30", null, TestName = "Invalid_Non_Existent_Date_and_Null_DateContext")]
+        [TestCase("2023-12-01", null, TestName = "Invalid_Valid_Date_Null_DateContext")]
+        [TestCase("2023-13-01", null, TestName = "Invalid_Invalid_Date_Format_Null_DateContext")]
+        [TestCase("2023-02-30", "", TestName = "Invalid_Non_Existent_Date_Empty_DateContext")]
+        [TestCase("2023-12-01", "", TestName = "Invalid_Valid_Date_Empty_DateContext")]
+        [TestCase("2023-13-01", "", TestName = "Invalid_Invalid_Date_Format_Empty_DateContext")]
+        public void Validate_Date_Should_Contain_Errors(string date, string dateContext)
+        {
+            var settings = new TPDbSceneSettings
+            {
+                ApiKey = "validApiKey",
+                OrderBy = "SomeOrderBy",
+                Date = date,
+                DateContext = dateContext
+            };
+
+            var result = settings.Validate();
+            Assert.AreEqual(!DateTime.TryParseExact(date, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out _),
+                result.Errors.Any(e => e.PropertyName == nameof(settings.Date)));
+        }
+
+        [TestCase(null, TestName = "DateContext_Null_When_Date_Provided")]
+        [TestCase("", TestName = "DateContext_Empty_When_Date_Provided")]
+        [TestCase("SomeContext", TestName = "Valid_DateContext_When_Date_Provided")]
+        public void Validate_DateContext_Should_Contain_Errors(string dateContext)
+        {
+            var settings = new TPDbSceneSettings
+            {
+                ApiKey = "validApiKey",
+                OrderBy = "SomeOrderBy",
+                Date = "2023-12-01",
+                DateContext = dateContext
+            };
+
+            var result = settings.Validate();
+            var expectedError = !string.IsNullOrEmpty(settings.Date) && string.IsNullOrEmpty(dateContext);
+            Assert.AreEqual(expectedError, result.Errors.Any(e => e.PropertyName == nameof(settings.DateContext)));
+        }
+
+        [TestCase("", "", "", "", false, TestName = "Invalid_All_Fields_Empty")]
+        [TestCase("validApiKey", "", "", "", false, TestName = "Invalid_OrderBy_Empty")]
+        [TestCase("validApiKey", "OrderByValue", "2023-13-01", "", false, TestName = "Invalid_Invalid_Date_Format")]
+        [TestCase("validApiKey", "OrderByValue", "2023-02-30", "", false, TestName = "Invalid_Non_Existent_Date")]
+        [TestCase("validApiKey", "OrderByValue", "2023-12-01", "", false, TestName = "Invalid_DateContext_Empty")]
+        [TestCase("validApiKey", "OrderByValue", "2023-12-01", "SomeContext", true, TestName = "Valid_All_Fields_Provided")]
+        [TestCase("validApiKey", "OrderByValue", null, null, true, TestName = "Valid_Optional_Date_And_Context_Not_Provided")]
+        public void Validate_CustomSettings_Should_Be_Valid_Or_Invalid(string apiKey, string orderBy, string date, string dateContext, bool isValid)
+        {
+            var settings = new TPDbSceneSettings
+            {
+                ApiKey = apiKey,
+                OrderBy = orderBy,
+                Date = date,
+                DateContext = dateContext
+            };
+
+            var result = settings.Validate();
+            Assert.AreEqual(isValid, result.IsValid);
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ThePornDb/ITPDbSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/ThePornDb/ITPDbSettings.cs
@@ -1,0 +1,19 @@
+using static NzbDrone.Core.ImportLists.ThePornDb.TPDbSceneSettings;
+
+namespace NzbDrone.Core.ImportLists.ThePornDb
+{
+    public interface ITPDbSettings : IImportListSettings
+    {
+        string ApiKey { get; set; }
+
+        string OrderBy { get; set; }
+
+        string Date {  get; set; }
+
+        string DateContext { get; set; }
+
+        TriPosition Collected { get; set; }
+
+        TriPosition Favourites { get; set; }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ThePornDb/TPDbImportProxy.cs
+++ b/src/NzbDrone.Core/ImportLists/ThePornDb/TPDbImportProxy.cs
@@ -6,13 +6,17 @@ using Newtonsoft.Json;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.ImportLists.ThePornDb;
+using static NzbDrone.Core.ImportLists.ThePornDb.TPDbSceneSettings;
 
 namespace NzbDrone.Core.ImportLists.TPDb
 {
     public interface ITPDbImportProxy
     {
         List<PerformerScene> GetPerformer(TPDbPerformerSettings settings);
+        List<PerformerScene> GetScenes(TPDbSceneSettings settings);
         ValidationFailure Test(TPDbPerformerSettings settings);
+        ValidationFailure Test(TPDbSceneSettings settings);
     }
 
     public class TPDbImportProxy : ITPDbImportProxy
@@ -24,6 +28,16 @@ namespace NzbDrone.Core.ImportLists.TPDb
         {
             _httpClient = httpClient;
             _logger = logger;
+        }
+
+        public List<PerformerScene> GetScenes(TPDbSceneSettings settings)
+        {
+            return Execute<TPDbApiObject>(settings).ToPerformerSceneList();
+        }
+
+        private void GetTestScenes(TPDbSceneSettings settings)
+        {
+            Check<TPDbApiObject>(settings);
         }
 
         public List<PerformerScene> GetPerformer(TPDbPerformerSettings settings)
@@ -57,6 +71,63 @@ namespace NzbDrone.Core.ImportLists.TPDb
             return null;
         }
 
+        public ValidationFailure Test(TPDbSceneSettings settings)
+        {
+            try
+            {
+                GetTestScenes(settings);
+            }
+            catch (HttpException ex)
+            {
+                if (ex.Response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    _logger.Error(ex, "There was an authorization issue. We cannot get the list from the provider.");
+                    return new ValidationFailure("BaseUrl", "It seems we are unauthorized to make this request.");
+                }
+
+                _logger.Error(ex, "Unable to send test message");
+                return new ValidationFailure("BaseUrl", $"We are unable to make the request to that URL. StatusCode: {ex.Response.StatusCode}");
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unable to send test message");
+                return new ValidationFailure("", "Unable to send test message");
+            }
+
+            return null;
+        }
+
+        private TPDbApiObject Execute<TResource>(TPDbSceneSettings settings)
+            where TResource : TPDbApiObject, new()
+        {
+            var tPDbApiObject = new TResource();
+            var currentPage = 1;
+            int lastPage;
+            do
+            {
+                var request = BuildRequest(settings, currentPage);
+                var response = _httpClient.Get(request);
+                var json = JsonConvert.DeserializeObject<TResource>(response.Content);
+                tPDbApiObject.CombineWith(json);
+
+                lastPage = tPDbApiObject.Meta.LastPage;
+                currentPage = tPDbApiObject.Meta.CurrentPage + 1;
+            }
+            while (currentPage <= lastPage);
+
+            return tPDbApiObject;
+        }
+
+        private void Check<TResource>(TPDbSceneSettings settings)
+        {
+            var request = new HttpRequestBuilder(settings.BaseUrl)
+                .Resource("auth/user")
+                .SetHeader("Authorization", $"Bearer {settings.ApiKey}")
+                .Accept(HttpAccept.Json)
+                .Build();
+            _httpClient.Get(request);
+        }
+
         private List<TResource> Execute<TResource>(TPDbPerformerSettings settings)
         {
             if (settings.BaseUrl.IsNullOrWhiteSpace())
@@ -70,6 +141,40 @@ namespace NzbDrone.Core.ImportLists.TPDb
             var results = JsonConvert.DeserializeObject<List<TResource>>(response.Content);
 
             return results;
+        }
+
+        private HttpRequest BuildRequest(TPDbSceneSettings settings, int page)
+        {
+            var baseUrl = settings.BaseUrl.TrimEnd('/');
+
+            var httpRequestBuilder = new HttpRequestBuilder(baseUrl)
+                .Resource("scenes")
+                .SetHeader("Authorization", $"Bearer {settings.ApiKey}")
+                .Accept(HttpAccept.Json)
+                .AddQueryParam("page", page)
+                .AddQueryParam("orderBy", settings.OrderBy)
+                .AddQueryParam("per_page", settings.PerPageLimit);
+
+            if (!string.IsNullOrEmpty(settings.Date) && !string.IsNullOrEmpty(settings.DateContext))
+            {
+                httpRequestBuilder
+                    .AddQueryParam("date", settings.Date)
+                    .AddQueryParam("date_operation", settings.DateContext);
+            }
+
+            if (settings.Collected != TriPosition.None)
+            {
+                httpRequestBuilder
+                    .AddQueryParam("is_collected", (int)settings.Collected);
+            }
+
+            if (settings.Favourites != TriPosition.None)
+            {
+                httpRequestBuilder
+                    .AddQueryParam("is_favourite", (int)settings.Favourites);
+            }
+
+            return httpRequestBuilder.Build();
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ThePornDb/TPDbSceneAPIResource.cs
+++ b/src/NzbDrone.Core/ImportLists/ThePornDb/TPDbSceneAPIResource.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using NzbDrone.Core.ImportLists.TPDb;
+
+namespace NzbDrone.Core.ImportLists.ThePornDb
+{
+    public class TPDbApiObject
+    {
+        public List<FeedData> Data { get; set; } = new List<FeedData>();
+
+        public FeedLinks Links { get; set; } = new FeedLinks();
+
+        public FeedMeta Meta { get; set; } = new FeedMeta();
+
+        internal void CombineWith(TPDbApiObject json)
+        {
+            Data.AddRange(json.Data);
+            Links = json.Links;
+            Meta = json.Meta;
+        }
+    }
+
+    public class FeedData
+    {
+        [JsonProperty("_id")]
+        public int SceneId { get; set; }
+
+        [JsonProperty("site_id")]
+        public int SiteId { get; set; }
+    }
+
+    public class FeedLinks
+    {
+        public string First { get; set; }
+        public string Next { get; set; }
+        public string Last { get; set; }
+        public string Prev { get; set; }
+    }
+
+    public class FeedMeta
+    {
+        public int Total { get; set; }
+
+        [JsonProperty("last_page")]
+        public int LastPage { get; set; }
+
+        [JsonProperty("current_page")]
+        public int CurrentPage { get; set; }
+
+        // This is for the links array inside "meta"
+        public List<MetaLink> Links { get; set; } = new List<MetaLink>();
+    }
+
+    public class MetaLink
+    {
+        public string Url { get; set; }
+        public string Label { get; set; }
+        public bool Active { get; set; }
+    }
+
+    public static class TPDbApiObjectExtensions
+    {
+        public static List<PerformerScene> ToPerformerSceneList(this List<FeedData> feedDataList)
+        {
+            return feedDataList.Select(item => new PerformerScene
+            {
+                SiteId = item.SiteId,
+                EpisodeId = item.SceneId
+            }).ToList();
+        }
+
+        public static List<PerformerScene> ToPerformerSceneList(this TPDbApiObject feedObject)
+        {
+            return feedObject.Data.ToPerformerSceneList();
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ThePornDb/TPDbSceneImport.cs
+++ b/src/NzbDrone.Core/ImportLists/ThePornDb/TPDbSceneImport.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentValidation.Results;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.ImportLists.TPDb;
+using NzbDrone.Core.Parser;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.ImportLists.ThePornDb
+{
+    public class TPDbSceneImport : ImportListBase<TPDbSceneSettings>
+    {
+        private readonly ITPDbImportProxy _customProxy;
+
+        public override string Name => "TPDb Scenes";
+
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(6);
+
+        public override ImportListType ListType => ImportListType.Advanced;
+
+        public TPDbSceneImport(
+            ITPDbImportProxy customProxy,
+            IImportListStatusService importListStatusService,
+            IConfigService configService,
+            IParsingService parsingService,
+            Logger logger)
+            : base(importListStatusService, configService, parsingService, logger)
+        {
+            _customProxy = customProxy;
+        }
+
+        public override object RequestAction(string stage, IDictionary<string, string> query)
+        {
+            if (stage == "getOrderBy")
+            {
+                var choices = new Dictionary<string, string>()
+                {
+                    { "recently_created", "Recently Created" },
+                    { "former_created", "Oldest Added" },
+                    { "recently_updated", "Recently Updated" },
+                    { "former_updated", "Former Updated" },
+                    { "recently_released", "Recently Released" },
+                    { "former_released", "Former Released" },
+                };
+                return new
+                {
+                    options = choices.Select(i => new
+                    {
+                        value = i.Key,
+                        name = i.Value
+                    })
+                };
+            }
+
+            if (stage == "getDateContext")
+            {
+                var choices = new Dictionary<string, string>()
+                {
+                    { "=", "Equal" },
+                    { ">", "Greater" },
+                    { ">=", "Greater or Equal" },
+                    { "<", "Less" },
+                    { "<=", "Less or Equal" }
+                };
+                return new
+                {
+                    options = choices.Select(i => new
+                    {
+                        value = i.Key,
+                        Name = i.Value
+                    })
+                };
+            }
+
+            return new { };
+        }
+
+        // remove if implementation is going to get pushed down to the concrete classes:
+        // TPDbCollectionImport/TPDbFavouritesImport
+        public override IList<ImportListItemInfo> Fetch()
+        {
+            var series = new List<ImportListItemInfo>();
+
+            try
+            {
+                var remoteSeries = _customProxy.GetScenes(Settings);
+
+                foreach (var item in remoteSeries)
+                {
+                    series.Add(new ImportListItemInfo
+                    {
+                        TpdbSiteId = item.SiteId,
+                        TpdbEpisodeId = item.EpisodeId
+                    });
+                }
+
+                _importListStatusService.RecordSuccess(Definition.Id);
+            }
+            catch
+            {
+                _importListStatusService.RecordFailure(Definition.Id);
+            }
+
+            return CleanupListItems(series);
+        }
+
+        protected override void Test(List<ValidationFailure> failures)
+        {
+            failures.AddIfNotNull(_customProxy.Test(Settings));
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ThePornDb/TPDbSceneSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/ThePornDb/TPDbSceneSettings.cs
@@ -1,0 +1,91 @@
+using System;
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.ImportLists.ThePornDb
+{
+    public class CustomSettingsValidator : AbstractValidator<TPDbSceneSettings>
+    {
+        public CustomSettingsValidator()
+        {
+            RuleFor(c => c.ApiKey).NotEmpty().WithMessage("API Key must not be empty");
+            RuleFor(c => c.OrderBy).NotEmpty().WithMessage("Must select a sort method");
+            RuleFor(c => c.Date)
+                .NotEmpty()
+                .When(x => !string.IsNullOrEmpty(x.DateContext))
+                .WithMessage("Date must not be empty if Date Context is provided")
+                .Matches(@"^\d{4}-\d{2}-\d{2}$")
+                .When(x => !string.IsNullOrEmpty(x.Date))
+                .WithMessage("Date must be in the format YYYY-MM-DD")
+                .Must(date =>
+                {
+                    return DateTime.TryParseExact(date, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out _);
+                })
+                .When(x => !string.IsNullOrEmpty(x.Date))
+                .WithMessage("Date must be a valid calendar date");
+            RuleFor(x => x.DateContext)
+                .NotEmpty()
+                .When(x => !string.IsNullOrEmpty(x.Date))
+                .WithMessage("DateContext must not be empty if Date is provided");
+        }
+    }
+
+    public class TPDbSceneSettings : ITPDbSettings
+    {
+        // Maximum page size the api will allow
+        private readonly int _PerPageLimit = 100;
+        private static readonly CustomSettingsValidator Validator = new CustomSettingsValidator();
+        private readonly string _BaseUrl = "https://api.theporndb.net";
+
+        public TPDbSceneSettings()
+        {
+        }
+
+        [FieldDefinition(0, Label = "API Key", HelpText = "The TPDb API Key", Type = FieldType.Textbox, Privacy = PrivacyLevel.ApiKey)]
+        public string ApiKey { get; set; }
+
+        [FieldDefinition(1, Type = FieldType.Select, SelectOptionsProviderAction = "getOrderBy", Label = "Sort", HelpText = "Sort by one of the following")]
+        public string OrderBy { get; set; }
+
+        [FieldDefinition(2, Label = "Date", HelpText = "Filter by date with format (YYYY-MM-DD)", Type = FieldType.Textbox)]
+        public string Date { get; set; }
+
+        [FieldDefinition(3, Type = FieldType.Select, SelectOptionsProviderAction = "getDateContext", Label = "Sort", HelpText = "Filter by date")]
+        public string DateContext { get; set; }
+
+        [FieldDefinition(4, Type = FieldType.Select, SelectOptions = typeof(TriPosition), Label = "Collection", HelpText = "Filter by Collection")]
+        public TriPosition Collected { get; set; }
+
+        [FieldDefinition(5, Type = FieldType.Select, SelectOptions = typeof(TriPosition), Label = "Favourites", HelpText = "Filter by Favourites")]
+        public TriPosition Favourites { get; set; }
+
+        public int PerPageLimit
+        {
+            get
+            {
+                return _PerPageLimit;
+            }
+        }
+
+        public string BaseUrl
+        {
+            get
+            {
+                return _BaseUrl;
+            }
+            set
+            {
+            }
+        }
+
+        public NzbDroneValidationResult Validate() => new NzbDroneValidationResult(Validator.Validate(this));
+
+        public enum TriPosition
+        {
+            True = 1,
+            False = 0,
+            None = -1
+        }
+    }
+}

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -17,13 +17,13 @@
     <PackageReference Include="Servarr.FluentMigrator.Runner.SQLite" Version="3.3.2.9" />
     <PackageReference Include="Servarr.FluentMigrator.Runner.Postgres" Version="3.3.2.9" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="MonoTorrent" Version="2.0.7" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
     <PackageReference Include="System.Text.Json" Version="6.0.8" />
-    <PackageReference Include="Npgsql" Version="7.0.4" />
+    <PackageReference Include="Npgsql" Version="7.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I wanted to expand the functionality of the Import Lists feature. Using TPDb API /scene endpoint, this makes it possible to create an Import List based on several of the same filters used by TPDb API. I intentionally left TPDbPerformer alone because it uses the Whisparr API.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

I took a look at the open issues and didn't find anything that was directly related.