### PR TITLE
New: Find by StashID

### DIFF
--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
@@ -54,7 +54,7 @@ namespace NzbDrone.Core.Test.Download
                   .Returns(new MovieHistory());
 
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.GetMovie("Drone.1998"))
+                  .Setup(s => s.GetMovie("Drone.1998", false))
                   .Returns(remoteMovie.Movie);
 
             Mocker.GetMock<IHistoryService>()
@@ -83,18 +83,18 @@ namespace NzbDrone.Core.Test.Download
                .Returns(new MovieHistory() { SourceTitle = "Droned 1998" });
 
             Mocker.GetMock<IParsingService>()
-               .Setup(s => s.GetMovie(It.IsAny<string>()))
+               .Setup(s => s.GetMovie(It.IsAny<string>(), false))
                .Returns((Movie)null);
 
             Mocker.GetMock<IParsingService>()
-                .Setup(s => s.GetMovie("Droned 1998"))
+                .Setup(s => s.GetMovie("Droned 1998", false))
                 .Returns(BuildRemoteMovie().Movie);
         }
 
         private void GivenSeriesMatch()
         {
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.GetMovie(It.IsAny<string>()))
+                  .Setup(s => s.GetMovie(It.IsAny<string>(), false))
                   .Returns(_trackedDownload.RemoteMovie.Movie);
         }
 

--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ProcessFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ProcessFixture.cs
@@ -56,7 +56,7 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
                   .Returns(new List<MovieHistory>());
 
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.GetMovie("Drone.S01E01.HDTV"))
+                  .Setup(s => s.GetMovie("Drone.S01E01.HDTV", false))
                   .Returns(remoteMovie.Movie);
         }
 
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
         private void GivenMovieMatch()
         {
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.GetMovie(It.IsAny<string>()))
+                  .Setup(s => s.GetMovie(It.IsAny<string>(), false))
                   .Returns(_trackedDownload.RemoteMovie.Movie);
         }
 
@@ -94,11 +94,11 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
                   });
 
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.GetMovie(It.IsAny<string>()))
+                  .Setup(s => s.GetMovie(It.IsAny<string>(), false))
                   .Returns((Movie)null);
 
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.GetMovie("Droned S01E01"))
+                  .Setup(s => s.GetMovie("Droned S01E01", false))
                   .Returns(BuildRemoteMovie().Movie);
         }
 
@@ -170,7 +170,7 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
         public void should_not_process_when_there_is_a_title_mismatch()
         {
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.GetMovie("Drone.S01E01.HDTV"))
+                  .Setup(s => s.GetMovie("Drone.S01E01.HDTV", false))
                   .Returns((Movie)null);
 
             Subject.Check(_trackedDownload);

--- a/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemovePendingFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemovePendingFixture.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Test.Download.Pending.PendingReleaseServiceTests
                   .Returns(new List<Movie> { _movie });
 
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.GetMovie(It.IsAny<string>()))
+                  .Setup(s => s.GetMovie(It.IsAny<string>(), false))
                   .Returns(_movie);
         }
 

--- a/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemoveRejectedFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/Pending/PendingReleaseServiceTests/RemoveRejectedFixture.cs
@@ -74,7 +74,7 @@ namespace NzbDrone.Core.Test.Download.Pending.PendingReleaseServiceTests
                   .Returns(new List<Movie> { _movie });
 
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.GetMovie(It.IsAny<string>()))
+                  .Setup(s => s.GetMovie(It.IsAny<string>(), false))
                   .Returns(_movie);
 
             Mocker.GetMock<IPrioritizeDownloadDecision>()

--- a/src/NzbDrone.Core.Test/MediaFiles/DownloadedMoviesImportServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DownloadedMoviesImportServiceFixture.cs
@@ -66,7 +66,7 @@ namespace NzbDrone.Core.Test.MediaFiles
         private void GivenValidMovie()
         {
             Mocker.GetMock<IParsingService>()
-                  .Setup(s => s.GetMovie(It.IsAny<string>()))
+                  .Setup(s => s.GetMovie(It.IsAny<string>(), false))
                   .Returns(Builder<Movie>.CreateNew().Build());
         }
 
@@ -98,7 +98,7 @@ namespace NzbDrone.Core.Test.MediaFiles
         {
             Subject.ProcessRootFolder(new DirectoryInfo(_droneFactory));
 
-            Mocker.GetMock<IParsingService>().Verify(c => c.GetMovie("foldername"), Times.Once());
+            Mocker.GetMock<IParsingService>().Verify(c => c.GetMovie("foldername", false), Times.Once());
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace NzbDrone.Core.Test.MediaFiles
         [Test]
         public void should_skip_if_no_series_found()
         {
-            Mocker.GetMock<IParsingService>().Setup(c => c.GetMovie("foldername")).Returns((Movie)null);
+            Mocker.GetMock<IParsingService>().Setup(c => c.GetMovie("foldername", false)).Returns((Movie)null);
 
             Subject.ProcessRootFolder(new DirectoryInfo(_droneFactory));
 
@@ -276,10 +276,10 @@ namespace NzbDrone.Core.Test.MediaFiles
             Subject.ProcessRootFolder(new DirectoryInfo(_droneFactory));
 
             Mocker.GetMock<IParsingService>()
-                .Verify(v => v.GetMovie(folderName), Times.Once());
+                .Verify(v => v.GetMovie(folderName, false), Times.Once());
 
             Mocker.GetMock<IParsingService>()
-                .Verify(v => v.GetMovie(It.Is<string>(s => s.StartsWith(prefix))), Times.Never());
+                .Verify(v => v.GetMovie(It.Is<string>(s => s.StartsWith(prefix)), false), Times.Never());
         }
 
         [Test]
@@ -404,7 +404,7 @@ namespace NzbDrone.Core.Test.MediaFiles
             Subject.ProcessPath(folderName).Should().BeEmpty();
 
             Mocker.GetMock<IParsingService>()
-                .Verify(v => v.GetMovie(It.IsAny<string>()), Times.Never());
+                .Verify(v => v.GetMovie(It.IsAny<string>(), false), Times.Never());
 
             ExceptionVerification.ExpectedErrors(1);
         }

--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
@@ -6,6 +6,7 @@ using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.Performers;
+using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Test.Framework;
 
 namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
@@ -56,6 +57,8 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
                                         .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .TheNext(1)
                                         .With(x => x.Title = "Milk & Chocolate Before Bed🥛🕟😵‍💫🕦🥛")
+                                        .With(x => x.ForeignId = "f3967398-1475-4e00-a7a0-935d7fd5dee1")
+                                        .With(x => x.MovieMetadata.Value.ForeignId = "f3967398-1475-4e00-a7a0-935d7fd5dee1")
                                         .With(x => x.MovieMetadata.Value.ReleaseDate = "2024-07-30")
                                         .With(x => x.MovieMetadata.Value.Credits = credits)
                                         .With(x => x.MovieMetadata.Value.Studio = studio)
@@ -131,6 +134,18 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
                                         .With(x => x.MovieMetadata.Value.Studio = studio)
                                         .Build()
                                         .ToList();
+
+            var studios = new List<Studio>
+            {
+                new Studio { ForeignId = "Studio" },
+                new Studio { ForeignId = "EvilAngel" },
+                new Studio { ForeignId = "Bellesa House" },
+                new Studio { ForeignId = "Step Siblings Caught" }
+            };
+
+            Mocker.GetMock<IStudioService>()
+                .Setup(s => s.FindAllByTitle(It.IsAny<string>()))
+                .Returns(studios);
 
             Mocker.GetMock<IMovieRepository>()
                 .Setup(s => s.GetByStudioForeignId(It.Is<string>(s => s.Equals("Studio"))))
@@ -215,6 +230,8 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
         [TestCase("Studio.21.01.08.Carrie", 10)]
         [TestCase("Studio.21.01.08.Carrie Sage", 10)]
         [TestCase("Studio - 2024-07-30 - Milk & Chocolate Before Bed", 6)]
+        [TestCase("Studio - 2024-07-30 - [f3967398-1475-4e00-a7a0-935d7fd5dee1]", 6)]
+        [TestCase("2024-07-30 - [f3967398-1475-4e00-a7a0-935d7fd5dee1]", 6)]
         [TestCase("Bellesa House 2024-08-15 Episode 200 Violet And Victor", 16)]
         [TestCase("Bellesa House 2024-08-15 Episode 200 Violet & Victor", 16)]
         [TestCase("Step Siblings Caught 2024-02-07 Cash For Kisses On Valentines Day - S25E7", 17)]
@@ -228,7 +245,7 @@ namespace NzbDrone.Core.Test.MovieTests.MovieServiceTests
 
             if (parsedMovieInfo.IsScene)
             {
-                var movie = Subject.FindByStudioAndReleaseDate(parsedMovieInfo.StudioTitle, parsedMovieInfo.ReleaseDate, parsedMovieInfo.ReleaseTokens);
+                var movie = Subject.FindScene(parsedMovieInfo, false, null);
 
                 if (id != null)
                 {

--- a/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
@@ -23,6 +23,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Studio.21.04.09.Title.XXX.480p.MP4-XXX", true)]
         [TestCase("Studio.22.10.18.Title.XXX.720p.HEVC.x265.PRT[XvX]", true)]
         [TestCase("Studio - 2017-08-04 - Some Title. [WEBDL-480p]", true)]
+        [TestCase("something random 77f1b861-91c1-4e6f-b0b1-3b1c46733fb2 anything", true)] // StashId
         [TestCase("Movie.2009.S01E14.English.HDTV.XviD-LOL", false)] // Movie
         public void should_parse_as_scene(string title, bool expected)
         {

--- a/src/NzbDrone.Core/Movies/MovieParseMatchType.cs
+++ b/src/NzbDrone.Core/Movies/MovieParseMatchType.cs
@@ -2,14 +2,15 @@ namespace NzbDrone.Core.Movies
 {
     public enum MovieParseMatchType
     {
-        Title = 1,
-        PerformersTitle = 2,
-        CharactersTitle = 3,
-        Performers = 4,
-        Characters = 5,
-        PerformerTitle = 6,
-        CharacterTitle = 7,
-        PerformersNotTitle = 8,
-        CharactersNotTitle = 9,
+        StashId = 1,
+        Title = 2,
+        PerformersTitle = 3,
+        CharactersTitle = 4,
+        Performers = 5,
+        Characters = 6,
+        PerformerTitle = 7,
+        CharacterTitle = 8,
+        PerformersNotTitle = 9,
+        CharactersNotTitle = 10,
     }
 }

--- a/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
+++ b/src/NzbDrone.Core/Parser/Model/ParsedMovieInfo.cs
@@ -26,6 +26,7 @@ namespace NzbDrone.Core.Parser.Model
         public string Episode { get; set; }
         public string Edition { get; set; }
         public int Year { get; set; }
+        public string StashId { get; set; }
         public string ImdbId { get; set; }
         public int TmdbId { get; set; }
         public string HardcodedSubs { get; set; }
@@ -50,11 +51,7 @@ namespace NzbDrone.Core.Parser.Model
         {
             get
             {
-                return ReleaseDate.IsNotNullOrWhiteSpace() || Episode.IsNotNullOrWhiteSpace();
-            }
-
-            private set
-            {
+                return ReleaseDate.IsNotNullOrWhiteSpace() || Episode.IsNotNullOrWhiteSpace() || StashId.IsNotNullOrWhiteSpace();
             }
         }
 

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -101,6 +101,9 @@ namespace NzbDrone.Core.Parser
             new Regex(@"^(?<title>.+?)?(?:(?:[-_\W](?<![)\[!]))*(?<year>(1(8|9)|20)\d{2}(?!p|i|\d+|\]|\W\d+)))+(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
             new Regex(@"^(?<title>(?![(\[]).+?)?(XXX)(\W+|_|$)(?!\\)", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+            // StashId
+            new Regex(@"(?<stashid>.{8}-.{4}-.{4}-.{4}-.{12})", RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 
         private static readonly Regex[] ReportTitleFolderRegex = new[]
@@ -162,6 +165,8 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex SpecialEpisodeTitleRegex = new Regex(@"(?<episodetitle>.+?)(?:\[.*(?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL).*\]|[. ]XXX[. ](?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL).*|(?:480p|720p|1080p|2160p|HDTV|WEB|WEBRip|WEB-?DL)|$)",
                           RegexOptions.Compiled);
+
+        private static readonly Regex StashIdRegex = new Regex(@"(?<stashid>.{8}-.{4}-.{4}-.{4}-.{12})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex SimpleReleaseTitleRegex = new Regex(@"\s*(?:[<>?*|])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
@@ -767,7 +772,7 @@ namespace NzbDrone.Core.Parser
 
         private static ParsedMovieInfo ParseMatchCollection(MatchCollection matchCollection, string releaseTitle)
         {
-            if (!matchCollection[0].Groups["airyear"].Success && !matchCollection[0].Groups["episode"].Success)
+            if (!matchCollection[0].Groups["airyear"].Success && !matchCollection[0].Groups["episode"].Success && !matchCollection[0].Groups["stashid"].Success)
             {
                 if (!matchCollection[0].Groups["title"].Success || matchCollection[0].Groups["title"].Value == "(")
                 {
@@ -950,6 +955,12 @@ namespace NzbDrone.Core.Parser
                     }
 
                     result.ReleaseTokens = releaseTokens;
+                }
+
+                var m = StashIdRegex.Match(result.ReleaseTokens);
+                if (m != null && m.Groups["stashid"].Success)
+                {
+                    result.StashId = m.Groups["stashid"].Value;
                 }
 
                 result.StudioTitle = studioTitle;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Migrate Scene matching to movie service, Studio - Date and Stash Id match 

TODO at another PR: Studio - (Episode, Studio Code)

Add the regex for a StashID and find it within a file.

TODO at another PR: hash the file ([Whisparr.VideoHashes](https://github.com/Whisparr/videohashes-build/blob/master/Whisparr.VideoHashes.csproj)) and use StashDB service to find a match.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX