### PR TITLE
FIX: V2 Limit Performer Tokens to 4 names

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -474,9 +474,25 @@ namespace NzbDrone.Core.Organizer
                 tokenHandlers["{Release Date}"] = m => "Unknown";
             }
 
-            tokenHandlers["{Episode Performers}"] = m => episodes.SelectMany(e => e.Actors.Select(a => a.Name)).Join(" ");
-            tokenHandlers["{Episode PerformersFemale}"] = m => episodes.SelectMany(e => e.Actors.Where(a => a.Gender == Gender.Female).Select(a => a.Name)).Join(" ");
-            tokenHandlers["{Episode PerformersMale}"] = m => episodes.SelectMany(e => e.Actors.Where(a => a.Gender == Gender.Male).Select(a => a.Name)).Join(" ");
+            tokenHandlers["{Episode Performers}"] = m =>
+            {
+                var allPerformers = episodes.SelectMany(e => e.Actors.Select(a => a.Name)).Distinct().Take(4).ToList();
+                return string.Join(", ", allPerformers);
+            };
+            tokenHandlers["{Episode PerformersFemale}"] = m =>
+            {
+                var femalePerformers = episodes
+                    .SelectMany(e => e.Actors.Where(a => a.Gender == Gender.Female).Select(a => a.Name)).Distinct()
+                    .Take(4).ToList();
+                return string.Join(", ", femalePerformers);
+            };
+            tokenHandlers["{Episode PerformersMale}"] = m =>
+            {
+                var malePerformers = episodes
+                    .SelectMany(e => e.Actors.Where(a => a.Gender == Gender.Male).Select(a => a.Name)).Distinct()
+                    .Take(4).ToList();
+                return string.Join(", ", malePerformers);
+            };
         }
 
         private void AddEpisodeTitlePlaceholderTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers)


### PR DESCRIPTION
This limits the performer tokens to 4 unique names when renaming to prevent from going over the byte/character limit.

* Fixes #433

WARNING: I did not test this as I don't have file for my dev env. 