### PR TITLE
Fix: Reposition Performer Delete Button On Left Side

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetails.js
+++ b/frontend/src/Performer/Details/PerformerDetails.js
@@ -296,6 +296,12 @@ class PerformerDetails extends Component {
               onPress={this.onEditMoviePress}
             />
 
+            <PageToolbarButton
+              label={translate('Delete')}
+              iconName={icons.DELETE}
+              onPress={this.onDeleteMoviePress}
+            />
+
             <PageToolbarSection alignContent="right">
               <PageToolbarButton
                 label={allExpanded ? 'Collapse All' : 'Expand All'}
@@ -303,12 +309,6 @@ class PerformerDetails extends Component {
                 onPress={this.onExpandAllPress}
               />
             </PageToolbarSection>
-
-            <PageToolbarButton
-              label={translate('Delete')}
-              iconName={icons.DELETE}
-              onPress={this.onDeleteMoviePress}
-            />
           </PageToolbarSection>
         </PageToolbar>
 


### PR DESCRIPTION
When creating the expand all button I accidently placed it above the delete button causing the delete button to be forced to the far right as it was inside the toolbar section.