### PR TITLE
eros - retrieve single performer studio

### DIFF
--- a/src/NzbDrone.Core/Movies/Performers/PerformerRepository.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerRepository.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.Movies.Performers
 {
     public interface IPerformerRepository : IBasicRepository<Performer>
     {
+        Performer FindByForeignId(string foreignId);
         List<string> AllPerformerForeignIds();
     }
 
@@ -16,6 +17,11 @@ namespace NzbDrone.Core.Movies.Performers
         public PerformerRepository(IMainDatabase database, IEventAggregator eventAggregator)
             : base(database, eventAggregator)
         {
+        }
+
+        public Performer FindByForeignId(string foreignId)
+        {
+            return Query(x => x.ForeignId == foreignId).FirstOrDefault();
         }
 
         public List<string> AllPerformerForeignIds()

--- a/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerService.cs
@@ -12,6 +12,7 @@ namespace NzbDrone.Core.Movies.Performers
         List<Performer> AddPerformers(List<Performer> performers);
         List<Performer> GetPerformers(IEnumerable<int> performerIds);
         Performer GetById(int id);
+        Performer FindByForeignId(string foreignId);
         List<Performer> GetAllPerformers();
         List<string> AllPerformerForeignIds();
         Performer Update(Performer performer);
@@ -58,6 +59,11 @@ namespace NzbDrone.Core.Movies.Performers
         public Performer GetById(int id)
         {
             return _performerRepo.Get(id);
+        }
+
+        public Performer FindByForeignId(string foreignId)
+        {
+            return _performerRepo.FindByForeignId(foreignId);
         }
 
         public List<Performer> GetPerformers(IEnumerable<int> performerIds)

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Messaging.Events;
@@ -42,9 +43,23 @@ namespace Whisparr.Api.V3.Performers
         }
 
         [HttpGet]
-        public List<PerformerResource> GetPerformers()
+        public List<PerformerResource> GetPerformers(string stashId)
         {
-            var performerResources = _performerService.GetAllPerformers().ToResource();
+            var performerResources = new List<PerformerResource>();
+
+            if (stashId.IsNotNullOrWhiteSpace())
+            {
+                var performer = _performerService.FindByForeignId(stashId);
+
+                if (performer != null)
+                {
+                    performerResources.AddIfNotNull(performer.ToResource());
+                }
+            }
+            else
+            {
+                performerResources = _performerService.GetAllPerformers().ToResource();
+            }
 
             var coverFileInfos = _coverMapper.GetPerformerCoverFileInfos();
 

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Messaging.Events;
@@ -39,9 +40,23 @@ namespace Whisparr.Api.V3.Studios
         }
 
         [HttpGet]
-        public List<StudioResource> GetStudios()
+        public List<StudioResource> GetStudios(string stashId)
         {
-            var studioResources = _studioService.GetAllStudios().ToResource();
+            var studioResources = new List<StudioResource>();
+
+            if (stashId.IsNotNullOrWhiteSpace())
+            {
+                var studio = _studioService.FindByForeignId(stashId);
+
+                if (studio != null)
+                {
+                    studioResources.AddIfNotNull(studio.ToResource());
+                }
+            }
+            else
+            {
+                studioResources = _studioService.GetAllStudios().ToResource();
+            }
 
             var coverFileInfos = _coverMapper.GetStudioCoverFileInfos();
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow the API to return a single performer or studio. This is similar to scene and can allow the client or other integrations to access a single item by the stashID

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX