### PR TITLE
V3 - Fixed: Re-work Import List table view in Settings

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusion.css
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusion.css
@@ -7,11 +7,14 @@
   line-height: 30px;
 }
 
-.foreignId,
+.foreignId {
+  flex: 1 1 300px;
+  overflow: hidden;
+}
+
 .movieTitle {
   @add-mixin truncate;
-
-  flex: 0 0 600px;
+  flex: 1 1 600px;
 }
 
 .type,

--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.css
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.css
@@ -1,12 +1,16 @@
 .importListExclusionsHeader {
   display: flex;
   margin-bottom: 10px;
+  border-bottom: 1px solid var(--borderColor);
   font-weight: bold;
 }
 
-.foreignId,
+.foreignId {
+  flex: 1 1 300px;
+}
+
 .title {
-  flex: 0 0 600px;
+  flex: 1 1 600px;
 }
 
 .type,
@@ -17,6 +21,7 @@
 .addImportExclusion {
   display: flex;
   justify-content: flex-end;
+  flex: 1 0 auto;
   padding-right: 10px;
 }
 

--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.js
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.js
@@ -60,6 +60,14 @@ class ImportListExclusions extends Component {
             <div className={styles.title}>
               {translate('ExclusionTitle')}
             </div>
+            <div className={styles.addImportExclusion}>
+              <Link
+                className={styles.addButton}
+                onPress={this.onAddImportExclusionPress}
+              >
+                <Icon name={icons.ADD} />
+              </Link>
+            </div>
           </div>
 
           <div>
@@ -76,15 +84,6 @@ class ImportListExclusions extends Component {
                 );
               })
             }
-          </div>
-
-          <div className={styles.addImportExclusion}>
-            <Link
-              className={styles.addButton}
-              onPress={this.onAddImportExclusionPress}
-            >
-              <Icon name={icons.ADD} />
-            </Link>
           </div>
 
           <EditImportListExclusionModalConnector


### PR DESCRIPTION
#### Database Migration
NO

#### Description
CSS for the import list table rendered in a way that prevented the wrench (Edit) button from displaying on some screen sizes.  I re-worked the flex widths for the columns to fix that, as well as moved the Add (+) button to the top of the table header so users don't need to scroll to the bottom to manually add an entry.

#### Screenshot (if UI related)
Before
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8696f385-7244-4da3-9639-0316be7ee046" />

After
<img width="500" alt="image" src="https://github.com/user-attachments/assets/925f253b-7ae6-444e-b8bf-2e9a887e43df" />

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)