### PR TITLE
FIX: Remove Interactive Search from PerformerDetailsStudio

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetailsStudio.js
+++ b/frontend/src/Performer/Details/PerformerDetailsStudio.js
@@ -81,7 +81,6 @@ class PerformerDetailsStudio extends Component {
       isOrganizeModalOpen: false,
       isManageMoviesOpen: false,
       isHistoryModalOpen: false,
-      isInteractiveSearchModalOpen: false,
       lastToggledMovie: null
     };
   }
@@ -131,14 +130,6 @@ class PerformerDetailsStudio extends Component {
 
   //
   // Listeners
-
-  onInteractiveSearchPress = () => {
-    this.setState({ isInteractiveSearchModalOpen: true });
-  };
-
-  onInteractiveSearchModalClose = () => {
-    this.setState({ isInteractiveSearchModalOpen: false });
-  };
 
   onExpandPress = () => {
     const {

--- a/frontend/src/Performer/Details/PerformerDetailsStudio.js
+++ b/frontend/src/Performer/Details/PerformerDetailsStudio.js
@@ -285,18 +285,6 @@ class PerformerDetailsStudio extends Component {
 
                     {translate('Search')}
                   </MenuItem>
-
-                  <MenuItem
-                    onPress={this.onInteractiveSearchPress}
-                    isDisabled={!totalMovieCount}
-                  >
-                    <Icon
-                      className={styles.actionMenuIcon}
-                      name={icons.INTERACTIVE}
-                    />
-
-                    {translate('InteractiveSearch')}
-                  </MenuItem>
                 </MenuContent>
               </Menu> :
 
@@ -309,15 +297,6 @@ class PerformerDetailsStudio extends Component {
                   isSpinning={isSearching}
                   isDisabled={isSearching || !hasMonitoredMovies}
                   onPress={onSearchPress}
-                />
-
-                <IconButton
-                  className={styles.actionButton}
-                  name={icons.INTERACTIVE}
-                  title={translate('InteractiveSearchSeason')}
-                  size={24}
-                  isDisabled={!totalMovieCount}
-                  onPress={this.onInteractiveSearchPress}
                 />
               </div>
           }


### PR DESCRIPTION
Currently Interactive search within a performer site just does nothing.

I am removing the front end as it won't be that useful anyway. Radarr doesn't have this functionality as it expects 1 search per studio (Movie). Sonarr has this ability to search per year but it searches for packs/siterips.

We could potentially make it work with siterips but would require significant work.

There is already a PR open to remove the interactive search from the header 
https://github.com/Whisparr/Whisparr/pull/419

* Fixes #428