### PR TITLE
FIX: Remove Interactive Search From Years Within Studio page

### DIFF
--- a/frontend/src/Studio/Details/StudioDetailsYear.js
+++ b/frontend/src/Studio/Details/StudioDetailsYear.js
@@ -271,18 +271,6 @@ class StudioDetailsYear extends Component {
 
                     {translate('Search')}
                   </MenuItem>
-
-                  <MenuItem
-                    onPress={this.onInteractiveSearchPress}
-                    isDisabled={!totalMovieCount}
-                  >
-                    <Icon
-                      className={styles.actionMenuIcon}
-                      name={icons.INTERACTIVE}
-                    />
-
-                    {translate('InteractiveSearch')}
-                  </MenuItem>
                 </MenuContent>
               </Menu> :
 
@@ -295,15 +283,6 @@ class StudioDetailsYear extends Component {
                   isSpinning={isSearching}
                   isDisabled={isSearching || !hasMonitoredMovies || !studioMonitored}
                   onPress={onSearchPress}
-                />
-
-                <IconButton
-                  className={styles.actionButton}
-                  name={icons.INTERACTIVE}
-                  title={translate('InteractiveSearchSeason')}
-                  size={24}
-                  isDisabled={!totalMovieCount}
-                  onPress={this.onInteractiveSearchPress}
                 />
               </div>
           }

--- a/frontend/src/Studio/Details/StudioDetailsYear.js
+++ b/frontend/src/Studio/Details/StudioDetailsYear.js
@@ -81,7 +81,6 @@ class StudioDetailsYear extends Component {
       isOrganizeModalOpen: false,
       isManageMoviesOpen: false,
       isHistoryModalOpen: false,
-      isInteractiveSearchModalOpen: false,
       lastToggledMovie: null
     };
   }
@@ -131,14 +130,6 @@ class StudioDetailsYear extends Component {
 
   //
   // Listeners
-
-  onInteractiveSearchPress = () => {
-    this.setState({ isInteractiveSearchModalOpen: true });
-  };
-
-  onInteractiveSearchModalClose = () => {
-    this.setState({ isInteractiveSearchModalOpen: false });
-  };
 
   onExpandPress = () => {
     const {


### PR DESCRIPTION
Currently Interactive search within a year just does nothing. 

I am removing the front end as it won't be that useful anyway. Radarr doesn't have this functionality as it expects 1 search per studio (Movie). Sonarr has this ability to search per year but it searches for packs/siterips.

We could potentially make it work with siterips but would require significant work. 

@plz12345 Already has a PR open to remove interactive search from Studio and performer details headers 

#419

* Fixes #427