### PR TITLE
Eros - Find Best Match

### DIFF
--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
@@ -23,77 +23,122 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
             var dualCredits = new List<Credit> { new Credit { Character = "Quinn", Performer = new CreditPerformer { Name = "Quinn Waters", Gender = Gender.Female } }, new Credit { Character = "Carrie", Performer = new CreditPerformer { Name = "Carrie Sage", Gender = Gender.Female } } };
             var differentCredits = new List<Credit> { new Credit { Character = "Angie", Performer = new CreditPerformer { Name = "Angela White", Gender = Gender.Female } } };
             var invalidCredits = new List<Credit> { new Credit { Character = "Invalid", Performer = new CreditPerformer { Name = "Invalid Name", Gender = Gender.Female } } };
+            var bellaCredits = new List<Credit> { new Credit { Character = "", Performer = new CreditPerformer { Name = "Violet Myers", Gender = Gender.Female } }, new Credit { Character = "", Performer = new CreditPerformer { Name = "Victor Ray", Gender = Gender.Male } } };
+            var evilCredits = new List<Credit> { new Credit { Character = "", Performer = new CreditPerformer { Name = "Whitney Wright", Gender = Gender.Female } }, new Credit { Character = "", Performer = new CreditPerformer { Name = "Mick Blue", Gender = Gender.Male } } };
+
+            var studio = new Core.MetadataSource.SkyHook.Resource.StudioResource { Title = "Studio" };
+            var evilStudio = new Core.MetadataSource.SkyHook.Resource.StudioResource { Title = "EvilAngel" };
 
             var scenes = Builder<Movie>.CreateListOfSize(2000)
                                         .TheFirst(1)
                                         .With(x => x.Title = "Invalid")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-01-01")
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .With(x => x.MovieMetadata.Value.Credits = invalidCredits)
                                         .TheNext(1)
                                         .With(x => x.Title = "Title Vol 1 E2")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-05-29")
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-04-01")
                                         .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Episode Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2020-04-02")
                                         .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Episode Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-06-11")
                                         .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Milk & Chocolate Before Bed🥛🕟😵‍💫🕦🥛")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-07-30")
                                         .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-08")
                                         .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Other Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-09")
                                         .With(x => x.MovieMetadata.Value.Credits = dualCredits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "White Winter")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-09")
                                         .With(x => x.MovieMetadata.Value.Credits = differentCredits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Another Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-01-08")
                                         .With(x => x.MovieMetadata.Value.Credits = otherCredits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
                                         .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
                                         .With(x => x.MovieMetadata.Value.Credits = dualCredits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Other Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
                                         .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Another Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
                                         .With(x => x.MovieMetadata.Value.Credits = otherCredits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Other Title")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2019-05-18")
                                         .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Episode 200: Violet & Victor")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-08-15")
+                                        .With(x => x.MovieMetadata.Value.Credits = bellaCredits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Cash For Kisses On Valentines Day - S25:E7")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-02-07")
+                                        .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "Whitney Wright POV Anal & A2M")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-02-24")
+                                        .With(x => x.MovieMetadata.Value.Studio = evilStudio)
+                                        .With(x => x.MovieMetadata.Value.Credits = evilCredits)
+                                        .TheNext(1)
+                                        .With(x => x.Title = "BTS Whitney Wright POV Anal & A2M")
+                                        .With(x => x.MovieMetadata.Value.ReleaseDate = "2021-02-24")
+                                        .With(x => x.MovieMetadata.Value.Studio = evilStudio)
+                                        .With(x => x.MovieMetadata.Value.Credits = evilCredits)
                                         .TheRest()
-                                        .With(x => x.Title = "Title")
+                                        .With(x => x.Title = "Title For the Rest")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-06-12")
                                         .With(x => x.MovieMetadata.Value.Credits = credits)
+                                        .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .Build()
                                         .ToList();
 
             Mocker.GetMock<IMovieRepository>()
                 .Setup(s => s.GetByStudioForeignId(It.Is<string>(s => s.Equals("Studio"))))
-                .Returns(scenes);
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.Studio.Title.Equals("Studio")).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.GetByStudioForeignId(It.Is<string>(s => s.Equals("EvilAngel"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.Studio.Title.Equals("EvilAngel")).ToList());
 
             Mocker.GetMock<IMovieRepository>()
                 .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2021-01-08"))))
@@ -123,6 +168,18 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
                 .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Studio")), It.Is<string>(d => d.Equals("2019-05-18"))))
                 .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2019-05-18")).Append(scenes.First()).ToList());
 
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Bellesa House")), It.Is<string>(d => d.Equals("2024-08-15"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2024-08-15")).Append(scenes.First()).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("Step Siblings Caught")), It.Is<string>(d => d.Equals("2024-02-07"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2024-02-07")).Append(scenes.First()).ToList());
+
+            Mocker.GetMock<IMovieRepository>()
+                .Setup(s => s.FindByStudioAndDate(It.Is<string>(s => s.Equals("EvilAngel")), It.Is<string>(d => d.Equals("2021-02-24"))))
+                .Returns(scenes.Where(s => s.MovieMetadata.Value.ReleaseDate.Equals("2021-02-24")).Append(scenes.First()).ToList());
+
             _candidates = Builder<Movie>.CreateListOfSize(3)
                                         .TheFirst(1)
                                         .With(x => x.MovieMetadata.Value.CleanTitle = "batman")
@@ -147,16 +204,25 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
         }
 
         [TestCase("Studio 2020-05-29 Title Vol 1 E2", 2)]
+        [TestCase("Studio 2020-05-29 Title Vol 1 E2_1", 2)]
         [TestCase("[Studio] Quinn Waters (Title / 08.01.2021) [2021 г., Big Tits, Blowjob, Brunette, Chubby, Curvy, Cowgirl, Reverse Cowgirl, Cumshots, Facials, Long Hair, Doggy Style, Hardcore, Missionary, PAWG, POV, Trimmed Pussy, Tattoo, Czech, VR, 8K, 3840p] [Oculus Rift / Vive]", 7)]
         [TestCase("Studio.21.01.08.Title", 7)]
         [TestCase("Studio.21.01.08.Quinn Waters", 7)]
         [TestCase("Studio.21.01.08.Quinn", 7)]
+        [TestCase("Studio.21.01.09.Quinn and Carrie", 8)]
         [TestCase("Studio.21.01.09.Quinn & Carrie", 8)]
         [TestCase("Studio.21.01.09.Quinn & Carrie - Other Title", 8)]
         [TestCase("Studio.21.01.08.Carrie", 10)]
         [TestCase("Studio.21.01.08.Carrie Sage", 10)]
         [TestCase("Studio - 2024-07-30 - Milk & Chocolate Before Bed", 6)]
-        public void should_find_by_studio_and_release_date(string title, int id)
+        [TestCase("Bellesa House 2024-08-15 Episode 200 Violet And Victor", 16)]
+        [TestCase("Bellesa House 2024-08-15 Episode 200 Violet & Victor", 16)]
+        [TestCase("Step Siblings Caught 2024-02-07 Cash For Kisses On Valentines Day - S25E7", 17)]
+        [TestCase("EvilAngel - 2021-02-24 - BTS Whitney Wright POV Anal & A2M", 18)]
+        [TestCase("EvilAngel - 2021-02-24 - Whitney Wright POV Anal & A2M", 19)]
+        [TestCase("EvilAngel.E1224.Whitney Wright POV Anal & A2M", 19)] // Episode (Search all for the studio)
+        [TestCase("EvilAngel - 2021-02-24 - Whitney Wright", null)]  // Possible Duplicate so no match
+        public void should_find_by_studio_and_release_date(string title, int? id)
         {
             var parsedMovieInfo = Parser.Parser.ParseMovieTitle(title);
 
@@ -164,8 +230,16 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
             {
                 var movie = Subject.FindByStudioAndReleaseDate(parsedMovieInfo.StudioTitle, parsedMovieInfo.ReleaseDate, parsedMovieInfo.ReleaseTokens);
 
-                movie.Should().NotBeNull();
-                movie.Id.Should().Be(id);
+                if (id != null)
+                {
+                    movie.Should().NotBeNull();
+                    movie.Id.Should().Be(id);
+                }
+                else
+                {
+                    // Should not match as duplicate
+                    movie.Should().BeNull();
+                }
             }
         }
     }

--- a/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
@@ -39,6 +39,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Studio.22.10.18.Title.XXX.720p.HEVC.x265.PRT[XvX]", "Studio")]
         [TestCase("Studio - 2017-08-04 - Some Title. [WEBDL-480p]", "Studio")]
         [TestCase("Studio - Performer Name - Some Title (10.01.2024)", "Studio")]
+        [TestCase("Step Siblings Caught 2024-02-07 Cash For Kisses On Valentines Day - S25E7", "Step Siblings Caught")]
         public void should_correctly_parse_studio_names(string title, string result)
         {
             Parser.Parser.ParseMovieTitle(title).StudioTitle.Should().Be(result);
@@ -56,6 +57,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Studio.22.10.18.Title.XXX.720p.HEVC.x265.PRT[XvX]", "2022-10-18")]
         [TestCase("Studio - 2017-08-04 - Some Title. [WEBDL-480p]", "2017-08-04")]
         [TestCase("Studio - Performer Name - Some Title (10.01.2024)", "2024-01-10")]
+        [TestCase("Step Siblings Caught 2024-02-07 Cash For Kisses On Valentines Day - S25E7", "2024-02-07")]
         public void should_correctly_parse_release_date(string title, string result)
         {
             Parser.Parser.ParseMovieTitle(title).ReleaseDate.Should().Be(result);
@@ -65,7 +67,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("LoveHerBoobs 24 06 11 Peachy Alice Successful Provocation XXX 720p AV1 XLeech.mkv", "peachy alice successful provocation")]
         [TestCase("Studio.E1224.Title.XXX.720p.HEVC.x265.PRT[XvX]", "title")]
         [TestCase("[Studio] Performer Name (Title / 08.01.2021) [2021 г., Big Tits, Blowjob, Brunette, Chubby, Curvy, Cowgirl, Reverse Cowgirl, Cumshots, Facials, Long Hair, Doggy Style, Hardcore, Missionary, PAWG, POV, Trimmed Pussy, Tattoo, Czech, VR, 8K, 3840p] [Oculus Rift / Vive]", "performer name title")]
-        [TestCase("[Studio.com] Performer & Performer - Studio Title (18.05.2019) [2019 г., Anal, IR, Rim Job, Ass To Mouth, Big Cocks, Black, Blowjobs, Brunettes, Deep Throat, Facial, Gaping, Natural, Teen, 1080p]", "performer performer studio title")]
+        [TestCase("[Studio.com] Performer & Performer - Studio Title (18.05.2019) [2019 г., Anal, IR, Rim Job, Ass To Mouth, Big Cocks, Black, Blowjobs, Brunettes, Deep Throat, Facial, Gaping, Natural, Teen, 1080p]", "performer and performer studio title")]
         [TestCase("[random.com][Studio] Performer name - Title(01.04.2020) rq.mp4", "performer name title")]
         [TestCase("Reflective Desire - 2022-12-01 - Chuck Faerie Vespa - Pussyfootin' - WEBDL-2160p h264", "chuck faerie vespa pussyfootin")]
         [TestCase("MollyRedWolf - 2022-04-14 - MollyRedWolf - Komi-San.I want you - WEBDL-720p x265", "mollyredwolf komi san i want you")]

--- a/src/NzbDrone.Core/Movies/MovieParseMatchType.cs
+++ b/src/NzbDrone.Core/Movies/MovieParseMatchType.cs
@@ -1,0 +1,15 @@
+namespace NzbDrone.Core.Movies
+{
+    public enum MovieParseMatchType
+    {
+        Title = 1,
+        PerformersTitle = 2,
+        CharactersTitle = 3,
+        Performers = 4,
+        Characters = 5,
+        PerformerTitle = 6,
+        CharacterTitle = 7,
+        PerformersNotTitle = 8,
+        CharactersNotTitle = 9,
+    }
+}

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -378,13 +378,40 @@ namespace NzbDrone.Core.Movies
 
         public Movie FindByStudioAndReleaseDate(string studioForeignId, string releaseDate, string releaseTokens)
         {
-            var movies = _movieRepository.FindByStudioAndDate(studioForeignId, releaseDate);
+            if (string.IsNullOrEmpty(studioForeignId))
+            {
+                studioForeignId = string.Empty;
+            }
 
-            if (!movies.Any())
+            if (string.IsNullOrEmpty(releaseDate))
+            {
+                releaseDate = string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(releaseTokens))
+            {
+                releaseTokens = string.Empty;
+            }
+
+            var movies = new List<Movie>();
+
+            if (releaseDate.IsNotNullOrWhiteSpace())
+            {
+                movies = _movieRepository.FindByStudioAndDate(studioForeignId, releaseDate);
+            }
+            else
+            {
+                movies = _movieRepository.GetByStudioForeignId(studioForeignId);
+            }
+
+            if (movies == null || !movies.Any())
             {
                 return null;
             }
 
+            // This should be removed to stop any false positives.
+            // Whispar may only have a single scene for the studio date but more actually exist
+            // Example Monitor a performer but not the studio
             if (movies.Count == 1)
             {
                 return movies.First();
@@ -394,110 +421,154 @@ namespace NzbDrone.Core.Movies
 
             if (parsedMovieTitle.IsNotNullOrWhiteSpace())
             {
-                var matches = new List<Movie>();
-
-                foreach (var movie in movies)
-                {
-                    var cleanTitle = movie.Title.IsNotNullOrWhiteSpace() ? Parser.Parser.NormalizeEpisodeTitle(movie.Title) : string.Empty;
-
-                    // If parsed title matches title, consider a match
-                    if (cleanTitle.IsNotNullOrWhiteSpace() && parsedMovieTitle.Equals(cleanTitle))
-                    {
-                        matches.Add(movie);
-                        continue;
-                    }
-
-                    var cleanPerformers = movie.MovieMetadata.Value.Credits.Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Performer.Name))
-                                                                           .Where(x => x.IsNotNullOrWhiteSpace());
-
-                    if (cleanPerformers.Empty())
-                    {
-                        continue;
-                    }
-
-                    // If parsed title matches performer, consider a match
-                    if (cleanPerformers.Any(p => p.IsNotNullOrWhiteSpace() && parsedMovieTitle.Equals(p)))
-                    {
-                        matches.Add(movie);
-                        continue;
-                    }
-
-                    var cleanCharacters = movie.MovieMetadata.Value.Credits.Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
-                                                                            .Where(x => x.IsNotNullOrWhiteSpace());
-
-                    // If parsed title matches character, consider a match
-                    if (cleanCharacters.Any() && cleanCharacters.Any(c => c.IsNotNullOrWhiteSpace() && parsedMovieTitle.Equals(c)))
-                    {
-                        matches.Add(movie);
-                        continue;
-                    }
-
-                    var cleanFemalePerformers = movie.MovieMetadata.Value.Credits.Where(a => a.Performer.Gender == Gender.Female)
-                                                                                 .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Performer.Name))
-                                                                                 .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
-
-                    // If all female performers are in title, consider a match
-                    if (cleanFemalePerformers.Any() && cleanFemalePerformers.All(x => parsedMovieTitle.Contains(x)))
-                    {
-                        matches.Add(movie);
-                        continue;
-                    }
-
-                    var cleanFemaleCharacters = movie.MovieMetadata.Value.Credits.Where(a => a.Performer.Gender == Gender.Female)
-                                                                                 .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
-                                                                                 .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
-
-                    // If all female characters are in title, consider a match
-                    if (cleanFemaleCharacters.Any() && cleanFemalePerformers.All(x => parsedMovieTitle.Contains(x)))
-                    {
-                        matches.Add(movie);
-                        continue;
-                    }
-
-                    if (cleanTitle.IsNullOrWhiteSpace())
-                    {
-                        continue;
-                    }
-
-                    // If parsed title contains a performer and the title then consider a match
-                    if (cleanPerformers.Any(x => parsedMovieTitle.Contains(x)) && parsedMovieTitle.Contains(cleanTitle))
-                    {
-                        matches.Add(movie);
-                        continue;
-                    }
-
-                    // If parsed title contains a character and the title then consider a match
-                    if (cleanCharacters.Any() && cleanCharacters.Any(x => parsedMovieTitle.Contains(x)) && parsedMovieTitle.Contains(cleanTitle))
-                    {
-                        matches.Add(movie);
-                        continue;
-                    }
-
-                    // If parsed title contains all performer and the not title then consider a match
-                    if (cleanPerformers.All(x => parsedMovieTitle.Contains(x)) && !parsedMovieTitle.Contains(cleanTitle))
-                    {
-                        matches.Add(movie);
-                        continue;
-                    }
-
-                    // If parsed title contains all character and the not title then consider a match
-                    if (cleanCharacters.Any() && cleanCharacters.All(x => parsedMovieTitle.Contains(x)) && !parsedMovieTitle.Contains(cleanTitle))
-                    {
-                        matches.Add(movie);
-                        continue;
-                    }
-                }
+                var matches = MatchMovies(parsedMovieTitle, releaseDate, movies);
 
                 if (matches.Count == 1)
                 {
-                    return matches.First();
+                    return matches.First().Key;
                 }
 
-                movies = matches;
+                movies = matches.Keys.ToList();
             }
 
             _logger.Debug("Multiple scenes with the same release date found. Date: {0}", releaseDate);
             return null;
+        }
+
+        private Dictionary<Movie, MovieParseMatchType> MatchMovies(string parsedMovieTitle, string releaseDate, List<Movie> movies)
+        {
+            var matches = new Dictionary<Movie, MovieParseMatchType>();
+
+            _logger.Debug("Checking {0} against {1} movies", parsedMovieTitle, movies.Count);
+
+            foreach (var movie in movies)
+            {
+                var cleanTitle = movie.Title.IsNotNullOrWhiteSpace() ? Parser.Parser.NormalizeEpisodeTitle(movie.Title) : string.Empty;
+
+                // If parsed title matches title, consider a match
+                if (cleanTitle.IsNotNullOrWhiteSpace() && parsedMovieTitle.Equals(cleanTitle))
+                {
+                    _logger.Debug("Match {0} against {1} [Title]", parsedMovieTitle, cleanTitle);
+                    matches.Add(movie, MovieParseMatchType.Title);
+                    continue;
+                }
+
+                if (cleanTitle.IsNotNullOrWhiteSpace() && Parser.Parser.StripSpaces(parsedMovieTitle).Equals(Parser.Parser.StripSpaces(cleanTitle)))
+                {
+                    _logger.Debug("Match {0} against {1} [Title]", parsedMovieTitle, cleanTitle);
+                    matches.Add(movie, MovieParseMatchType.Title);
+                    continue;
+                }
+
+                var cleanPerformers = movie.MovieMetadata.Value.Credits.Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Performer.Name))
+                                                                       .Where(x => x.IsNotNullOrWhiteSpace());
+
+                if (cleanPerformers.Empty())
+                {
+                    continue;
+                }
+
+                // If parsed title matches performer, consider a match
+                if (cleanPerformers.Any(p => p.IsNotNullOrWhiteSpace() && parsedMovieTitle.Equals(p)))
+                {
+                    _logger.Debug("Match {0} against {1} [Performers]", parsedMovieTitle, cleanPerformers.Join(", "));
+                    matches.Add(movie, MovieParseMatchType.PerformersTitle);
+                    continue;
+                }
+
+                var cleanCharacters = movie.MovieMetadata.Value.Credits.Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
+                                                                        .Where(x => x.IsNotNullOrWhiteSpace());
+
+                // If parsed title matches character, consider a match
+                if (cleanCharacters.Any() && cleanCharacters.Any(c => c.IsNotNullOrWhiteSpace() && parsedMovieTitle.Equals(c)))
+                {
+                    _logger.Debug("Match {0} against {1} [Characters]", parsedMovieTitle, cleanCharacters.Join(", "));
+                    matches.Add(movie, MovieParseMatchType.CharactersTitle);
+                    continue;
+                }
+
+                var cleanFemalePerformers = movie.MovieMetadata.Value.Credits.Where(a => a.Performer.Gender == Gender.Female)
+                                                                             .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Performer.Name))
+                                                                             .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
+
+                // If all female performers are in title, consider a match
+                if (cleanFemalePerformers.Any() && cleanFemalePerformers.All(x => parsedMovieTitle.Contains(x)))
+                {
+                    _logger.Debug("Match {0} against {1} [Female Performers]", parsedMovieTitle, cleanFemalePerformers.Join(", "));
+                    matches.Add(movie, MovieParseMatchType.Performers);
+                    continue;
+                }
+
+                var cleanFemaleCharacters = movie.MovieMetadata.Value.Credits.Where(a => a.Performer.Gender == Gender.Female)
+                                                                             .Select(a => Parser.Parser.NormalizeEpisodeTitle(a.Character))
+                                                                             .Where(x => x.IsNotNullOrWhiteSpace()).ToList();
+
+                // If all female characters are in title, consider a match
+                if (cleanFemaleCharacters.Any() && cleanFemalePerformers.All(x => parsedMovieTitle.Contains(x)))
+                {
+                    _logger.Debug("Match {0} against {1} [Female Characters]", parsedMovieTitle, cleanFemaleCharacters.Join(", "));
+                    matches.Add(movie, MovieParseMatchType.Characters);
+                    continue;
+                }
+
+                if (cleanTitle.IsNullOrWhiteSpace())
+                {
+                    continue;
+                }
+
+                // If parsed title contains a performer and the title then consider a match
+                if (cleanPerformers.Any(x => parsedMovieTitle.Contains(x)) && parsedMovieTitle.Contains(cleanTitle))
+                {
+                    _logger.Debug("Match {0} against {1} {2} [Title & Performer]", parsedMovieTitle, cleanTitle, cleanPerformers.Join(", "));
+                    matches.Add(movie, MovieParseMatchType.PerformerTitle);
+                    continue;
+                }
+
+                // If parsed title contains a character and the title then consider a match
+                if (cleanCharacters.Any() && cleanCharacters.Any(x => parsedMovieTitle.Contains(x)) && parsedMovieTitle.Contains(cleanTitle))
+                {
+                    _logger.Debug("Match {0} against {1} {2} [Title & Character]", parsedMovieTitle, cleanTitle, cleanCharacters.Join(", "));
+                    matches.Add(movie, MovieParseMatchType.CharacterTitle);
+                    continue;
+                }
+
+                // If parsed title contains all performer and the not title then consider a match
+                if (cleanPerformers.All(x => parsedMovieTitle.Contains(x)) && !parsedMovieTitle.Contains(cleanTitle))
+                {
+                    _logger.Debug("Match {0} against {1} {2} [Performers & NOT Title]", parsedMovieTitle, cleanTitle, cleanPerformers.Join(", "));
+                    matches.Add(movie, MovieParseMatchType.PerformersNotTitle);
+                    continue;
+                }
+
+                // If parsed title contains all character and the not title then consider a match
+                if (cleanCharacters.Any() && cleanCharacters.All(x => parsedMovieTitle.Contains(x)) && !parsedMovieTitle.Contains(cleanTitle))
+                {
+                    _logger.Debug("Match {0} against {1} {2} [Characters & NOT Title]", parsedMovieTitle, cleanTitle, cleanCharacters.Join(", "));
+                    matches.Add(movie, MovieParseMatchType.CharactersNotTitle);
+                    continue;
+                }
+            }
+
+            // Find the best match
+            if (matches.Count > 1)
+            {
+                foreach (var movieMatchType in (MovieParseMatchType[])Enum.GetValues(typeof(MovieParseMatchType)))
+                {
+                    var filteredMatches = matches.Where(m => m.Value > movieMatchType).ToDictionary(x => x.Key, x => x.Value);
+                    if (releaseDate.IsNotNullOrWhiteSpace() && (int)movieMatchType < 2)
+                    {
+                        filteredMatches = new Dictionary<Movie, MovieParseMatchType>();
+                    }
+
+                    if (filteredMatches.Count == 1)
+                    {
+                        matches = filteredMatches;
+                        break;
+                    }
+                }
+            }
+
+            return matches;
         }
 
         private Movie ReturnSingleMovieOrThrow(List<Movie> movies)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -200,12 +200,16 @@ namespace NzbDrone.Core.Parser
         // name only...BE VERY CAREFUL WITH THIS, HIGH CHANCE OF FALSE POSITIVES
         private static readonly Regex ExceptionReleaseGroupRegexExact = new Regex(@"(?<releasegroup>KRaLiMaRKo|E\.N\.D|D\-Z0N3|Koten_Gars|BluDragon|ZØNEHD|Tigole|HQMUX|VARYG|YIFY|YTS(.(MX|LT|AG))?)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex WordDelimiterRegex = new Regex(@"(\s|\.|,|_|-|=|'|\|)+", RegexOptions.Compiled);
+        private static readonly Regex WordDelimiterRegex = new Regex(@"(\s|\.|,|_|-|=|’|'|\|)+", RegexOptions.Compiled);
         private static readonly Regex SpecialCharRegex = new Regex(@"(\&|\:|\\|\/)+", RegexOptions.Compiled);
         private static readonly Regex PunctuationRegex = new Regex(@"[^\w\s]", RegexOptions.Compiled);
         private static readonly Regex CommonWordRegex = new Regex(@"\b(a|an|the|and|or|of)\b\s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex SpecialEpisodeWordRegex = new Regex(@"\b(part|special|edition|christmas)\b\s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex DuplicateSpacesRegex = new Regex(@"\s{2,}", RegexOptions.Compiled);
+        private static readonly Regex NamerDuplicateRegex = new Regex(@"_\d$", RegexOptions.Compiled);
+
+        private static readonly Regex EmojiRegex = new Regex(@"\p{Cs}", RegexOptions.Compiled);
+        private static readonly Regex UniCodeRegex = new Regex(@"[^\u0000-\u007F]+", RegexOptions.Compiled);
 
         private static readonly Regex RequestInfoRegex = new Regex(@"^(?:\[.+?\])+", RegexOptions.Compiled);
 
@@ -590,8 +594,14 @@ namespace NzbDrone.Core.Parser
                 return string.Empty;
             }
 
+            // Standard & as and
+            title = title.Replace(" & ", " and ");
+
             title = SpecialEpisodeWordRegex.Replace(title, string.Empty);
             title = PunctuationRegex.Replace(title, " ");
+            title = EmojiRegex.Replace(title, " ");
+            title = UniCodeRegex.Replace(title, " ");
+            title = NamerDuplicateRegex.Replace(title, " ");
             title = DuplicateSpacesRegex.Replace(title, " ");
 
             return title.Trim()
@@ -622,6 +632,16 @@ namespace NzbDrone.Core.Parser
             }
 
             return SimpleReleaseTitleRegex.Replace(title, string.Empty);
+        }
+
+        public static string StripSpaces(this string title)
+        {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
+            return title.Replace(" ", string.Empty);
         }
 
         public static string TrimAtEnd(this string title, string textToTrim)


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Normalise the ReleaseTokens value so that it can match more often, & to and, remove any space substitutions from special characters.
Search all of the studios in case a duplicate match exists across studios potential.
Rank the matches and use the best match if there is multiple, MovieParseMatchType order.


If a single item is return for a studio on a date it is still excepted, but this should be removed, either for all or via a setting within the client. Left it as this can upset some people if items are not auto accepted like before. I will let someone else make that call or code the option to turn it off in the client.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX