### PR TITLE
Fixed: Import movie/scene filter to use cleanTitle and support stashId, tmdbId

### DIFF
--- a/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
+++ b/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
@@ -172,9 +172,11 @@ function SelectMovieModalContent(props: SelectMovieModalContentProps) {
 
     return sorted.filter(
       (item) =>
-        item.sortTitle.includes(
-          filter.toLowerCase().replace(/[^a-zA-Z ]/g, '')
-        ) || item.tmdbId.toString() === filter
+        item.cleanTitle.includes(
+          filter.toLowerCase().replace(/[^a-zA-Z0-9]/g, '')
+        ) ||
+        item.stashId === filter ||
+        item.tmdbId.toString() === filter
     );
   }, [allMovies, filter]);
 

--- a/frontend/src/Movie/Movie.ts
+++ b/frontend/src/Movie/Movie.ts
@@ -28,9 +28,11 @@ export interface Ratings {
 interface Movie extends ModelBase {
   tmdbId: number;
   imdbId: string;
+  stashId: string;
   itemType: string;
   foreignId: string;
   sortTitle: string;
+  cleanTitle: string;
   overview: string;
   monitored: boolean;
   status: string;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I tweaked the filter when importing a scene/movie manually so the filter keys off of cleanTitle and the input transparently handles user input to conform with cleanTitle as [A-Za-z0-9] only.  Tested extensively with random input for matching movies and scenes.  

Previously, I had this filter ignoring numeric input, so trying to match "scene 1" would silently drop the "1" and match on just "scene".  That and a bunch of other edge cases are fixed by way of revised regex and the use of the cleanTitle column instead of sortTitle.

Support for matching on both scene (Stash) and movie (TMDB) ID's will also help users with very large libraries, as this dialog can be sluggish with the onChange filtering against the entire movie/scene list.  

#### Screenshot (if UI related)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/391f324c-c7a0-46ef-b635-f04df20ff593">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/10308602-ad0f-49df-abb1-c2956b005439">


#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX