### PR TITLE
New: import list source stashdb favorites

### DIFF
--- a/src/NzbDrone.Common/Cloud/WhisparrCloudRequestBuilder.cs
+++ b/src/NzbDrone.Common/Cloud/WhisparrCloudRequestBuilder.cs
@@ -7,6 +7,7 @@ namespace NzbDrone.Common.Cloud
         IHttpRequestBuilderFactory Services { get; }
         IHttpRequestBuilderFactory TMDB { get; }
         IHttpRequestBuilderFactory WhisparrMetadata { get; }
+        IHttpRequestBuilderFactory StashDB { get; }
     }
 
     public class WhisparrCloudRequestBuilder : IWhisparrCloudRequestBuilder
@@ -22,11 +23,15 @@ namespace NzbDrone.Common.Cloud
 
             WhisparrMetadata = new HttpRequestBuilder("https://api.whisparr.com/v4/{route}")
                 .CreateFactory();
+
+            StashDB = new HttpRequestBuilder("https://stashdb.org/graphql")
+                .CreateFactory();
         }
 
         public IHttpRequestBuilderFactory Services { get; private set; }
         public IHttpRequestBuilderFactory TMDB { get; private set; }
         public IHttpRequestBuilderFactory WhisparrMetadata { get; private set; }
+        public IHttpRequestBuilderFactory StashDB { get; private set; }
 
         public string AuthToken => "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIxYTczNzMzMDE5NjFkMDNmOTdmODUzYTg3NmRkMTIxMiIsInN1YiI6IjU4NjRmNTkyYzNhMzY4MGFiNjAxNzUzNCIsInNjb3BlcyI6WyJhcGlfcmVhZCJdLCJ2ZXJzaW9uIjoxfQ.gh1BwogCCKOda6xj9FRMgAAj_RYKMMPC3oNlcBtlmwk";
     }

--- a/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBSettingsValidatorFixture.cs
+++ b/src/NzbDrone.Core.Test/ImportListTests/StashDB/StashDBSettingsValidatorFixture.cs
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.ImportLists.StashDB;
+using NzbDrone.Core.Test.Framework;
+
+namespace NzbDrone.Core.Test.ImportListTests.StashDB
+{
+    public class StashDBSettingsValidatorFixture : CoreTest
+    {
+        [TestCase("")]
+        [TestCase(null)]
+        public void invalid_api_key_should_not_validate(string apiKey)
+        {
+            var settings = new StashDBSettings
+            {
+                ApiKey = apiKey,
+            };
+
+            settings.Validate().IsValid.Should().BeFalse();
+            settings.Validate().Errors.Should().Contain(c => c.PropertyName == "ApiKey");
+        }
+
+        [TestCase("validApiKey123")]
+        [TestCase("anotherValidApiKey456")]
+        public void valid_api_key_should_validate(string apiKey)
+        {
+            var settings = new StashDBSettings
+            {
+                ApiKey = apiKey,
+            };
+
+            settings.Validate().IsValid.Should().BeTrue();
+            settings.Validate().Errors.Should().NotContain(c => c.PropertyName == "ApiKey");
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/ImportListType.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListType.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.ImportLists
         Plex,
         Simkl,
         Other,
-        Advanced
+        Advanced,
+        StashDB
     }
 }

--- a/src/NzbDrone.Core/ImportLists/StashDB/FavoriteFilter.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/FavoriteFilter.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace NzbDrone.Core.ImportLists.StashDB
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum FavoriteFilter
+    {
+        ALL,
+        PERFORMER,
+        STUDIO
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/StashDB/SceneSort.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/SceneSort.cs
@@ -1,0 +1,44 @@
+using System;
+using Newtonsoft.Json;
+
+namespace NzbDrone.Core.ImportLists.StashDB
+{
+    [JsonConverter(typeof(SceneSortConverter))]
+    public enum SceneSort
+    {
+        RELEASED,
+        CREATED
+    }
+
+    public class SceneSortConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(SceneSort);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            var sort = (SceneSort)value;
+            var sortString = sort switch
+            {
+                SceneSort.RELEASED => "DATE",
+                SceneSort.CREATED => "CREATED_AT",
+                _ => throw new ArgumentOutOfRangeException(nameof(sort), sort, null)
+            };
+
+            writer.WriteValue(sortString);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var sortString = (string)reader.Value;
+            return sortString switch
+            {
+                "DATE" => SceneSort.RELEASED,
+                "CREATED_AT" => SceneSort.CREATED,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBImport.cs
@@ -1,0 +1,52 @@
+using System;
+using NLog;
+using NzbDrone.Common.Cloud;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.MetadataSource;
+using NzbDrone.Core.Parser;
+
+namespace NzbDrone.Core.ImportLists.StashDB
+{
+    public class StashDBImport : HttpImportListBase<StashDBSettings>
+    {
+        public StashDBImport(IWhisparrCloudRequestBuilder requestBuilder,
+                                    IHttpClient httpClient,
+                                    IImportListStatusService importListStatusService,
+                                    IConfigService configService,
+                                    IParsingService parsingService,
+                                    ISearchForNewMovie skyhookProxy,
+                                    Logger logger)
+            : base(httpClient, importListStatusService, configService, parsingService, logger)
+        {
+            _skyhookProxy = skyhookProxy;
+            _requestBuilder = requestBuilder.StashDB;
+        }
+
+        private readonly IHttpRequestBuilderFactory _requestBuilder;
+
+        public readonly ISearchForNewMovie _skyhookProxy;
+        public override int PageSize => 100;
+        public override string Name => "StashDB Favorites";
+        public override bool Enabled => true;
+        public override bool EnableAuto => false;
+        public override ImportListType ListType => ImportListType.StashDB;
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(12);
+
+        public override IParseImportListResponse GetParser()
+        {
+            return new StashDBParser();
+        }
+
+        public override IImportListRequestGenerator GetRequestGenerator()
+        {
+            return new StashDBRequestGenerator(PageSize, MaxNumResultsPerQuery)
+            {
+                RequestBuilder = _requestBuilder,
+                Settings = Settings,
+                Logger = _logger,
+                HttpClient = _httpClient,
+            };
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBParser.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBParser.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.ImportLists.Exceptions;
+using NzbDrone.Core.ImportLists.ImportListMovies;
+
+namespace NzbDrone.Core.ImportLists.StashDB
+{
+    public class StashDBParser : IParseImportListResponse
+    {
+        public virtual IList<ImportListMovie> ParseResponse(ImportListResponse importResponse)
+        {
+            var scenes = new List<ImportListMovie>();
+
+            if (!PreProcess(importResponse))
+            {
+                return scenes;
+            }
+
+            var jsonResponse = JsonConvert.DeserializeObject<QueryScenesResult>(importResponse.Content);
+
+            // empty response
+            if (jsonResponse == null)
+            {
+                return scenes;
+            }
+
+            foreach (var scene in jsonResponse.Data.QueryScenes.Scenes)
+            {
+                scenes.Add(MapListMovie(scene));
+            }
+
+            return scenes;
+        }
+
+        protected ImportListMovie MapListMovie(Scene stashDBScene)
+        {
+            var scene = new ImportListMovie()
+            {
+                StashId = stashDBScene.Id.ToString(),
+                Title = stashDBScene.Title,
+            };
+
+            if (stashDBScene.ReleaseDate.IsNotNullOrWhiteSpace() && DateTime.TryParse(stashDBScene.ReleaseDate, out var releaseDate))
+            {
+                scene.Year = releaseDate.Year;
+            }
+
+            return scene;
+        }
+
+        protected virtual bool PreProcess(ImportListResponse listResponse)
+        {
+            if (listResponse.HttpResponse.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                throw new ImportListException(listResponse,
+                    "StashDB API call resulted in an unexpected StatusCode [{0}]",
+                    listResponse.HttpResponse.StatusCode);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBRequestGenerator.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using NLog;
+using NzbDrone.Common.Http;
+
+namespace NzbDrone.Core.ImportLists.StashDB
+{
+    public class StashDBRequestGenerator : IImportListRequestGenerator
+    {
+        public StashDBRequestGenerator(int pageSize, int maxResultsPerQuery)
+        {
+            _pageSize = pageSize;
+            _maxResultsPerQuery = maxResultsPerQuery;
+        }
+
+        private readonly int _pageSize;
+        private readonly int _maxResultsPerQuery;
+        public StashDBSettings Settings { get; set; }
+        public IHttpClient HttpClient { get; set; }
+        public IHttpRequestBuilderFactory RequestBuilder { get; set; }
+        public Logger Logger { get; set; }
+        public virtual ImportListPageableRequestChain GetMovies()
+        {
+            var pageableRequests = new ImportListPageableRequestChain();
+
+            pageableRequests.Add(GetSceneRequest());
+
+            return pageableRequests;
+        }
+
+        private IEnumerable<ImportListRequest> GetSceneRequest()
+        {
+            Logger.Info($"Importing StashDB scenes from favorites: {Settings.Filter}");
+
+            var querySceneQuery = new QuerySceneQuery(1, _pageSize, Settings.Filter, Settings.Sort);
+
+            var requestBuilder = RequestBuilder
+                                        .Create()
+                                        .SetHeader("ApiKey", Settings.ApiKey)
+                                        .AddQueryParam("query", querySceneQuery.Query)
+                                        .AddQueryParam("variables", querySceneQuery.Variables);
+
+            var jsonResponse = JsonConvert.DeserializeObject<QueryScenesResult>(HttpClient.Execute(requestBuilder.Build()).Content);
+
+            var pagesInResponse = (jsonResponse.Data.QueryScenes.Count / _pageSize) + 1;
+
+            var maxPagesAllowed = _maxResultsPerQuery / _pageSize;
+
+            var pages = Math.Min(pagesInResponse, maxPagesAllowed);
+
+            var requests = new List<ImportListRequest>();
+
+            for (var pageNumber = 1; pageNumber <= pages; pageNumber++)
+            {
+                querySceneQuery.SetPage(pageNumber);
+
+                requestBuilder.AddQueryParam("variables", querySceneQuery.Variables, true);
+
+                var request = requestBuilder.Build();
+
+                Logger.Debug($"Importing StashDB scenes from {request.Url}");
+
+                requests.Add(new ImportListRequest(request));
+            }
+
+            return requests;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBResources.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBResources.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace NzbDrone.Core.ImportLists.StashDB
+{
+    public class QueryScenesResult
+    {
+        [JsonProperty("data")]
+        public QuerySceneData Data { get; set; }
+    }
+
+    public class QuerySceneData
+    {
+        [JsonProperty("queryScenes")]
+        public QueryScene QueryScenes { get; set; }
+    }
+
+    public class QueryScene
+    {
+        [JsonProperty("scenes")]
+        public List<Scene> Scenes { get; set; }
+        [JsonProperty("count")]
+        public int Count { get; set; }
+    }
+
+    public class Scene
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        [JsonProperty("title")]
+        public string Title { get; set; }
+        [JsonProperty("performers")]
+        public List<Performer> Performers { get; set; }
+        [JsonProperty("release_date")]
+        public string ReleaseDate { get; set; }
+    }
+
+    public class Performer
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+
+    public class QuerySceneQuery
+    {
+        private QuerySceneQueryVariables _variables;
+        private string _query;
+        public string Query
+        {
+            get
+            {
+                return _query;
+            }
+        }
+
+        public string Variables
+        {
+            get
+            {
+                return JsonConvert.SerializeObject(_variables);
+            }
+        }
+
+        public QuerySceneQuery(int page, int pageSize, FavoriteFilter filter, SceneSort sort)
+        {
+            _query = @"
+                        query QueryScenes($sort: SceneSortEnum!, $page: Int!, $perPage: Int!, $favorites: FavoriteFilter!) {
+                            queryScenes(
+                                input: { sort: $sort, direction: DESC, favorites: $favorites, per_page: $perPage, page: $page }
+                            ) {
+                                scenes {
+                                    id
+                                    title
+                                    performers {
+                                        performer {
+                                            name
+                                        }
+                                    }
+                                    release_date
+                                }
+                                count
+                            }
+                        }
+                        ";
+            _variables = new QuerySceneQueryVariables(page, pageSize, filter, sort);
+        }
+
+        public void SetPage(int page)
+        {
+            _variables.Page = page;
+        }
+    }
+
+    public class QuerySceneQueryVariables
+    {
+        [JsonProperty("page")]
+        public int Page { get; set; }
+
+        [JsonProperty("perPage")]
+        public int PageSize { get; set; }
+
+        [JsonProperty("favorites")]
+        public FavoriteFilter Filter { get; set; }
+
+        [JsonProperty("sort")]
+        public SceneSort Sort { get; set; }
+
+        public QuerySceneQueryVariables(int page, int pageSize, FavoriteFilter filter, SceneSort sort)
+        {
+            Page = page;
+            PageSize = pageSize;
+            Filter = filter;
+            Sort = sort;
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettings.cs
@@ -1,0 +1,43 @@
+using FluentValidation;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.ImportLists.StashDB
+{
+    public class StashDBSettingsValidator : AbstractValidator<StashDBSettings>
+    {
+        public StashDBSettingsValidator()
+        {
+            RuleFor(c => c.ApiKey)
+                .NotEmpty()
+                .WithMessage("Api Key must not be empty");
+        }
+    }
+
+    public class StashDBSettings : IProviderConfig
+    {
+        private static readonly StashDBSettingsValidator Validator = new StashDBSettingsValidator();
+
+        public StashDBSettings()
+        {
+            Filter = FavoriteFilter.ALL;
+            Sort = SceneSort.RELEASED;
+            ApiKey = "";
+        }
+
+        [FieldDefinition(0, Label = "Api Key", Privacy = PrivacyLevel.ApiKey, HelpText = "Your StashDB Api Key")]
+        public string ApiKey { get; set; }
+
+        [FieldDefinition(1, Label = "Favorite Filter", Type = FieldType.Select, SelectOptions = typeof(FavoriteFilter), HelpText = "Filter by favorited entity")]
+        public FavoriteFilter Filter { get; set; }
+
+        [FieldDefinition(2, Label = "Sort Date Descending", Type =FieldType.Select, SelectOptions =typeof(SceneSort), HelpText = "Descending sort by date style")]
+        public SceneSort Sort { get; set; }
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+    }
+}


### PR DESCRIPTION
#### Database Migration
No

#### Description
A user that has an account on stashdb.org with access to their API Key can add a new type of Import List. This new list titled "StashDB Favorites" can be configured with their API Key to list either their favorite performers, studios, or both. The users are provided the ability to not immediately download everything once the list has been added ([see discussion on issue #134](https://github.com/Whisparr/Whisparr/issues/134)). Additionally, the existing application limits the number of list items immediately available to download at 1000 ([see line 23 in HttpImportListBase.cs](https://github.com/Whisparr/Whisparr/blob/abe98a44b4582158b6a378971e70ab6cd240b4c5/src/NzbDrone.Core/ImportLists/HttpImportListBase.cs#L23)).

#### Screenshot (if UI related)
Import list looks like all the others, no frontend code was changed.

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Close #134 