### PR TITLE
Eros stashdb exclude list items and limit results

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1190,7 +1190,7 @@ stages:
           ./build.sh --backend -f net6.0 -r win-x64
           TEST_DIR=_tests/net6.0/win-x64/publish/ ./test.sh Windows Unit Coverage
         displayName: Coverage Unit Tests
-      - task: reportgenerator@5
+      - task: reportgenerator@5.3.11
         displayName: Generate Coverage Report
         inputs:
           reports: '$(Build.SourcesDirectory)/CoverageResults/**/coverage.opencover.xml'

--- a/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteImport.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Favorite
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new StashDBFavoriteRequestGenerator(PageSize, MaxNumResultsPerQuery)
+            return new StashDBFavoriteRequestGenerator(PageSize, Settings.Limit)
             {
                 RequestBuilder = _requestBuilder,
                 Settings = Settings,

--- a/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Favorite
     {
         protected override AbstractValidator<StashDBFavoriteSettings> Validator => new StashDBFavoriteSettingsValidator();
 
-        [FieldDefinition(1, Label = "Favorite Filter", Type = FieldType.Select, SelectOptions = typeof(FavoriteFilter), HelpText = "Filter by favorited entity")]
+        [FieldDefinition(3, Label = "Favorite Filter", Type = FieldType.Select, SelectOptions = typeof(FavoriteFilter), HelpText = "Filter by favorited entity")]
         public FavoriteFilter Filter { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/StashDB/FilterModifier.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/FilterModifier.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace NzbDrone.Core.ImportLists.StashDB
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum FilterModifier
+    {
+        INCLUDES,
+        EXCLUDES
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/StashDB/FilterType.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/FilterType.cs
@@ -6,13 +6,13 @@ namespace NzbDrone.Core.ImportLists.StashDB
     public class FilterType
     {
         [JsonProperty("modifier")]
-        public string Modifier { get; set; }
+        public FilterModifier Modifier { get; set; }
         [JsonProperty("value")]
         public List<string> Value { get; set; }
 
-        public FilterType(List<string> value)
+        public FilterType(FilterModifier filterModifier, List<string> value)
         {
-            Modifier = "INCLUDES";
+            Modifier = filterModifier;
             Value = value;
         }
     }

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerImport.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new StashDBPerformerRequestGenerator(PageSize, MaxNumResultsPerQuery)
+            return new StashDBPerformerRequestGenerator(PageSize, Settings.Limit)
             {
                 RequestBuilder = _requestBuilder,
                 Settings = Settings,

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerRequestGenerator.cs
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
 
             Logger.Info($"Importing StashDB scenes for performers: {parameterLog}");
 
-            var querySceneQuery = new QueryPerformerSceneQuery(1, _pageSize, performers, studios, tags, Settings.OnlyFavoriteStudios, Settings.Sort);
+            var querySceneQuery = new QueryPerformerSceneQuery(1, _pageSize, performers, studios, Settings.StudiosFilter, tags, Settings.TagsFilter, Settings.OnlyFavoriteStudios, Settings.Sort);
 
             var requestBuilder = RequestBuilder
                                         .Create()

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerResources.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerResources.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
         private QueryPerformerSceneQueryVariables _variables;
         private string _query;
 
-        public QueryPerformerSceneQuery(int page, int pageSize, List<string> performers, List<string> studios, List<string> tags, bool onlyFavoriteStudios, SceneSort sort)
+        public QueryPerformerSceneQuery(int page, int pageSize, List<string> performers, List<string> studios, FilterModifier studiosFilter, List<string> tags, FilterModifier tagsFilter, bool onlyFavoriteStudios, SceneSort sort)
         {
             _query = @"query Scenes($input: SceneQueryInput!) {
                          queryScenes(input: $input) {
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
                            count
                          }
                         }";
-            _variables = new QueryPerformerSceneQueryVariables(page, pageSize, performers, studios, tags, onlyFavoriteStudios, sort);
+            _variables = new QueryPerformerSceneQueryVariables(page, pageSize, performers, studios, studiosFilter, tags, tagsFilter, onlyFavoriteStudios, sort);
         }
 
         public string Query
@@ -47,18 +47,18 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
 
     public class QueryPerformerSceneQueryVariables : QuerySceneQueryVariablesBase
     {
-        public QueryPerformerSceneQueryVariables(int page, int pageSize, List<string> performers, List<string> studios, List<string> tags, bool onlyFavoriteStudios, SceneSort sort)
+        public QueryPerformerSceneQueryVariables(int page, int pageSize, List<string> performers, List<string> studios, FilterModifier studiosFilter, List<string> tags, FilterModifier tagsFilter, bool onlyFavoriteStudios, SceneSort sort)
             : base(page, pageSize, sort)
         {
-            Input.performers = new FilterType(performers);
+            Input.performers = new FilterType(FilterModifier.INCLUDES, performers);
             if (studios.Count > 0)
             {
-                Input.studios = new FilterType(studios);
+                Input.studios = new FilterType(studiosFilter, studios);
             }
 
             if (tags.Count > 0)
             {
-                Input.tags = new FilterType(tags);
+                Input.tags = new FilterType(tagsFilter, tags);
             }
 
             if (onlyFavoriteStudios)

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerSettings.cs
@@ -22,16 +22,22 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
     {
         protected override AbstractValidator<StashDBPerformerSettings> Validator => new StashDBPerformerSettingsValidator();
 
-        [FieldDefinition(0, Label = "Performers stashIDs",  HelpText = "Enter Performers StashIDs, Comma Seperated")]
+        [FieldDefinition(3, Label = "Performers StashIDs",  HelpText = "Enter Performers StashIDs, comma seperated")]
         public string Performers { get; set; }
 
-        [FieldDefinition(0, Label = "Studios stashIDs", HelpText = "Enter studios StashIDs, Comma Seperated (Optional)")]
+        [FieldDefinition(4, Label = "Studios StashIDs", HelpText = "Enter studios StashIDs, comma seperated (Optional)")]
         public string Studios { get; set; }
 
-        [FieldDefinition(0, Label = "Tag stashIds", HelpText = "Enter studios StashIDs, Comma Seperated  (Optional)")]
+        [FieldDefinition(5, Label = "Studios Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter studios by")]
+        public FilterModifier StudiosFilter { get; set; }
+
+        [FieldDefinition(6, Label = "Tag StashIDs", HelpText = "Enter tag StashIDs, comma seperated  (Optional)")]
         public string Tags { get; set; }
 
-        [FieldDefinition(0, Label = "Only favorite studios", Type = FieldType.Checkbox,  HelpText = "Filter by favorite studios")]
+        [FieldDefinition(7, Label = "Tags Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter tags by")]
+        public FilterModifier TagsFilter { get; set; }
+
+        [FieldDefinition(8, Label = "Only Favorite Studios", Type = FieldType.Checkbox,  HelpText = "Filter by favorite studios")]
         public bool OnlyFavoriteStudios { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.ImportLists.StashDB
         [FieldDefinition(0, Label = "Api Key", Privacy = PrivacyLevel.ApiKey, HelpText = "Your StashDB Api Key")]
         public string ApiKey { get; set; }
 
-        [FieldDefinition(5, Label = "Limit", HelpText = "Limit the number of movies to get")]
+        [FieldDefinition(1, Label = "Limit", HelpText = "Limit the number of movies to get")]
         public int Limit { get; set; }
 
         [FieldDefinition(2, Label = "Sort Date Descending", Type = FieldType.Select, SelectOptions = typeof(SceneSort), HelpText = "Descending sort by date style")]

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
@@ -13,6 +13,11 @@ namespace NzbDrone.Core.ImportLists.StashDB
             RuleFor(c => c.ApiKey)
                 .NotEmpty()
                 .WithMessage("Api Key must not be empty");
+
+            // Limit not smaller than 1 and not larger than 100
+            RuleFor(c => c.Limit)
+                .GreaterThan(0)
+                .WithMessage("Must be integer greater than 0");
         }
     }
 
@@ -23,12 +28,16 @@ namespace NzbDrone.Core.ImportLists.StashDB
 
         public StashDBSettingsBase()
         {
+            Limit = 100;
             Sort = SceneSort.CREATED;
             ApiKey = "";
         }
 
         [FieldDefinition(0, Label = "Api Key", Privacy = PrivacyLevel.ApiKey, HelpText = "Your StashDB Api Key")]
         public string ApiKey { get; set; }
+
+        [FieldDefinition(5, Label = "Limit", HelpText = "Limit the number of movies to get")]
+        public int Limit { get; set; }
 
         [FieldDefinition(2, Label = "Sort Date Descending", Type = FieldType.Select, SelectOptions = typeof(SceneSort), HelpText = "Descending sort by date style")]
         public SceneSort Sort { get; set; }

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioImport.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new StashDBStudioRequestGenerator(PageSize, MaxNumResultsPerQuery)
+            return new StashDBStudioRequestGenerator(PageSize, Settings.Limit)
             {
                 RequestBuilder = _requestBuilder,
                 Settings = Settings,

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioRequestGenerator.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
             Logger.Info($"Importing StashDB scenes for performers: {parameterLog}");
 
-            var querySceneQuery = new QueryStudioSceneQuery(1, _pageSize, studios, tags, Settings.OnlyFavoritePerformers, Settings.Sort);
+            var querySceneQuery = new QueryStudioSceneQuery(1, _pageSize, studios, tags, Settings.TagsFilter, Settings.OnlyFavoritePerformers, Settings.Sort);
 
             var requestBuilder = RequestBuilder
                                         .Create()

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioResources.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioResources.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
         private QueryStudioSceneQueryVariables _variables;
         private string _query;
 
-        public QueryStudioSceneQuery(int page, int pageSize, List<string> studios, List<string> tags, bool onlyFavoriteStudios, SceneSort sort)
+        public QueryStudioSceneQuery(int page, int pageSize, List<string> studios, List<string> tags, FilterModifier tagsFilter, bool onlyFavoriteStudios, SceneSort sort)
         {
             _query = @"query Scenes($input: SceneQueryInput!) {
                          queryScenes(input: $input) {
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
                            count
                          }
                         }";
-            _variables = new QueryStudioSceneQueryVariables(page, pageSize, studios, tags, onlyFavoriteStudios, sort);
+            _variables = new QueryStudioSceneQueryVariables(page, pageSize, studios, tags, tagsFilter, onlyFavoriteStudios, sort);
         }
 
         public string Query
@@ -47,14 +47,14 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
     public class QueryStudioSceneQueryVariables : QuerySceneQueryVariablesBase
     {
-        public QueryStudioSceneQueryVariables(int page, int pageSize, List<string> studios, List<string> tags, bool onlyFavoritePerformers, SceneSort sort)
+        public QueryStudioSceneQueryVariables(int page, int pageSize, List<string> studios, List<string> tags, FilterModifier tagsFilter, bool onlyFavoritePerformers, SceneSort sort)
             : base(page, pageSize, sort)
         {
-            Input.studios = new FilterType(studios);
+            Input.studios = new FilterType(FilterModifier.INCLUDES, studios);
 
             if (tags.Count > 0)
             {
-                Input.tags = new FilterType(tags);
+                Input.tags = new FilterType(tagsFilter, tags);
             }
 
             if (onlyFavoritePerformers)

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioSettings.cs
@@ -22,13 +22,19 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
     {
         protected override AbstractValidator<StashDBStudioSettings> Validator => new StashDBPerformerSettingsValidator();
 
-        [FieldDefinition(0, Label = "Studios stashIDs", HelpText = "Enter studios StashIDs, Comma Seperated")]
+        [FieldDefinition(3, Label = "Studios StashIDs", HelpText = "Enter Studios StashIDs, comma seperated")]
         public string Studios { get; set; }
 
-        [FieldDefinition(0, Label = "Tag stashIds", HelpText = "Enter studios StashIDs, Comma Seperated  (Optional)")]
+        [FieldDefinition(4, Label = "Performers Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter performers by")]
+        public FilterModifier PerformersFilter { get; set; }
+
+        [FieldDefinition(5, Label = "Tag StashIDs", HelpText = "Enter Tags StashIDs, comma seperated (Optional)")]
         public string Tags { get; set; }
 
-        [FieldDefinition(0, Label = "Only favorite performers", Type = FieldType.Checkbox,  HelpText = "Filter by favorite performers")]
+        [FieldDefinition(6, Label = "Tags Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter tags by")]
+        public FilterModifier TagsFilter { get; set; }
+
+        [FieldDefinition(7, Label = "Only Favorite Performers", Type = FieldType.Checkbox,  HelpText = "Filter by favorite performers")]
         public bool OnlyFavoritePerformers { get; set; }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Default limit is set to a page 100, instead of 1000.
The optional stashIDs items can not be an exclude list. (performer, studio, tags)

#### Screenshot (if UI related)
![image](https://github.com/user-attachments/assets/1be14e83-ef42-4485-9c98-28cc43924bfb)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #294 