### PR TITLE
Fix history retention error message

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -282,6 +282,10 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                     out var daysRetention);
                 status.RemovesCompletedDownloads = daysRetention < 14;
             }
+            else if (config.Misc.history_retention.IsNullOrWhiteSpace())
+            {
+                status.RemovesCompletedDownloads = false;
+            }
             else
             {
                 status.RemovesCompletedDownloads = config.Misc.history_retention != "0";

--- a/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRemovesCompletedDownloadsCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRemovesCompletedDownloadsCheck.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                     {
                         return new HealthCheck(GetType(),
                             HealthCheckResult.Warning,
-                            string.Format(_localizationService.GetLocalizedString("DownloadClientRemovesCompletedDownloadsHealthCheckMessage"), clientName, "Sonarr"),
+                            string.Format(_localizationService.GetLocalizedString("DownloadClientRemovesCompletedDownloadsHealthCheckMessage"), clientName, "Whisparr"),
                             "#download-client-removes-completed-downloads");
                     }
                 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This is a quick fix for the following situation:
If the SABnzbd config property `history_retention` is an empty string, the retention will be infinite. Whisparr has a false positive error message in this case, stating that the download client would probably remove downloads before "Sonarr" [sic] could grab them.

#### Screenshot (if UI related)
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/faac69a4-3c15-4320-92d5-0db146e81531" />

#### Todos
- ~[ ] Tests~
- ~[ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)~
- ~[ ] [Wiki Updates](https://wiki.servarr.com)~

#### Issues Fixed or Closed by this PR
