### PR TITLE
Fixed: Scene details page now allows scroll for long descriptions

### DIFF
--- a/frontend/src/Movie/Details/MovieDetails.css
+++ b/frontend/src/Movie/Details/MovieDetails.css
@@ -66,7 +66,7 @@
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .titleRow {
@@ -131,6 +131,8 @@
 }
 
 .details {
+  overflow-x: hidden;
+  overflow-y: scroll;
   margin-bottom: 8px;
   padding-left: 7px;
   font-weight: 300;
@@ -181,8 +183,14 @@
   font-size: 17px;
 }
 
+.path {
+  text-wrap: auto;
+}
+
 .overview {
+  display: block;
   flex: 1 0 auto;
+  overflow: auto;
   margin-top: 8px;
   padding-left: 7px;
   min-height: 0;

--- a/frontend/src/Movie/Details/MovieDetails.js
+++ b/frontend/src/Movie/Details/MovieDetails.js
@@ -573,7 +573,7 @@ class MovieDetails extends Component {
 
                 <Measure onMeasure={this.onMeasure}>
                   <div className={styles.overview}>
-                    <TextTruncate
+                    <TextTruncate className={styles.overview}
                       line={Math.floor(overviewHeight / (defaultFontSize * lineHeight))}
                       text={overview}
                     />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Previously, when viewing a scene with a long description, the text of that description was cut off.  This small CSS update allows that part of the page to scroll.  I also forced tha file path to wrap, to avoid a horizontal scroll.  Tested on desktop, tablet, and mobile (this is hidden) display types.

#### Screenshot (if UI related)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e11a79ee-1dd1-4fd4-8aaf-44a1923e79ff" />


#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR