### PR TITLE
Fixed: Parse Movies and Scenes separately

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1190,7 +1190,7 @@ stages:
           ./build.sh --backend -f net6.0 -r win-x64
           TEST_DIR=_tests/net6.0/win-x64/publish/ ./test.sh Windows Unit Coverage
         displayName: Coverage Unit Tests
-      - task: reportgenerator@5
+      - task: reportgenerator@5.3.11
         displayName: Generate Coverage Report
         inputs:
           reports: '$(Build.SourcesDirectory)/CoverageResults/**/coverage.opencover.xml'

--- a/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
@@ -60,7 +60,14 @@ namespace NzbDrone.Core.Parser.Model
 
         public override string ToString()
         {
-            return string.Format("{0} - {1} {2}", PrimaryMovieTitle, Year, Quality);
+            var result = string.Format("{0} - {1} {2}", PrimaryMovieTitle, Year, Quality);
+
+            if (IsScene)
+            {
+                result = string.Format("{0} - {1} - {2} [{3}]", StudioTitle, ReleaseDate, ReleaseTokens, Quality);
+            }
+
+            return result;
         }
     }
 }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -161,7 +161,7 @@ namespace NzbDrone.Core.Parser
         {
             FindMovieResult result = null;
 
-            if (parsedMovieInfo.IsScene)
+            if (parsedMovieInfo.IsScene || searchCriteria?.Movie.MovieMetadata?.Value.ItemType == ItemType.Scene)
             {
                 var studios = _studioService.FindAllByTitle(parsedMovieInfo.StudioTitle);
 
@@ -169,7 +169,7 @@ namespace NzbDrone.Core.Parser
                 {
                     foreach (var studio in studios)
                     {
-                        if (result == null)
+                        if (result == null && studio != null)
                         {
                             result = GetSceneMovie(studio, parsedMovieInfo.ReleaseDate, parsedMovieInfo.ReleaseTokens, searchCriteria);
                         }
@@ -178,7 +178,7 @@ namespace NzbDrone.Core.Parser
 
                 if (result?.Movie == null)
                 {
-                    _logger.Debug($"No matching scene '{searchCriteria}' for studio {parsedMovieInfo.StudioTitle} and release date '{parsedMovieInfo.ReleaseDate}' '{parsedMovieInfo.ReleaseTokens}'");
+                    _logger.Debug($"No matching scene '{searchCriteria}' for '{parsedMovieInfo}'");
                 }
             }
             else
@@ -230,7 +230,7 @@ namespace NzbDrone.Core.Parser
             if (parsedMovieInfo.Year > 1800)
             {
                 movieByTitleAndOrYear = _movieService.FindByTitle(parsedMovieInfo.MovieTitles, parsedMovieInfo.Year, otherTitles, candidates);
-                if (movieByTitleAndOrYear != null)
+                if (movieByTitleAndOrYear != null && movieByTitleAndOrYear.MovieMetadata?.Value.ItemType == ItemType.Movie)
                 {
                     return new FindMovieResult(movieByTitleAndOrYear, MovieMatchType.Title);
                 }
@@ -239,7 +239,7 @@ namespace NzbDrone.Core.Parser
             }
 
             movieByTitleAndOrYear = _movieService.FindByTitle(parsedMovieInfo.MovieTitles, null, otherTitles, candidates);
-            if (movieByTitleAndOrYear != null)
+            if (movieByTitleAndOrYear != null && movieByTitleAndOrYear.MovieMetadata?.Value.ItemType == ItemType.Movie)
             {
                 return new FindMovieResult(movieByTitleAndOrYear, MovieMatchType.Title);
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
There is some existing logic within Whisparr V3 to match movies, and this can cause false positives if there is also a movie with the same name that exists. An indexer may name the movie with just the title and then this can cause an issue.

The Logic of movies and scenes will be separated, so that the movie logic can only return a movie.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #296 