### PR TITLE
V3: Return To Studio Page After Deletion Of Studio

### DIFF
--- a/frontend/src/Studio/Delete/DeleteStudioModalContentConnector.js
+++ b/frontend/src/Studio/Delete/DeleteStudioModalContentConnector.js
@@ -1,4 +1,5 @@
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import { createSelector } from 'reselect';
 import { deleteStudio, setDeleteOption } from 'Store/Actions/studioActions';
 import createStudioSelector from 'Store/Selectors/createStudioSelector';
@@ -37,8 +38,9 @@ function createMapDispatchToProps(dispatch, props) {
       );
 
       props.onModalClose(true);
+      props.history.push('/studios');
     }
   };
 }
 
-export default connect(createMapStateToProps, createMapDispatchToProps)(DeleteStudioModalContent);
+export default withRouter(connect(createMapStateToProps, createMapDispatchToProps)(DeleteStudioModalContent));


### PR DESCRIPTION
Currently, when you delete a studio from the studio tab it routes you back to the movies tab. This can be quite tedious if you have a few studios you want to delete and can cause extra clicks.

Now, when you delete a studio it takes you back to the original studios page that you were just on.