### PR TITLE
Fixed: Studio scene table should wrap very long  scene titles

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1190,7 +1190,7 @@ stages:
           ./build.sh --backend -f net6.0 -r win-x64
           TEST_DIR=_tests/net6.0/win-x64/publish/ ./test.sh Windows Unit Coverage
         displayName: Coverage Unit Tests
-      - task: reportgenerator@5
+      - task: reportgenerator@5.3.11
         displayName: Generate Coverage Report
         inputs:
           reports: '$(Build.SourcesDirectory)/CoverageResults/**/coverage.opencover.xml'

--- a/frontend/src/Performer/Details/SceneRow.css
+++ b/frontend/src/Performer/Details/SceneRow.css
@@ -1,7 +1,7 @@
 .title {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
-  white-space: nowrap;
+  white-space: wrap;
 }
 
 .monitored {
@@ -13,7 +13,7 @@
 .performers {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
-  width: 400px;
+  white-space: wrap;
 }
 
 .runtime {

--- a/frontend/src/Studio/Details/SceneRow.css
+++ b/frontend/src/Studio/Details/SceneRow.css
@@ -1,7 +1,7 @@
 .title {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
-  white-space: nowrap;
+  white-space: wrap;
 }
 
 .monitored {
@@ -13,7 +13,7 @@
 .performers {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
-  width: 400px;
+  white-space: wrap;
 }
 
 .runtime {

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -190,5 +190,47 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
             page.Url.Query.Should().NotContain(" & ");
             page.Url.Query.Should().NotContain("%26");
         }
+
+        [Test]
+        public void test_scene_raw()
+        {
+            _capabilities.SupportedMovieSearchParameters = new[] { "q" };
+            _capabilities.TextSearchEngine = "raw";
+
+            var sceneSearchCriteria = new SceneSearchCriteria
+            {
+                Movie = new Movies.Movie { Title = "Some Movie & Title: Words", ForeignId = "123", },
+                SceneTitles = new List<string> { "Studio 24.01.01" },
+                ReleaseDate = new System.DateOnly(2024, 01, 01)
+            };
+
+            var results = Subject.GetSearchRequests(sceneSearchCriteria);
+
+            var page = results.GetTier(0).First().First();
+
+            page.Url.Query.Should().Contain("q=Studio");
+            page.Url.Query.Should().Contain("24.01.01");
+        }
+
+        [Test]
+        public void test_scene()
+        {
+            _capabilities.SupportedMovieSearchParameters = new[] { "q" };
+            _capabilities.TextSearchEngine = "sphinx";
+
+            var sceneSearchCriteria = new SceneSearchCriteria
+            {
+                Movie = new Movies.Movie { Title = "Some Movie & Title: Words", ForeignId = "123", },
+                SceneTitles = new List<string> { "Studio 24.01.01" },
+                ReleaseDate = new System.DateOnly(2024, 01, 01)
+            };
+
+            var results = Subject.GetSearchRequests(sceneSearchCriteria);
+
+            var page = results.GetTier(0).First().First();
+
+            page.Url.Query.Should().Contain("q=Studio");
+            page.Url.Query.Should().Contain("24.01.01");
+        }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteImport.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Favorite
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new StashDBFavoriteRequestGenerator(PageSize, MaxNumResultsPerQuery)
+            return new StashDBFavoriteRequestGenerator(PageSize, Settings.Limit)
             {
                 RequestBuilder = _requestBuilder,
                 Settings = Settings,

--- a/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Favorite/StashDBFavoriteSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Favorite
     {
         protected override AbstractValidator<StashDBFavoriteSettings> Validator => new StashDBFavoriteSettingsValidator();
 
-        [FieldDefinition(1, Label = "Favorite Filter", Type = FieldType.Select, SelectOptions = typeof(FavoriteFilter), HelpText = "Filter by favorited entity")]
+        [FieldDefinition(3, Label = "Favorite Filter", Type = FieldType.Select, SelectOptions = typeof(FavoriteFilter), HelpText = "Filter by favorited entity")]
         public FavoriteFilter Filter { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/StashDB/FilterModifier.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/FilterModifier.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace NzbDrone.Core.ImportLists.StashDB
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum FilterModifier
+    {
+        INCLUDES,
+        EXCLUDES
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/StashDB/FilterType.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/FilterType.cs
@@ -6,13 +6,13 @@ namespace NzbDrone.Core.ImportLists.StashDB
     public class FilterType
     {
         [JsonProperty("modifier")]
-        public string Modifier { get; set; }
+        public FilterModifier Modifier { get; set; }
         [JsonProperty("value")]
         public List<string> Value { get; set; }
 
-        public FilterType(List<string> value)
+        public FilterType(FilterModifier filterModifier, List<string> value)
         {
-            Modifier = "INCLUDES";
+            Modifier = filterModifier;
             Value = value;
         }
     }

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerImport.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new StashDBPerformerRequestGenerator(PageSize, MaxNumResultsPerQuery)
+            return new StashDBPerformerRequestGenerator(PageSize, Settings.Limit)
             {
                 RequestBuilder = _requestBuilder,
                 Settings = Settings,

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerRequestGenerator.cs
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
 
             Logger.Info($"Importing StashDB scenes for performers: {parameterLog}");
 
-            var querySceneQuery = new QueryPerformerSceneQuery(1, _pageSize, performers, studios, tags, Settings.OnlyFavoriteStudios, Settings.Sort);
+            var querySceneQuery = new QueryPerformerSceneQuery(1, _pageSize, performers, studios, Settings.StudiosFilter, tags, Settings.TagsFilter, Settings.OnlyFavoriteStudios, Settings.Sort);
 
             var requestBuilder = RequestBuilder
                                         .Create()

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerResources.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerResources.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
         private QueryPerformerSceneQueryVariables _variables;
         private string _query;
 
-        public QueryPerformerSceneQuery(int page, int pageSize, List<string> performers, List<string> studios, List<string> tags, bool onlyFavoriteStudios, SceneSort sort)
+        public QueryPerformerSceneQuery(int page, int pageSize, List<string> performers, List<string> studios, FilterModifier studiosFilter, List<string> tags, FilterModifier tagsFilter, bool onlyFavoriteStudios, SceneSort sort)
         {
             _query = @"query Scenes($input: SceneQueryInput!) {
                          queryScenes(input: $input) {
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
                            count
                          }
                         }";
-            _variables = new QueryPerformerSceneQueryVariables(page, pageSize, performers, studios, tags, onlyFavoriteStudios, sort);
+            _variables = new QueryPerformerSceneQueryVariables(page, pageSize, performers, studios, studiosFilter, tags, tagsFilter, onlyFavoriteStudios, sort);
         }
 
         public string Query
@@ -47,18 +47,18 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
 
     public class QueryPerformerSceneQueryVariables : QuerySceneQueryVariablesBase
     {
-        public QueryPerformerSceneQueryVariables(int page, int pageSize, List<string> performers, List<string> studios, List<string> tags, bool onlyFavoriteStudios, SceneSort sort)
+        public QueryPerformerSceneQueryVariables(int page, int pageSize, List<string> performers, List<string> studios, FilterModifier studiosFilter, List<string> tags, FilterModifier tagsFilter, bool onlyFavoriteStudios, SceneSort sort)
             : base(page, pageSize, sort)
         {
-            Input.performers = new FilterType(performers);
+            Input.performers = new FilterType(FilterModifier.INCLUDES, performers);
             if (studios.Count > 0)
             {
-                Input.studios = new FilterType(studios);
+                Input.studios = new FilterType(studiosFilter, studios);
             }
 
             if (tags.Count > 0)
             {
-                Input.tags = new FilterType(tags);
+                Input.tags = new FilterType(tagsFilter, tags);
             }
 
             if (onlyFavoriteStudios)

--- a/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Performer/StashDBPerformerSettings.cs
@@ -22,16 +22,22 @@ namespace NzbDrone.Core.ImportLists.StashDB.Performer
     {
         protected override AbstractValidator<StashDBPerformerSettings> Validator => new StashDBPerformerSettingsValidator();
 
-        [FieldDefinition(0, Label = "Performers stashIDs",  HelpText = "Enter Performers StashIDs, Comma Seperated")]
+        [FieldDefinition(3, Label = "Performers StashIDs",  HelpText = "Enter Performers StashIDs, comma seperated")]
         public string Performers { get; set; }
 
-        [FieldDefinition(0, Label = "Studios stashIDs", HelpText = "Enter studios StashIDs, Comma Seperated (Optional)")]
+        [FieldDefinition(4, Label = "Studios StashIDs", HelpText = "Enter studios StashIDs, comma seperated (Optional)")]
         public string Studios { get; set; }
 
-        [FieldDefinition(0, Label = "Tag stashIds", HelpText = "Enter studios StashIDs, Comma Seperated  (Optional)")]
+        [FieldDefinition(5, Label = "Studios Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter studios by")]
+        public FilterModifier StudiosFilter { get; set; }
+
+        [FieldDefinition(6, Label = "Tag StashIDs", HelpText = "Enter tag StashIDs, comma seperated  (Optional)")]
         public string Tags { get; set; }
 
-        [FieldDefinition(0, Label = "Only favorite studios", Type = FieldType.Checkbox,  HelpText = "Filter by favorite studios")]
+        [FieldDefinition(7, Label = "Tags Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter tags by")]
+        public FilterModifier TagsFilter { get; set; }
+
+        [FieldDefinition(8, Label = "Only Favorite Studios", Type = FieldType.Checkbox,  HelpText = "Filter by favorite studios")]
         public bool OnlyFavoriteStudios { get; set; }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/StashDBSettingsBase.cs
@@ -13,6 +13,11 @@ namespace NzbDrone.Core.ImportLists.StashDB
             RuleFor(c => c.ApiKey)
                 .NotEmpty()
                 .WithMessage("Api Key must not be empty");
+
+            // Limit not smaller than 1 and not larger than 100
+            RuleFor(c => c.Limit)
+                .GreaterThan(0)
+                .WithMessage("Must be integer greater than 0");
         }
     }
 
@@ -23,12 +28,16 @@ namespace NzbDrone.Core.ImportLists.StashDB
 
         public StashDBSettingsBase()
         {
+            Limit = 100;
             Sort = SceneSort.CREATED;
             ApiKey = "";
         }
 
         [FieldDefinition(0, Label = "Api Key", Privacy = PrivacyLevel.ApiKey, HelpText = "Your StashDB Api Key")]
         public string ApiKey { get; set; }
+
+        [FieldDefinition(1, Label = "Limit", HelpText = "Limit the number of movies to get")]
+        public int Limit { get; set; }
 
         [FieldDefinition(2, Label = "Sort Date Descending", Type = FieldType.Select, SelectOptions = typeof(SceneSort), HelpText = "Descending sort by date style")]
         public SceneSort Sort { get; set; }

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioImport.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioImport.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new StashDBStudioRequestGenerator(PageSize, MaxNumResultsPerQuery)
+            return new StashDBStudioRequestGenerator(PageSize, Settings.Limit)
             {
                 RequestBuilder = _requestBuilder,
                 Settings = Settings,

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioRequestGenerator.cs
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
             Logger.Info($"Importing StashDB scenes for performers: {parameterLog}");
 
-            var querySceneQuery = new QueryStudioSceneQuery(1, _pageSize, studios, tags, Settings.OnlyFavoritePerformers, Settings.Sort);
+            var querySceneQuery = new QueryStudioSceneQuery(1, _pageSize, studios, tags, Settings.TagsFilter, Settings.OnlyFavoritePerformers, Settings.Sort);
 
             var requestBuilder = RequestBuilder
                                         .Create()

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioResources.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioResources.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
         private QueryStudioSceneQueryVariables _variables;
         private string _query;
 
-        public QueryStudioSceneQuery(int page, int pageSize, List<string> studios, List<string> tags, bool onlyFavoriteStudios, SceneSort sort)
+        public QueryStudioSceneQuery(int page, int pageSize, List<string> studios, List<string> tags, FilterModifier tagsFilter, bool onlyFavoriteStudios, SceneSort sort)
         {
             _query = @"query Scenes($input: SceneQueryInput!) {
                          queryScenes(input: $input) {
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
                            count
                          }
                         }";
-            _variables = new QueryStudioSceneQueryVariables(page, pageSize, studios, tags, onlyFavoriteStudios, sort);
+            _variables = new QueryStudioSceneQueryVariables(page, pageSize, studios, tags, tagsFilter, onlyFavoriteStudios, sort);
         }
 
         public string Query
@@ -47,14 +47,14 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
 
     public class QueryStudioSceneQueryVariables : QuerySceneQueryVariablesBase
     {
-        public QueryStudioSceneQueryVariables(int page, int pageSize, List<string> studios, List<string> tags, bool onlyFavoritePerformers, SceneSort sort)
+        public QueryStudioSceneQueryVariables(int page, int pageSize, List<string> studios, List<string> tags, FilterModifier tagsFilter, bool onlyFavoritePerformers, SceneSort sort)
             : base(page, pageSize, sort)
         {
-            Input.studios = new FilterType(studios);
+            Input.studios = new FilterType(FilterModifier.INCLUDES, studios);
 
             if (tags.Count > 0)
             {
-                Input.tags = new FilterType(tags);
+                Input.tags = new FilterType(tagsFilter, tags);
             }
 
             if (onlyFavoritePerformers)

--- a/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/StashDB/Studio/StashDBStudioSettings.cs
@@ -22,13 +22,19 @@ namespace NzbDrone.Core.ImportLists.StashDB.Studio
     {
         protected override AbstractValidator<StashDBStudioSettings> Validator => new StashDBPerformerSettingsValidator();
 
-        [FieldDefinition(0, Label = "Studios stashIDs", HelpText = "Enter studios StashIDs, Comma Seperated")]
+        [FieldDefinition(3, Label = "Studios StashIDs", HelpText = "Enter Studios StashIDs, comma seperated")]
         public string Studios { get; set; }
 
-        [FieldDefinition(0, Label = "Tag stashIds", HelpText = "Enter studios StashIDs, Comma Seperated  (Optional)")]
+        [FieldDefinition(4, Label = "Performers Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter performers by")]
+        public FilterModifier PerformersFilter { get; set; }
+
+        [FieldDefinition(5, Label = "Tag StashIDs", HelpText = "Enter Tags StashIDs, comma seperated (Optional)")]
         public string Tags { get; set; }
 
-        [FieldDefinition(0, Label = "Only favorite performers", Type = FieldType.Checkbox,  HelpText = "Filter by favorite performers")]
+        [FieldDefinition(6, Label = "Tags Filter", Type = FieldType.Select, SelectOptions = typeof(FilterModifier), HelpText = "Filter tags by")]
+        public FilterModifier TagsFilter { get; set; }
+
+        [FieldDefinition(7, Label = "Only Favorite Performers", Type = FieldType.Checkbox,  HelpText = "Filter by favorite performers")]
         public bool OnlyFavoritePerformers { get; set; }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -62,8 +62,11 @@ namespace NzbDrone.Core.IndexerSearch
             {
                 var movieSearchSpec = Get<MovieSearchCriteria>(movie, userInvokedSearch, interactiveSearch);
 
-                // For movies, the year only is appended
-                movieSearchSpec.SceneTitles = movieSearchSpec.SceneTitles.Select(title => $"{title} {movie.Year}").ToList();
+                // For movies, add search with year
+                if (movie.Year > 1900)
+                {
+                    movieSearchSpec.SceneTitles.AddRange(movieSearchSpec.SceneTitles.Select(title => $"{title} {movie.Year}").ToList());
+                }
 
                 decisions = await Dispatch(indexer => indexer.Fetch(movieSearchSpec), movieSearchSpec);
             }

--- a/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
@@ -60,7 +60,14 @@ namespace NzbDrone.Core.Parser.Model
 
         public override string ToString()
         {
-            return string.Format("{0} - {1} {2}", PrimaryMovieTitle, Year, Quality);
+            var result = string.Format("{0} - {1} {2}", PrimaryMovieTitle, Year, Quality);
+
+            if (IsScene)
+            {
+                result = string.Format("{0} - {1} - {2} [{3}]", StudioTitle, ReleaseDate, ReleaseTokens, Quality);
+            }
+
+            return result;
         }
     }
 }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -161,7 +161,7 @@ namespace NzbDrone.Core.Parser
         {
             FindMovieResult result = null;
 
-            if (parsedMovieInfo.IsScene)
+            if (parsedMovieInfo.IsScene || searchCriteria?.Movie.MovieMetadata?.Value.ItemType == ItemType.Scene)
             {
                 var studios = _studioService.FindAllByTitle(parsedMovieInfo.StudioTitle);
 
@@ -169,7 +169,7 @@ namespace NzbDrone.Core.Parser
                 {
                     foreach (var studio in studios)
                     {
-                        if (result == null)
+                        if (result == null && studio != null)
                         {
                             result = GetSceneMovie(studio, parsedMovieInfo.ReleaseDate, parsedMovieInfo.ReleaseTokens, searchCriteria);
                         }
@@ -178,7 +178,7 @@ namespace NzbDrone.Core.Parser
 
                 if (result?.Movie == null)
                 {
-                    _logger.Debug($"No matching scene '{searchCriteria}' for studio {parsedMovieInfo.StudioTitle} and release date '{parsedMovieInfo.ReleaseDate}' '{parsedMovieInfo.ReleaseTokens}'");
+                    _logger.Debug($"No matching scene '{searchCriteria}' for '{parsedMovieInfo}'");
                 }
             }
             else
@@ -230,7 +230,7 @@ namespace NzbDrone.Core.Parser
             if (parsedMovieInfo.Year > 1800)
             {
                 movieByTitleAndOrYear = _movieService.FindByTitle(parsedMovieInfo.MovieTitles, parsedMovieInfo.Year, otherTitles, candidates);
-                if (movieByTitleAndOrYear != null)
+                if (movieByTitleAndOrYear != null && movieByTitleAndOrYear.MovieMetadata?.Value.ItemType == ItemType.Movie)
                 {
                     return new FindMovieResult(movieByTitleAndOrYear, MovieMatchType.Title);
                 }
@@ -239,7 +239,7 @@ namespace NzbDrone.Core.Parser
             }
 
             movieByTitleAndOrYear = _movieService.FindByTitle(parsedMovieInfo.MovieTitles, null, otherTitles, candidates);
-            if (movieByTitleAndOrYear != null)
+            if (movieByTitleAndOrYear != null && movieByTitleAndOrYear.MovieMetadata?.Value.ItemType == ItemType.Movie)
             {
                 return new FindMovieResult(movieByTitleAndOrYear, MovieMatchType.Title);
             }

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using DryIoc.ImTools;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using NLog;
@@ -203,6 +204,18 @@ namespace Whisparr.Api.V3.Movies
             LinkMovieStatistics(moviesResources, sdict);
 
             return moviesResources;
+        }
+
+        [HttpGet("listByPerformerForeignId")]
+        public List<int> ListByPerformerForeignId(string performerForeignId)
+        {
+            return _moviesService.GetByPerformerForeignId(performerForeignId).Map(x => x.Id).ToList();
+        }
+
+        [HttpGet("listByStudioForeignId")]
+        public List<int> ListByStudioForeignId(string studioForeignId)
+        {
+            return _moviesService.GetByStudioForeignId(studioForeignId).Map(x => x.Id).ToList();
         }
 
         protected MovieResource MapToResource(Movie movie)

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DryIoc.ImTools;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Movies.Performers.Events;
 using NzbDrone.SignalR;
@@ -21,16 +23,19 @@ namespace Whisparr.Api.V3.Performers
         private readonly IPerformerService _performerService;
         private readonly IAddPerformerService _addPerformerService;
         private readonly IMapCoversToLocal _coverMapper;
+        private readonly IMovieService _moviesService;
 
         public PerformerController(IPerformerService performerService,
                                    IAddPerformerService addPerformerService,
                                    IMapCoversToLocal coverMapper,
+                                   IMovieService moviesService,
                                    IBroadcastSignalRMessage signalRBroadcaster)
         : base(signalRBroadcaster)
         {
             _performerService = performerService;
             _addPerformerService = addPerformerService;
             _coverMapper = coverMapper;
+            _moviesService = moviesService;
         }
 
         protected override PerformerResource GetResourceById(int id)
@@ -86,6 +91,25 @@ namespace Whisparr.Api.V3.Performers
             BroadcastResourceChange(ModelAction.Updated, updatedPerformer.ToResource());
 
             return Accepted(updatedPerformer);
+        }
+
+        [RestDeleteById]
+        public void DeletePerformer(int id, bool deleteFiles = false, bool addImportExclusion = false)
+        {
+            var performer = _performerService.GetById(id);
+
+            if (performer == null)
+            {
+                return;
+            }
+
+            // Get the scenes for the performer
+            var scenes = _moviesService.GetByPerformerForeignId(performer.ForeignId);
+            var sceneIds = scenes.Map(x => x.Id).ToList();
+            _moviesService.DeleteMovies(sceneIds, deleteFiles, addImportExclusion);
+
+            // Remove the performer now that the associated scenes have been removed
+            _performerService.RemovePerformer(performer);
         }
 
         public void Handle(PerformerUpdatedEvent message)

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DryIoc.ImTools;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Movies.Studios.Events;
 using NzbDrone.SignalR;
@@ -19,15 +21,21 @@ namespace Whisparr.Api.V3.Studios
     public class StudioController : RestControllerWithSignalR<StudioResource, Studio>, IHandle<StudioUpdatedEvent>
     {
         private readonly IStudioService _studioService;
+        private readonly IAddStudioService _addStudioService;
         private readonly IMapCoversToLocal _coverMapper;
+        private readonly IMovieService _moviesService;
 
         public StudioController(IStudioService studioService,
+                                IAddStudioService addStudioService,
                                 IMapCoversToLocal coverMapper,
+                                IMovieService moviesService,
                                 IBroadcastSignalRMessage signalRBroadcaster)
         : base(signalRBroadcaster)
         {
             _studioService = studioService;
+            _addStudioService = addStudioService;
             _coverMapper = coverMapper;
+            _moviesService = moviesService;
         }
 
         protected override StudioResource GetResourceById(int id)
@@ -68,7 +76,7 @@ namespace Whisparr.Api.V3.Studios
         [RestPostById]
         public ActionResult<StudioResource> AddStudio(StudioResource studioResource)
         {
-            var studio = _studioService.AddStudio(studioResource.ToModel());
+            var studio = _addStudioService.AddStudio(studioResource.ToModel());
 
             return Created(studio.Id);
         }
@@ -83,6 +91,25 @@ namespace Whisparr.Api.V3.Studios
             BroadcastResourceChange(ModelAction.Updated, updatedStudio.ToResource());
 
             return Accepted(updatedStudio);
+        }
+
+        [RestDeleteById]
+        public void DeleteStudio(int id, bool deleteFiles = false, bool addImportExclusion = false)
+        {
+            var studio = _studioService.GetById(id);
+
+            if (studio == null)
+            {
+                return;
+            }
+
+            // Get the scenes for the studio
+            var scenes = _moviesService.GetByStudioForeignId(studio.ForeignId);
+            var sceneIds = scenes.Map(x => x.Id).ToList();
+            _moviesService.DeleteMovies(sceneIds, deleteFiles, addImportExclusion);
+
+            // Remove the studio now that the associated scenes have been removed
+            _studioService.RemoveStudio(studio);
         }
 
         public void Handle(StudioUpdatedEvent message)


### PR DESCRIPTION
Fixed: Scene row in Performer view should wrap long title

#### Database Migration
NO

#### Description
I removed the whitespace wrap on the title and performer columns as well as the and hard-coded width on the performer column.  Tested in landscape & portrait on desktop, tablet, and mobile phone screen sizes.

#### Screenshot (if UI related)
Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1231b4fa-89df-48a4-ae3d-1efff8dad287">

After
<img width="400" alt="image" src="https://github.com/user-attachments/assets/6713f0ca-1166-4cdc-b139-fb4d268c1fc2">

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
* Fixes #206 