### PR TITLE
Add: Speed up Studio page dont autoexpang large list of scenes

### DIFF
--- a/frontend/src/Studio/Details/StudioDetailsYear.js
+++ b/frontend/src/Studio/Details/StudioDetailsYear.js
@@ -123,7 +123,7 @@ class StudioDetailsYear extends Component {
     } = this.props;
 
     const expand = _.some(items, (item) => {
-      return year === moment().year();
+      return year === moment().year() && items.length < 60;
     });
 
     onExpandPress(year, expand);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If a studio has a large number of scenes for the current year it can take a long time to render, and causes a delay in loading. It's perceived to be faster if the user expands the list after the studio is loaded, and the render happens then. 

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX