### PR TITLE
New: Manual import allows folders with more than 100 items, first 100

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -169,14 +169,13 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
                 // Filter paths based on the rootFolder, so files in subfolders that should be ignored are ignored.
                 // It will lead to some extra directories being checked for files, but it saves the processing of them and is cleaner than
                 // teaching FilterPaths to know whether it's processing a file or a folder and changing it's filtering based on that.
-                // If the movie is unknown for the directory and there are more than 100 files in the folder don't process the items before returning.
+                // If the movie is unknown for the directory and there are more than 100 files in the folder process the first 100 items before returning.
                 var files = _diskScanService.FilterPaths(rootFolder, _diskScanService.GetVideoFiles(baseFolder, false));
 
                 if (files.Count > 100)
                 {
-                    _logger.Warn("Unable to determine movie from folder name and found more than 100 files. Skipping parsing");
-
-                    return ProcessDownloadDirectory(rootFolder, files);
+                    _logger.Warn("Found more than 100 files to import. Using only the first 100");
+                    files = files.GetRange(0, 99);
                 }
 
                 var subfolders = _diskScanService.FilterPaths(rootFolder, _diskProvider.GetDirectories(baseFolder));


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Previously when attempting to do a manual import in bulk, the process would fail silently if that folder had more than 100 items in it.  This was done via an upstream Radarr/Sonarr commit picked from https://github.com/Whisparr/Whisparr/commit/e5f66da087988c234e742d4f14ea99399c590e54 .  This change amends that code to allow just the first 100 items to be processed, instead of bailing out of this process entirely.  Users can re-run the process if they have a folder with more than 100 files to import, instead of the current workaround to liit files in each folder to 100.  This should help some v2 users to migrate libraries from v2 to v3 a bit more efficiently.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX