### PR TITLE
fix: #262; click on movie in search bar

### DIFF
--- a/frontend/src/Components/Page/Header/MovieSearchInput.js
+++ b/frontend/src/Components/Page/Header/MovieSearchInput.js
@@ -134,9 +134,11 @@ class MovieSearchInput extends Component {
       return;
     }
 
-    this.setState({
-      value: newValue.replace(/[^a-zA-Z ]/g, '')
-    });
+    if (newValue) {
+      this.setState({
+        value: newValue.replace(/[^a-zA-Z ]/g, '')
+      });
+    }
   };
 
   onKeyDown = (event) => {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Resolves an issue where clicking on a movie from the search bar in the header wouldn't navigate to said movie/scene. The issue was that occasionally the `newValue` variable would be null. The fix simply only changes the state when `newValue` isn't null.

#### Screenshot (if UI related)
![image](https://github.com/user-attachments/assets/a6f7b775-6e7a-4500-a835-90f95b4f1890)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #262 