### PR TITLE
New: Toggle on and off if a scene will be automatically accepted by date

### DIFF
--- a/frontend/src/Settings/General/GeneralSettings.js
+++ b/frontend/src/Settings/General/GeneralSettings.js
@@ -17,6 +17,7 @@ import LoggingSettings from './LoggingSettings';
 import ProxySettings from './ProxySettings';
 import SecuritySettings from './SecuritySettings';
 import UpdateSettings from './UpdateSettings';
+import WhisparrSettings from './WhisparrSettings';
 
 const requiresRestartKeys = [
   'bindAddress',
@@ -175,6 +176,12 @@ class GeneralSettings extends Component {
                 />
 
                 <BackupSettings
+                  advancedSettings={advancedSettings}
+                  settings={settings}
+                  onInputChange={onInputChange}
+                />
+
+                <WhisparrSettings
                   advancedSettings={advancedSettings}
                   settings={settings}
                   onInputChange={onInputChange}

--- a/frontend/src/Settings/General/WhisparrSettings.js
+++ b/frontend/src/Settings/General/WhisparrSettings.js
@@ -1,0 +1,51 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import FieldSet from 'Components/FieldSet';
+import FormGroup from 'Components/Form/FormGroup';
+import FormInputGroup from 'Components/Form/FormInputGroup';
+import FormLabel from 'Components/Form/FormLabel';
+import { inputTypes } from 'Helpers/Props';
+import translate from 'Utilities/String/translate';
+
+function WhisparrSettings(props) {
+  const {
+    advancedSettings,
+    settings,
+    onInputChange
+  } = props;
+
+  const {
+    whisparrAutoMatchOnDate
+  } = settings;
+
+  if (!advancedSettings) {
+    return null;
+  }
+
+  return (
+    <FieldSet legend={translate('Whisparr')}>
+      <FormGroup
+        advancedSettings={advancedSettings}
+        isAdvanced={true}
+      >
+        <FormLabel>{translate('WhisparrAutoMatchOnDate')}</FormLabel>
+
+        <FormInputGroup
+          type={inputTypes.CHECK}
+          name="whisparrAutoMatchOnDate"
+          helpText={translate('WhisparrAutoMatchOnDateHelpText')}
+          onChange={onInputChange}
+          {...whisparrAutoMatchOnDate}
+        />
+      </FormGroup>
+    </FieldSet>
+  );
+}
+
+WhisparrSettings.propTypes = {
+  advancedSettings: PropTypes.bool.isRequired,
+  settings: PropTypes.object.isRequired,
+  onInputChange: PropTypes.func.isRequired
+};
+
+export default WhisparrSettings;

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -428,6 +428,13 @@ namespace NzbDrone.Core.Configuration
 
         public string ApplicationUrl => GetValue("ApplicationUrl", string.Empty);
 
+        public bool WhisparrAutoMatchOnDate
+        {
+            get { return GetValueBoolean("WhisparrAutoMatchOnDate", true); }
+
+            set { SetValue("WhisparrAutoMatchOnDate", value); }
+        }
+
         private string GetValue(string key)
         {
             return GetValue(key, string.Empty);

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -100,6 +100,9 @@ namespace NzbDrone.Core.Configuration
         int BackupInterval { get; }
         int BackupRetention { get; }
 
+        // Whisparr
+        bool WhisparrAutoMatchOnDate { get; }
+
         CertificateValidationType CertificateValidation { get; }
         string ApplicationUrl { get; }
     }

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -409,10 +409,7 @@ namespace NzbDrone.Core.Movies
                 return null;
             }
 
-            // This should be removed to stop any false positives.
-            // Whispar may only have a single scene for the studio date but more actually exist
-            // Example Monitor a performer but not the studio
-            if (movies.Count == 1)
+            if (movies.Count == 1 && _configService.WhisparrAutoMatchOnDate)
             {
                 return movies.First();
             }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allows a user to turn off the default of automatically accepting a scene if it matches on studio and date. There is the potential of another scene that either has not been added to stashDB, or the complete studio is not monitored. 

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #299 