### PR TITLE
Sonarr to Whisparr Verbage Fixes

### DIFF
--- a/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRemovesCompletedDownloadsCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/DownloadClientRemovesCompletedDownloadsCheck.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.HealthCheck.Checks
                     {
                         return new HealthCheck(GetType(),
                             HealthCheckResult.Warning,
-                            string.Format(_localizationService.GetLocalizedString("DownloadClientRemovesCompletedDownloadsHealthCheckMessage"), clientName, "Sonarr"),
+                            string.Format(_localizationService.GetLocalizedString("DownloadClientRemovesCompletedDownloadsHealthCheckMessage"), clientName, "Whisparr"),
                             "#download-client-removes-completed-downloads");
                     }
                 }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -355,7 +355,7 @@
   "DownloadClientCheckNoneAvailableHealthCheckMessage": "No download client is available",
   "DownloadClientCheckUnableToCommunicateWithHealthCheckMessage": "Unable to communicate with {0}.",
   "DownloadClientOptionsLoadError": "Unable to load download client options",
-  "DownloadClientRemovesCompletedDownloadsHealthCheckMessage": "Download client {0} is set to remove completed downloads. This can result in downloads being removed from your client before Whisparr can import them.",
+  "DownloadClientRemovesCompletedDownloadsHealthCheckMessage": "Download client {0} is set to remove completed downloads. This can result in downloads being removed from your client before {1} can import them.",
   "DownloadClientRootFolderHealthCheckMessage": "Download client {0} places downloads in the root folder {1}. You should not download to a root folder.",
   "DownloadClientSettings": "Download Client Settings",
   "DownloadClientSortingHealthCheckMessage": "Download client {0} has {1} sorting enabled for Whisparr's category. You should disable sorting in your download client to avoid import issues.",


### PR DESCRIPTION
Fixing an error in #329

I made an error with how Whisparr pulls the name for `DownloadClientRemovesCompletedDownloadsHealthCheckMessage`

A kind soul pointed it out to me so I reverted a change and added a new one.