### PR TITLE
Adding TPDBID to Site Page

### DIFF
--- a/frontend/src/Series/Details/SeriesDetails.js
+++ b/frontend/src/Series/Details/SeriesDetails.js
@@ -527,6 +527,24 @@ class SeriesDetails extends Component {
                       </Label>
                   }
 
+                  {
+                    !!tvdbId && (
+                      <Label
+                        className={styles.detailsLabel}
+                        title={translate('TPDB ID')}
+                        size={sizes.LARGE}
+                      >
+                        <Icon
+                          name={icons.NETWORK}
+                          size={17}
+                        />
+                        <span className={styles.qualityProfileName}>
+                          {tvdbId}
+                        </span>
+                      </Label>
+                    )
+                  }
+
                   <Tooltip
                     anchor={
                       <Label
@@ -543,6 +561,7 @@ class SeriesDetails extends Component {
                         </span>
                       </Label>
                     }
+
                     tooltip={
                       <SeriesDetailsLinks
                         tvdbId={tvdbId}


### PR DESCRIPTION
Adding in another label in the site details section to show the Site ID. Users find it complicated to either click the link and go to a whole new site or search TPDB manually with the name to find the ID.

As you can see by the preview it adds the Site ID next to the Network Label.


![before](https://github.com/user-attachments/assets/53f4e8a3-16dc-4fa6-84a3-04a29fdf54de)
vs
![after](https://github.com/user-attachments/assets/15c6ca62-e03a-4330-9155-4093f888e5ae)
