### PR TITLE
Fixed: Scene title and performer columns should wrap

### DIFF
--- a/frontend/src/Performer/Details/SceneRow.css
+++ b/frontend/src/Performer/Details/SceneRow.css
@@ -1,7 +1,7 @@
 .title {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
-  white-space: nowrap;
+  white-space: wrap;
 }
 
 .monitored {
@@ -13,7 +13,7 @@
 .performers {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
-  width: 400px;
+  white-space: wrap;
 }
 
 .runtime {

--- a/frontend/src/Studio/Details/SceneRow.css
+++ b/frontend/src/Studio/Details/SceneRow.css
@@ -1,7 +1,7 @@
 .title {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
-  white-space: nowrap;
+  white-space: wrap;
 }
 
 .monitored {
@@ -13,7 +13,7 @@
 .performers {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 
-  width: 400px;
+  white-space: wrap;
 }
 
 .runtime {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Scene title and performer columns now properly wrap on the studio and performer detail pages.

#### Screenshot (if UI related)
Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/1f6b92b2-1151-41ee-92c2-51c4158ba537">

After
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b08716cd-a766-4921-91b4-34ab62119317">

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #206 