### PR TITLE
resolve an issue where adding a studio via the api wouldn't work

### DIFF
--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -19,14 +19,17 @@ namespace Whisparr.Api.V3.Studios
     public class StudioController : RestControllerWithSignalR<StudioResource, Studio>, IHandle<StudioUpdatedEvent>
     {
         private readonly IStudioService _studioService;
+        private readonly IAddStudioService _addStudioService;
         private readonly IMapCoversToLocal _coverMapper;
 
         public StudioController(IStudioService studioService,
+                                IAddStudioService addStudioService,
                                 IMapCoversToLocal coverMapper,
                                 IBroadcastSignalRMessage signalRBroadcaster)
         : base(signalRBroadcaster)
         {
             _studioService = studioService;
+            _addStudioService = addStudioService;
             _coverMapper = coverMapper;
         }
 
@@ -68,7 +71,7 @@ namespace Whisparr.Api.V3.Studios
         [RestPostById]
         public ActionResult<StudioResource> AddStudio(StudioResource studioResource)
         {
-            var studio = _studioService.AddStudio(studioResource.ToModel());
+            var studio = _addStudioService.AddStudio(studioResource.ToModel());
 
             return Created(studio.Id);
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Updates the StudioController API endpoint for adding a new Studio to match that of the PerformerController API endpoint by calling the IAddStudioService instead of the IStudioService. This change matches the implementation for the Performer which will facilitate the further integration of new features into [Stasharr](https://github.com/enymawse/stasharr).

#### Screenshot (if UI related)
Not related
#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Could raise a new one but figured I'd just send the fix instead.