### PR TITLE
Fix: Performers Delete Button was Accidentally Moved

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetails.js
+++ b/frontend/src/Performer/Details/PerformerDetails.js
@@ -296,6 +296,12 @@ class PerformerDetails extends Component {
               onPress={this.onEditMoviePress}
             />
 
+            <PageToolbarButton
+              label={translate('Delete')}
+              iconName={icons.DELETE}
+              onPress={this.onDeleteMoviePress}
+            />
+
             <PageToolbarSection alignContent="right">
               <PageToolbarButton
                 label={allExpanded ? 'Collapse All' : 'Expand All'}
@@ -303,12 +309,6 @@ class PerformerDetails extends Component {
                 onPress={this.onExpandAllPress}
               />
             </PageToolbarSection>
-
-            <PageToolbarButton
-              label={translate('Delete')}
-              iconName={icons.DELETE}
-              onPress={this.onDeleteMoviePress}
-            />
           </PageToolbarSection>
         </PageToolbar>
 

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Servarr.FluentMigrator.Runner.SQLite" Version="3.3.2.9" />
     <PackageReference Include="Servarr.FluentMigrator.Runner.Postgres" Version="3.3.2.9" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.2.3" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />


### PR DESCRIPTION
When creating the expand/collapse all for performers I accidently put it above the delete button causing the delete button to move to the far right. 