### PR TITLE
FIx: Qbittorrent unknown download state issue

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -237,7 +237,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
                 // Avoid removing torrents that haven't reached the global max ratio.
                 // Removal also requires the torrent to be paused, in case a higher max ratio was set on the torrent itself (which is not exposed by the api).
-                item.CanMoveFiles = item.CanBeRemoved = torrent.State == "pausedUP" && HasReachedSeedLimit(torrent, config);
+                item.CanMoveFiles = item.CanBeRemoved = (torrent.State == "pausedUP" || torrent.State == "stoppedUP") && HasReachedSeedLimit(torrent, config);
 
                 switch (torrent.State)
                 {
@@ -246,6 +246,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         item.Message = "qBittorrent is reporting an error";
                         break;
 
+                    case "stoppedDL": // torrent has stopped and has NOT finished downloading
                     case "pausedDL": // torrent is paused and has NOT finished downloading
                         item.Status = DownloadItemStatus.Paused;
                         break;
@@ -258,6 +259,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                         break;
 
                     case "pausedUP": // torrent is paused and has finished downloading:
+                    case "stoppedUP": // torrent has stopped and finished downloading
                     case "uploading": // torrent is being seeded and data is being transferred
                     case "stalledUP": // torrent is being seeded, but no connection were made
                     case "queuedUP": // queuing is enabled and torrent is queued for upload


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Wouldn't build without updating the nuget packages. Then updates the switch that handles the download states from qbittorrent to work with two of the updates torrent states as described in #260.

#### Screenshot (if UI related)
N/A

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #260 