### PR TITLE
Fixed: Allow numbers in header search

### DIFF
--- a/frontend/src/Components/Page/Header/MovieSearchInput.js
+++ b/frontend/src/Components/Page/Header/MovieSearchInput.js
@@ -136,7 +136,7 @@ class MovieSearchInput extends Component {
 
     if (newValue) {
       this.setState({
-        value: newValue.replace(/[^a-zA-Z ]/g, '')
+        value: newValue.replace(/[^a-zA-Z0-9\s]/g, '')
       });
     }
   };


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Previously, the search filter in the app header only allowed A-Z and a-z.  Now it also allows 0-9.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #336 