### PR TITLE
V3 - Fix: Set Scenes as default page and hide scene import in sidebar

### DIFF
--- a/frontend/src/App/AppRoutes.js
+++ b/frontend/src/App/AppRoutes.js
@@ -52,7 +52,7 @@ function AppRoutes(props) {
       <Route
         exact={true}
         path="/"
-        component={MovieIndex}
+        component={SceneIndex}
       />
 
       {

--- a/frontend/src/Components/Page/Sidebar/PageSidebar.js
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.js
@@ -20,10 +20,27 @@ const SIDEBAR_WIDTH = parseInt(dimensions.sidebarWidth);
 
 const links = [
   {
+    iconName: icons.SCENE,
+    title: () => translate('Scenes'),
+    to: '/',
+    alias: '/scenes',
+    children: [
+      // Hide until library import is usable for Scenes
+      /* {
+          title: () => translate('ImportLibrary'),
+          to: '/add/import/scenes'
+      },*/
+      {
+        title: () => translate('AddNew'),
+        to: '/add/new/scene'
+      }
+    ]
+  },
+
+  {
     iconName: icons.FILM,
     title: () => translate('Movies'),
-    to: '/',
-    alias: '/movies',
+    to: '/movies',
     children: [
       {
         title: () => translate('ImportLibrary'),
@@ -32,22 +49,6 @@ const links = [
       {
         title: () => translate('AddNew'),
         to: '/add/new/movie'
-      }
-    ]
-  },
-
-  {
-    iconName: icons.SCENE,
-    title: () => translate('Scenes'),
-    to: '/scenes',
-    children: [
-      {
-        title: () => translate('ImportLibrary'),
-        to: '/add/import/scenes'
-      },
-      {
-        title: () => translate('AddNew'),
-        to: '/add/new/scene'
       }
     ]
   },
@@ -208,7 +209,13 @@ function getActiveParent(pathname) {
     const movieId = pathname.split('movie/')[1];
 
     if (pathname.contains('movie/') && uuidRegex.test(movieId)) {
-      activeParent = '/scenes';
+      activeParent = '/';
+      return false;
+    }
+
+    // force "Movies" sidebar when viewing movie detail
+    if (pathname.contains('movie/')) {
+      activeParent = '/movies';
       return false;
     }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Discord discussion in Discord dev channel, it was agreed that Scenes should be priority over Movies for default views, so this PR adjusts that.

Also
It often comes up in Discord that scene library import doesn't work.  This is known, and pending a refactor to specifically support this (mostly users wanting to migrate from v2), it makes sense to just hide the item under the Scenes heading in the left navigation.

#### Screenshot (if UI related)
<img width="207" alt="image" src="https://github.com/user-attachments/assets/dad40608-9050-47ae-9fda-dec0087a1264" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
