### PR TITLE
Get Information about a single Scene by stashId

### DIFF
--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -107,7 +107,7 @@ namespace Whisparr.Api.V3.Movies
         }
 
         [HttpGet]
-        public List<MovieResource> AllMovie(int? tmdbId, bool excludeLocalCovers = false)
+        public List<MovieResource> AllMovie(int? tmdbId, string stashId, bool excludeLocalCovers = false)
         {
             var moviesResources = new List<MovieResource>();
 
@@ -116,6 +116,15 @@ namespace Whisparr.Api.V3.Movies
             if (tmdbId.HasValue)
             {
                 var movie = _moviesService.FindByTmdbId(tmdbId.Value);
+
+                if (movie != null)
+                {
+                    moviesResources.AddIfNotNull(MapToResource(movie));
+                }
+            }
+            else if (stashId.IsNotNullOrWhiteSpace())
+            {
+                var movie = _moviesService.FindByForeignId(stashId);
 
                 if (movie != null)
                 {
@@ -137,7 +146,6 @@ namespace Whisparr.Api.V3.Movies
                 }
 
                 var movies = movieTask.GetAwaiter().GetResult();
-
                 moviesResources = new List<MovieResource>(movies.Count);
 
                 foreach (var movie in movies)


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
The update is allow and external tool to find if a single scene is in the Whisparr instance, can be used with http://tampermonkey.net/ scripts to find if a scene is within Whisparr and if it has been downloaded.

Previously you would need to read all of the scenes to then find one scene.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX