### PR TITLE
TPDB ID Tooltip Hover Table View

### DIFF
--- a/frontend/src/Series/Details/SeriesDetails.js
+++ b/frontend/src/Series/Details/SeriesDetails.js
@@ -527,6 +527,24 @@ class SeriesDetails extends Component {
                       </Label>
                   }
 
+                  {
+                    !!tvdbId && (
+                      <Label
+                        className={styles.detailsLabel}
+                        title={translate('TPDB ID')}
+                        size={sizes.LARGE}
+                      >
+                        <Icon
+                          name={icons.NETWORK}
+                          size={17}
+                        />
+                        <span className={styles.qualityProfileName}>
+                          {tvdbId}
+                        </span>
+                      </Label>
+                    )
+                  }
+
                   <Tooltip
                     anchor={
                       <Label
@@ -543,6 +561,7 @@ class SeriesDetails extends Component {
                         </span>
                       </Label>
                     }
+
                     tooltip={
                       <SeriesDetailsLinks
                         tvdbId={tvdbId}

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.tsx
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.tsx
@@ -206,7 +206,11 @@ function SeriesIndexRow(props: SeriesIndexRowProps) {
                   )}
                 </Link>
               ) : (
-                <SeriesTitleLink titleSlug={titleSlug} title={title} />
+                <SeriesTitleLink
+                  titleSlug={titleSlug}
+                  title={title}
+                  tvdbId={series.tvdbId}
+                />
               )}
             </VirtualTableRowCell>
           );

--- a/frontend/src/Series/SeriesTitleLink.js
+++ b/frontend/src/Series/SeriesTitleLink.js
@@ -1,20 +1,29 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Link from 'Components/Link/Link';
+import Tooltip from '../Components/Tooltip/Tooltip';
 
-function SeriesTitleLink({ titleSlug, title }) {
+function SeriesTitleLink({ titleSlug, title, tvdbId }) {
   const link = `/site/${titleSlug}`;
 
   return (
-    <Link to={link}>
-      {title}
-    </Link>
+    <Tooltip
+      anchor={
+        <Link to={link}>
+          {title}
+        </Link>
+      }
+      tooltip={tvdbId ? `${tvdbId}` : 'No TVDB ID available'}
+      kind="inverse"
+      position="top"
+    />
   );
 }
 
 SeriesTitleLink.propTypes = {
   titleSlug: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  tvdbId: PropTypes.number
 };
 
 export default SeriesTitleLink;


### PR DESCRIPTION
Adds the ability for users to hover over site hyperlinks in Table view on sites tabs and see TPDB ID. 

Discord user wanted to be able to get all the IDs from their sites a little faster. Doing it this way reduces the visual clutter but allows the users to speed up the process.

Example: 


![example](https://github.com/user-attachments/assets/7a74e3f6-e6e0-437e-89de-66980e9a0dc4)
