### PR TITLE
Fixed: Remove year from movie search string

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1190,7 +1190,7 @@ stages:
           ./build.sh --backend -f net6.0 -r win-x64
           TEST_DIR=_tests/net6.0/win-x64/publish/ ./test.sh Windows Unit Coverage
         displayName: Coverage Unit Tests
-      - task: reportgenerator@5
+      - task: reportgenerator@5.3.11
         displayName: Generate Coverage Report
         inputs:
           reports: '$(Build.SourcesDirectory)/CoverageResults/**/coverage.opencover.xml'

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -190,5 +190,47 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
             page.Url.Query.Should().NotContain(" & ");
             page.Url.Query.Should().NotContain("%26");
         }
+
+        [Test]
+        public void test_scene_raw()
+        {
+            _capabilities.SupportedMovieSearchParameters = new[] { "q" };
+            _capabilities.TextSearchEngine = "raw";
+
+            var sceneSearchCriteria = new SceneSearchCriteria
+            {
+                Movie = new Movies.Movie { Title = "Some Movie & Title: Words", ForeignId = "123", },
+                SceneTitles = new List<string> { "Studio 24.01.01" },
+                ReleaseDate = new System.DateOnly(2024, 01, 01)
+            };
+
+            var results = Subject.GetSearchRequests(sceneSearchCriteria);
+
+            var page = results.GetTier(0).First().First();
+
+            page.Url.Query.Should().Contain("q=Studio");
+            page.Url.Query.Should().Contain("24.01.01");
+        }
+
+        [Test]
+        public void test_scene()
+        {
+            _capabilities.SupportedMovieSearchParameters = new[] { "q" };
+            _capabilities.TextSearchEngine = "sphinx";
+
+            var sceneSearchCriteria = new SceneSearchCriteria
+            {
+                Movie = new Movies.Movie { Title = "Some Movie & Title: Words", ForeignId = "123", },
+                SceneTitles = new List<string> { "Studio 24.01.01" },
+                ReleaseDate = new System.DateOnly(2024, 01, 01)
+            };
+
+            var results = Subject.GetSearchRequests(sceneSearchCriteria);
+
+            var page = results.GetTier(0).First().First();
+
+            page.Url.Query.Should().Contain("q=Studio");
+            page.Url.Query.Should().Contain("24.01.01");
+        }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -62,8 +62,11 @@ namespace NzbDrone.Core.IndexerSearch
             {
                 var movieSearchSpec = Get<MovieSearchCriteria>(movie, userInvokedSearch, interactiveSearch);
 
-                // For movies, the year only is appended
-                movieSearchSpec.SceneTitles = movieSearchSpec.SceneTitles.Select(title => $"{title} {movie.Year}").ToList();
+                // For movies, add search with year
+                if (movie.Year > 1900)
+                {
+                    movieSearchSpec.SceneTitles.AddRange(movieSearchSpec.SceneTitles.Select(title => $"{title} {movie.Year}").ToList());
+                }
 
                 decisions = await Dispatch(indexer => indexer.Fetch(movieSearchSpec), movieSearchSpec);
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Currently a lot of movies/scenes are not found by the indexer(s) due to the fact that the year is passed to the search string.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #255 