### PR TITLE
V3: Return To Performers Page After Deletion Of Performer

### DIFF
--- a/frontend/src/Performer/Delete/DeletePerformerModalContentConnector.js
+++ b/frontend/src/Performer/Delete/DeletePerformerModalContentConnector.js
@@ -3,6 +3,7 @@ import { createSelector } from 'reselect';
 import { deletePerformer, setDeleteOption } from 'Store/Actions/performerActions';
 import createPerformerSelector from 'Store/Selectors/createPerformerSelector';
 import DeletePerformerModalContent from './DeletePerformerModalContent';
+import { withRouter } from "react-router-dom";
 
 function createMapStateToProps() {
   return createSelector(
@@ -37,8 +38,9 @@ function createMapDispatchToProps(dispatch, props) {
       );
 
       props.onModalClose(true);
+      props.history.push('/performers');
     }
   };
 }
 
-export default connect(createMapStateToProps, createMapDispatchToProps)(DeletePerformerModalContent);
+export default withRouter(connect(createMapStateToProps, createMapDispatchToProps)(DeletePerformerModalContent));

--- a/frontend/src/Performer/Delete/DeletePerformerModalContentConnector.js
+++ b/frontend/src/Performer/Delete/DeletePerformerModalContentConnector.js
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import { createSelector } from 'reselect';
 import { deletePerformer, setDeleteOption } from 'Store/Actions/performerActions';
 import createPerformerSelector from 'Store/Selectors/createPerformerSelector';
 import DeletePerformerModalContent from './DeletePerformerModalContent';
-import { withRouter } from "react-router-dom";
 
 function createMapStateToProps() {
   return createSelector(


### PR DESCRIPTION
Currently, when you delete a performer from the performers tab it routes you back to the movies tab. This can be quite tedious if you have a few performers you want to delete and can cause extra clicks. 

Now, when you delete a performer it takes you back to the original Performers page that you were just on. 