### PR TITLE
discord notifications embedded links hook to stashdb instead of themoviedb and trakt

### DIFF
--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Core.Notifications.Discord
                     Name = Settings.Author.IsNullOrWhiteSpace() ? Environment.MachineName : Settings.Author,
                     IconUrl = "https://raw.githubusercontent.com/Whisparr/Whisparr/develop/Logo/256.png"
                 },
-                Url = $"https://www.themoviedb.org/movie/{message.Movie.MovieMetadata.Value.ForeignId}",
+                Url = GetUrl(message.Movie.MovieMetadata.Value.ForeignId),
                 Description = "Movie Grabbed",
                 Title = GetTitle(message.Movie),
                 Color = (int)DiscordColors.Standard,
@@ -143,7 +143,7 @@ namespace NzbDrone.Core.Notifications.Discord
                     Name = Settings.Author.IsNullOrWhiteSpace() ? Environment.MachineName : Settings.Author,
                     IconUrl = "https://raw.githubusercontent.com/Whisparr/Whisparr/develop/Logo/256.png"
                 },
-                Url = $"https://www.themoviedb.org/movie/{message.Movie.MovieMetadata.Value.ForeignId}",
+                Url = GetUrl(message.Movie.MovieMetadata.Value.ForeignId),
                 Description = isUpgrade ? "Movie Upgraded" : "Movie Imported",
                 Title = GetTitle(message.Movie),
                 Color = isUpgrade ? (int)DiscordColors.Upgrade : (int)DiscordColors.Success,
@@ -250,7 +250,7 @@ namespace NzbDrone.Core.Notifications.Discord
                     Name = Settings.Author.IsNullOrWhiteSpace() ? Environment.MachineName : Settings.Author,
                     IconUrl = "https://raw.githubusercontent.com/Whisparr/Whisparr/develop/Logo/256.png"
                 },
-                Url = $"https://www.themoviedb.org/movie/{movie.MovieMetadata.Value.ForeignId}",
+                Url = GetUrl(movie.MovieMetadata.Value.ForeignId),
                 Title = movie.Title,
                 Description = "Movie Added",
                 Color = (int)DiscordColors.Success,
@@ -307,7 +307,7 @@ namespace NzbDrone.Core.Notifications.Discord
                     Name = Settings.Author.IsNullOrWhiteSpace() ? Environment.MachineName : Settings.Author,
                     IconUrl = "https://raw.githubusercontent.com/Whisparr/Whisparr/develop/Logo/256.png"
                 },
-                Url = $"https://www.themoviedb.org/movie/{movie.MovieMetadata.Value.ForeignId}",
+                Url = GetUrl(movie.MovieMetadata.Value.ForeignId),
                 Title = movie.Title,
                 Description = deleteMessage.DeletedFilesMessage,
                 Color = (int)DiscordColors.Danger,
@@ -348,7 +348,7 @@ namespace NzbDrone.Core.Notifications.Discord
                     Name = Settings.Author.IsNullOrWhiteSpace() ? Environment.MachineName : Settings.Author,
                     IconUrl = "https://raw.githubusercontent.com/Whisparr/Whisparr/develop/Logo/256.png"
                 },
-                Url = $"https://www.themoviedb.org/movie/{movie.MovieMetadata.Value.ForeignId}",
+                Url = GetUrl(movie.MovieMetadata.Value.ForeignId),
                 Title = GetTitle(movie),
                 Description = "Movie File Deleted",
                 Color = (int)DiscordColors.Danger,
@@ -448,7 +448,7 @@ namespace NzbDrone.Core.Notifications.Discord
                     Name = Settings.Author.IsNullOrWhiteSpace() ? Environment.MachineName : Settings.Author,
                     IconUrl = "https://raw.githubusercontent.com/Whisparr/Whisparr/develop/Logo/256.png"
                 },
-                Url = $"https://www.themoviedb.org/movie/{movie.MovieMetadata.Value.ForeignId}",
+                Url = GetUrl(movie.MovieMetadata.Value.ForeignId),
                 Description = "Manual interaction needed",
                 Title = GetTitle(movie),
                 Color = (int)DiscordColors.Standard,
@@ -596,8 +596,7 @@ namespace NzbDrone.Core.Notifications.Discord
 
         private static string GetLinksString(Movie movie)
         {
-            var links = string.Format("[{0}]({1})", "TMDb", $"https://themoviedb.org/movie/{movie.MovieMetadata.Value.ForeignId}");
-            links += string.Format(" / [{0}]({1})", "Trakt", $"https://trakt.tv/search/tmdb/{movie.MovieMetadata.Value.ForeignId}?id_type=movie");
+            var links = string.Format("[{0}]({1})", "StashDB", GetUrl(movie.MovieMetadata.Value.ForeignId));
             if (movie.MovieMetadata.Value.ImdbId.IsNotNullOrWhiteSpace())
             {
                 links += string.Format(" / [{0}]({1})", "IMDb", $"https://imdb.com/title/{movie.MovieMetadata.Value.ImdbId}/");
@@ -609,6 +608,11 @@ namespace NzbDrone.Core.Notifications.Discord
             }
 
             return links;
+        }
+
+        private static string GetUrl(string foreignId)
+        {
+            return $"https://stashdb.org/scenes/{foreignId}";
         }
 
         private string GetTitle(Movie movie)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The Discord notification were including broken links in their messages. This PR removes links to themoviedb and trakt and replaces them with links to stashdb.

#### Screenshot (if UI related)
![image](https://github.com/user-attachments/assets/a0721460-273b-41d3-894a-9f50bd0d64e8)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Didn't open an issue but I could if needed.