### PR TITLE
Fix: Scene detail sometimes hid year / studio / duration

### DIFF
--- a/frontend/src/Movie/Details/MovieDetails.css
+++ b/frontend/src/Movie/Details/MovieDetails.css
@@ -131,9 +131,6 @@
 }
 
 .details {
-  overflow-x: hidden;
-  overflow-y: scroll;
-  margin-bottom: 8px;
   padding-left: 7px;
   font-weight: 300;
   font-size: 20px;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I broke CSS a little when I introduced scrolling for scenes with long descriptions.  This fixes that issue.  Tested on desktop, tablet, and mobile in both orientations.

#### Screenshot (if UI related)
Before
<img width="500" alt="image" src="https://github.com/user-attachments/assets/4fde8f25-448a-46a2-b695-0a07bbb6ed61" />

After
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ddbe15d7-bbe2-4f66-8e2d-22fd1c3838e1" />

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)