### PR TITLE
Changed studio link in SceneIndexRow from white to defaultColor

### DIFF
--- a/frontend/src/Scene/Index/Table/SceneIndexRow.css
+++ b/frontend/src/Scene/Index/Table/SceneIndexRow.css
@@ -35,7 +35,7 @@
 .studio>a:visited,
 .studio>a:hover,
 .studio>a:active {
-  color: var(--white);
+  color: var(--defaultColor);
 }
 
 .originalLanguage,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Light mode rendering causes the Studio Name and Link to be pretty much invisible when using the Scene Table view. The existing css has the color set to "White". Updated it to defaultColor so it will adjust with changing between light and dark mode.

#### Screenshot (if UI related)
**Before**
![before](https://github.com/user-attachments/assets/93a2c522-2637-4a36-9d5c-effe6a6098ad)

**After**
![after](https://github.com/user-attachments/assets/7bce48ef-b0a3-421f-9682-b49d4b74f4ac)

**Dark Mode continues to work as before**
![dorkmode](https://github.com/user-attachments/assets/c450339e-d4c8-483b-8292-58bcd40e284c)

#### Todos


#### Issues Fixed or Closed by this PR
