### PR TITLE
New: Audit Items Synced

### DIFF
--- a/src/NzbDrone.Core/Movies/Performers/AddPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/AddPerformerService.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Movies.Performers
                         throw;
                     }
 
-                    _logger.Debug("TmdbId {0} was not added due to validation failures. {1}", m.ForeignId, ex.Message);
+                    _logger.Error("{0} was not added due to validation failures. {1}", m.ForeignId, ex.Message);
                 }
             }
 

--- a/src/NzbDrone.Core/Movies/Studios/AddStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/AddStudioService.cs
@@ -91,7 +91,7 @@ namespace NzbDrone.Core.Movies.Studios
                         throw;
                     }
 
-                    _logger.Debug("StashId {0} was not added due to validation failures. {1}", m.ForeignId, ex.Message);
+                    _logger.Error("StashId {0} was not added due to validation failures. {1}", m.ForeignId, ex.Message);
                 }
             }
 

--- a/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
@@ -102,6 +102,7 @@ namespace NzbDrone.Core.Movies.Studios
                 var studioScenes = _movieInfo.GetStudioScenes(studio.ForeignId);
                 var excludedScenes = _importExclusionService.GetAllExclusions().Select(e => e.ForeignId);
                 var scenesToAdd = studioScenes.Where(m => !existingMovies.Contains(m)).Where(m => !excludedScenes.Contains(m));
+                var scenesAdded = 0;
 
                 if (scenesToAdd.Any())
                 {
@@ -121,8 +122,10 @@ namespace NzbDrone.Core.Movies.Studios
 
                     foreach (var sceneList in sceneLists)
                     {
-                        _addMovieService.AddMovies(sceneList.ToList(), true);
+                        scenesAdded += _addMovieService.AddMovies(sceneList.ToList(), true).Count;
                     }
+
+                    _logger.Info("Synced studio {0} has {1} movies adding {2} and added {3}", studio.Title, studioScenes.Count, scenesToAdd.Count(), scenesAdded);
                 }
             }
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Additional Audit to show what items are going to be added for a performer or studio.

Capture additional error when adding a movie.

Fix message so that it is correct for a scene or movie

This is for so that the client has additional auditing #187, but the item would need to be corrected in skyhook as Whisparr will only sync the data that is avaliable.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes 