### PR TITLE
Adjusted search behavior to also return results by Studio+Scene combo…

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -185,7 +185,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             var page = results.GetTier(0).First().First();
 
-            page.Url.Query.Should().Contain("q=Some%20Movie%20and%20Title%20Words%202021");
+            page.Url.Query.Should().Contain("q=Some%20Movie%20and%20Title%20Words");
             page.Url.Query.Should().Contain("and");
             page.Url.Query.Should().NotContain(" & ");
             page.Url.Query.Should().NotContain("%26");

--- a/src/NzbDrone.Core/Indexers/FileList/FileListRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListRequestGenerator.cs
@@ -44,11 +44,9 @@ namespace NzbDrone.Core.Indexers.FileList
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            var releaseDate = searchCriteria.ReleaseDate?.ToString("yy.MM.dd") ?? string.Empty;
-
             foreach (var sceneTitle in searchCriteria.SceneTitles)
             {
-                pageableRequests.Add(GetRequest("search-torrents", string.Format("&type=name&query={0}{1}", Uri.EscapeDataString($"{sceneTitle.Trim()} {releaseDate}"))));
+                pageableRequests.Add(GetRequest("search-torrents", string.Format("&type=name&query={0}", Uri.EscapeDataString($"{sceneTitle.Trim()}"))));
             }
 
             return pageableRequests;

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -106,8 +106,6 @@ namespace NzbDrone.Core.Indexers.Newznab
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            var releaseDate = searchCriteria.ReleaseDate?.ToString("yy.MM.dd") ?? string.Empty;
-
             if (SupportsSearch)
             {
                 var queryTitles = TextSearchEngine == "raw" ? searchCriteria.SceneTitles : searchCriteria.CleanSceneTitles;
@@ -116,7 +114,7 @@ namespace NzbDrone.Core.Indexers.Newznab
                     pageableRequests.Add(GetPagedRequests(MaxPages,
                         Settings.Categories,
                         "search",
-                        $"&q={NewsnabifyTitle(queryTitle)}+{releaseDate}"));
+                        $"&q={NewsnabifyTitle(queryTitle)}"));
                 }
             }
 
@@ -156,8 +154,6 @@ namespace NzbDrone.Core.Indexers.Newznab
                 foreach (var queryTitle in queryTitles)
                 {
                     var searchQuery = queryTitle;
-
-                    searchQuery = $"{searchQuery} {searchCriteria.Movie.Year}";
 
                     chain.Add(GetPagedRequests(MaxPages,
                         Settings.Categories,


### PR DESCRIPTION
#### Database Migration
NO

#### Problem Statement
The goal of this PR is to address the core issues raised in #132. The general use case for this is to improve torrent results by avoiding the common situation where the date is not part of the tracker's title. The goal is to provide more results by not forcing a date query. That said, queries on the Studio name unbounded by date make little sense, requiring a bit of rewiring in how the dates are injected.

#### Description
This is based on #240 as that item may have been abandoned as it just needed a clean up to be merged. Trozmagon may add a item for the date format as the issue was mention on the support channel.

This PR adds a non-date bound "scene name" plus "studio name" combination search. This delivers much better results to the system to pick a good release. It does this by modifying the SearchService to have a bit more sophisticated behavior. To facilitate this, the Trackers no longer inject dates, this is done at the service level. (The trackers seem to be consistent in their implementation.)

The affect of this change is that user will see more results in interactive mode. This does not affect the parsing behaviour yet, so we shouldn't see a flood of mismatches.

There are some parser that look for the dd.MM.yyyy, so that is added as a search, as some indexers will use this format, and do not return results for yy.MM.dd.

There is better coverage for Studio Name, as it will use Full name, the cleaned name, and the name with no spaces.
Studio Example
Casting Couch-X (Original)
CastingCouchX (Clean)
CastingCouch-X (no space)

Example Searches
Studio Name 12.09.22 > Same as before
StudioName 12.09.22 > Same as before
Scene Name 12.09.22 > Same as before
StudioName 22.09.2012 > New
StudioName Scene Name  > New
StudioName Scene Name > New

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #115 