### PR TITLE
V3 Fix: Hide interactive search on Performer and Studio

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetails.js
+++ b/frontend/src/Performer/Details/PerformerDetails.js
@@ -17,7 +17,6 @@ import PageToolbarSeparator from 'Components/Page/Toolbar/PageToolbarSeparator';
 import Tooltip from 'Components/Tooltip/Tooltip';
 import { icons, kinds, sizes, tooltipPositions } from 'Helpers/Props';
 import MovieHeadshot from 'Movie/MovieHeadshot';
-import MovieInteractiveSearchModalConnector from 'Movie/Search/MovieInteractiveSearchModalConnector';
 import DeletePerformerModalConnector from 'Performer/Delete/DeletePerformerModalConnector';
 import EditPerformerModalConnector from 'Performer/Edit/EditPerformerModalConnector';
 import { getPerformerStatusDetails } from 'Performer/PerformerStatus';
@@ -56,7 +55,6 @@ class PerformerDetails extends Component {
     this.state = {
       isEditMovieModalOpen: false,
       isDeleteMovieModalOpen: false,
-      isInteractiveSearchModalOpen: false,
       allExpanded: false,
       allCollapsed: false,
       expandedState: {},
@@ -99,14 +97,6 @@ class PerformerDetails extends Component {
     this.setState({ isEditMovieModalOpen: false });
   };
 
-  onInteractiveSearchPress = () => {
-    this.setState({ isInteractiveSearchModalOpen: true });
-  };
-
-  onInteractiveSearchModalClose = () => {
-    this.setState({ isInteractiveSearchModalOpen: false });
-  };
-
   onTitleMeasure = ({ width }) => {
     this.setState({ titleWidth: width });
   };
@@ -140,8 +130,7 @@ class PerformerDetails extends Component {
       touchStart < 50 ||
       this.props.isSidebarVisible ||
       this.state.isDeleteMovieModalOpen ||
-      this.state.isEditMovieModalOpen ||
-      this.state.isInteractiveSearchModalOpen
+      this.state.isEditMovieModalOpen
     ) {
       return;
     }
@@ -238,7 +227,6 @@ class PerformerDetails extends Component {
     const {
       isDeleteMovieModalOpen,
       isEditMovieModalOpen,
-      isInteractiveSearchModalOpen,
       expandedState,
       allExpanded,
       allCollapsed
@@ -278,14 +266,6 @@ class PerformerDetails extends Component {
               isSpinning={isSearching}
               title={undefined}
               onPress={onSearchPress}
-            />
-
-            <PageToolbarButton
-              label={translate('InteractiveSearch')}
-              iconName={icons.INTERACTIVE}
-              isSpinning={isSearching}
-              title={undefined}
-              onPress={this.onInteractiveSearchPress}
             />
 
             <PageToolbarSeparator />
@@ -605,11 +585,6 @@ class PerformerDetails extends Component {
             onModalClose={this.onEditMovieModalClose}
           />
 
-          <MovieInteractiveSearchModalConnector
-            isOpen={isInteractiveSearchModalOpen}
-            movieId={id}
-            onModalClose={this.onInteractiveSearchModalClose}
-          />
         </PageContentBody>
       </PageContent>
     );

--- a/frontend/src/Studio/Details/StudioDetails.js
+++ b/frontend/src/Studio/Details/StudioDetails.js
@@ -16,7 +16,6 @@ import PageToolbarSection from 'Components/Page/Toolbar/PageToolbarSection';
 import PageToolbarSeparator from 'Components/Page/Toolbar/PageToolbarSeparator';
 import Tooltip from 'Components/Tooltip/Tooltip';
 import { icons, kinds, sizes, tooltipPositions } from 'Helpers/Props';
-import MovieInteractiveSearchModalConnector from 'Movie/Search/MovieInteractiveSearchModalConnector';
 import QualityProfileNameConnector from 'Settings/Profiles/Quality/QualityProfileNameConnector';
 import DeleteStudioModalConnector from 'Studio/Delete/DeleteStudioModalConnector';
 import EditStudioModalConnector from 'Studio/Edit/EditStudioModalConnector';
@@ -53,7 +52,6 @@ class StudioDetails extends Component {
 
     this.state = {
       isEditMovieModalOpen: false,
-      isInteractiveSearchModalOpen: false,
       allExpanded: false,
       allCollapsed: false,
       expandedState: {},
@@ -96,14 +94,6 @@ class StudioDetails extends Component {
     this.setState({ isEditMovieModalOpen: false });
   };
 
-  onInteractiveSearchPress = () => {
-    this.setState({ isInteractiveSearchModalOpen: true });
-  };
-
-  onInteractiveSearchModalClose = () => {
-    this.setState({ isInteractiveSearchModalOpen: false });
-  };
-
   onTitleMeasure = ({ width }) => {
     this.setState({ titleWidth: width });
   };
@@ -137,8 +127,7 @@ class StudioDetails extends Component {
       touchStart < 50 ||
       this.props.isSidebarVisible ||
       this.state.isDeleteMovieModalOpen ||
-      this.state.isEditMovieModalOpen ||
-      this.state.isInteractiveSearchModalOpen
+      this.state.isEditMovieModalOpen
     ) {
       return;
     }
@@ -235,7 +224,6 @@ class StudioDetails extends Component {
     const {
       isEditMovieModalOpen,
       isDeleteMovieModalOpen,
-      isInteractiveSearchModalOpen,
       expandedState,
       allExpanded,
       allCollapsed
@@ -275,14 +263,6 @@ class StudioDetails extends Component {
               isSpinning={isSearching}
               title={undefined}
               onPress={onSearchPress}
-            />
-
-            <PageToolbarButton
-              label={translate('InteractiveSearch')}
-              iconName={icons.INTERACTIVE}
-              isSpinning={isSearching}
-              title={undefined}
-              onPress={this.onInteractiveSearchPress}
             />
 
             <PageToolbarSeparator />
@@ -585,11 +565,6 @@ class StudioDetails extends Component {
             onDeleteMoviePress={this.onDeleteMoviePress}
           />
 
-          <MovieInteractiveSearchModalConnector
-            isOpen={isInteractiveSearchModalOpen}
-            movieId={id}
-            onModalClose={this.onInteractiveSearchModalClose}
-          />
         </PageContentBody>
       </PageContent>
     );

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1528,6 +1528,7 @@
   "SearchSelected": "Search Selected",
   "SearchTitleDate": "Search Title Date",
   "SearchTitleDateHelpText": "Search with a Title and Date combination",
+  "SearchStudio": "Search Studio",
   "SearchStudioDate": "Search Studio Date",
   "SearchStudioDateHelpText": "Search with a Studio and Date combination",
   "SearchStudioTitle": "Search Studio Title",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
At present, Interactive Search only works when viewing a single scene, not a performer or studio.  The level of effort to fix these is heavy, so I opted to hide them until later efforts can be put into redesigning them.  I also added a missing English translation for `SearchStudio` to display as `Search Studio`.

#### Screenshot (if UI related)
The button was hidden on Performer Detail and Studio Detail.

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #417 , #418 