### PR TITLE
NEW: Add `{Scene PerformersMale}` Naming Token + Limit all Performer Tokens to 4

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -356,10 +356,19 @@ namespace NzbDrone.Core.Organizer
             {
                 var credits = movie.MovieMetadata.Value.Credits;
                 tokenHandlers["{Scene Performers}"] = m => credits.OrderBy(p => p.Performer.Name)
-                                                                  .Select(p => p.Performer.Name).Join(" ");
+                    .Select(p => p.Performer.Name)
+                    .Take(4)
+                    .Join(" ");
                 tokenHandlers["{Scene PerformersFemale}"] = m => credits.Where(p => p.Performer.Gender == Gender.Female)
-                                                                        .OrderBy(p => p.Performer.Name)
-                                                                        .Select(p => p.Performer.Name).Join(" ");
+                    .OrderBy(p => p.Performer.Name)
+                    .Select(p => p.Performer.Name)
+                    .Take(4)
+                    .Join(" ");
+                tokenHandlers["{Scene PerformersMale}"] = m => credits.Where(p => p.Performer.Gender == Gender.Male)
+                    .OrderBy(p => p.Performer.Name)
+                    .Select(p => p.Performer.Name)
+                    .Take(4)
+                    .Join(" ");
             }
         }
 


### PR DESCRIPTION
Add `{Scene PerformersMale}` Naming Token so that people can name by male performer if they choose.

Also modified all performer tokens to like to 4 unique names so that no naming errors occurs on longer listed performers.

WARNING: I did not test this as I don't have file for my dev env.