### PR TITLE
New: Delete Performer/Studio and associated scenes and view scenes for a Performer/Studio API

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1190,7 +1190,7 @@ stages:
           ./build.sh --backend -f net6.0 -r win-x64
           TEST_DIR=_tests/net6.0/win-x64/publish/ ./test.sh Windows Unit Coverage
         displayName: Coverage Unit Tests
-      - task: reportgenerator@5
+      - task: reportgenerator@5.3.11
         displayName: Generate Coverage Report
         inputs:
           reports: '$(Build.SourcesDirectory)/CoverageResults/**/coverage.opencover.xml'

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using DryIoc.ImTools;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using NLog;
@@ -203,6 +204,18 @@ namespace Whisparr.Api.V3.Movies
             LinkMovieStatistics(moviesResources, sdict);
 
             return moviesResources;
+        }
+
+        [HttpGet("listByPerformerForeignId")]
+        public List<int> ListByPerformerForeignId(string performerForeignId)
+        {
+            return _moviesService.GetByPerformerForeignId(performerForeignId).Map(x => x.Id).ToList();
+        }
+
+        [HttpGet("listByStudioForeignId")]
+        public List<int> ListByStudioForeignId(string studioForeignId)
+        {
+            return _moviesService.GetByStudioForeignId(studioForeignId).Map(x => x.Id).ToList();
         }
 
         protected MovieResource MapToResource(Movie movie)

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DryIoc.ImTools;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Movies.Performers.Events;
 using NzbDrone.SignalR;
@@ -21,16 +23,19 @@ namespace Whisparr.Api.V3.Performers
         private readonly IPerformerService _performerService;
         private readonly IAddPerformerService _addPerformerService;
         private readonly IMapCoversToLocal _coverMapper;
+        private readonly IMovieService _moviesService;
 
         public PerformerController(IPerformerService performerService,
                                    IAddPerformerService addPerformerService,
                                    IMapCoversToLocal coverMapper,
+                                   IMovieService moviesService,
                                    IBroadcastSignalRMessage signalRBroadcaster)
         : base(signalRBroadcaster)
         {
             _performerService = performerService;
             _addPerformerService = addPerformerService;
             _coverMapper = coverMapper;
+            _moviesService = moviesService;
         }
 
         protected override PerformerResource GetResourceById(int id)
@@ -86,6 +91,25 @@ namespace Whisparr.Api.V3.Performers
             BroadcastResourceChange(ModelAction.Updated, updatedPerformer.ToResource());
 
             return Accepted(updatedPerformer);
+        }
+
+        [RestDeleteById]
+        public void DeletePerformer(int id, bool deleteFiles = false, bool addImportExclusion = false)
+        {
+            var performer = _performerService.GetById(id);
+
+            if (performer == null)
+            {
+                return;
+            }
+
+            // Get the scenes for the performer
+            var scenes = _moviesService.GetByPerformerForeignId(performer.ForeignId);
+            var sceneIds = scenes.Map(x => x.Id).ToList();
+            _moviesService.DeleteMovies(sceneIds, deleteFiles, addImportExclusion);
+
+            // Remove the performer now that the associated scenes have been removed
+            _performerService.RemovePerformer(performer);
         }
 
         public void Handle(PerformerUpdatedEvent message)

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DryIoc.ImTools;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Movies.Studios.Events;
 using NzbDrone.SignalR;
@@ -20,14 +22,17 @@ namespace Whisparr.Api.V3.Studios
     {
         private readonly IStudioService _studioService;
         private readonly IMapCoversToLocal _coverMapper;
+        private readonly IMovieService _moviesService;
 
         public StudioController(IStudioService studioService,
                                 IMapCoversToLocal coverMapper,
+                                IMovieService moviesService,
                                 IBroadcastSignalRMessage signalRBroadcaster)
         : base(signalRBroadcaster)
         {
             _studioService = studioService;
             _coverMapper = coverMapper;
+            _moviesService = moviesService;
         }
 
         protected override StudioResource GetResourceById(int id)
@@ -83,6 +88,25 @@ namespace Whisparr.Api.V3.Studios
             BroadcastResourceChange(ModelAction.Updated, updatedStudio.ToResource());
 
             return Accepted(updatedStudio);
+        }
+
+        [RestDeleteById]
+        public void DeleteStudio(int id, bool deleteFiles = false, bool addImportExclusion = false)
+        {
+            var studio = _studioService.GetById(id);
+
+            if (studio == null)
+            {
+                return;
+            }
+
+            // Get the scenes for the studio
+            var scenes = _moviesService.GetByStudioForeignId(studio.ForeignId);
+            var sceneIds = scenes.Map(x => x.Id).ToList();
+            _moviesService.DeleteMovies(sceneIds, deleteFiles, addImportExclusion);
+
+            // Remove the studio now that the associated scenes have been removed
+            _studioService.RemoveStudio(studio);
         }
 
         public void Handle(StudioUpdatedEvent message)


### PR DESCRIPTION
#### Database Migration
NO

#### Description

Allow Whisparr to delete a Performer or Studio and the associated scenes via the API. The client can be updated, or used externally.

Note: moviesService.GetByPerformerForeignId is a high cost query as it is a searching within a field. It would be faster is there was an additional table with sceneStashID and performerStashID, as the fields could have an index to return the values faster with less compute.

Add an API to list scenes for a performer or studio.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX