### PR TITLE
Fix: studio performer performance

### DIFF
--- a/frontend/src/Components/Delayed.js
+++ b/frontend/src/Components/Delayed.js
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import LoadingIndicator from 'Components/Loading/LoadingIndicator';
+
+class Delayed extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { hidden: true };
+  }
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.setState({ hidden: false });
+    }, this.props.waitBeforeShow);
+  }
+
+  render() {
+    return this.state.hidden ? <LoadingIndicator /> : this.props.children;
+  }
+}
+
+Delayed.propTypes = {
+  waitBeforeShow: PropTypes.number.isRequired,
+  children: PropTypes.element
+};
+
+export default Delayed;

--- a/frontend/src/Performer/Details/PerformerDetails.js
+++ b/frontend/src/Performer/Details/PerformerDetails.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Alert from 'Components/Alert';
+import Delayed from 'Components/Delayed';
 import FieldSet from 'Components/FieldSet';
 import Icon from 'Components/Icon';
 import Label from 'Components/Label';
@@ -556,13 +557,15 @@ class PerformerDetails extends Component {
                   <div>
                     {studios.map((studio) => {
                       return (
-                        <PerformerDetailsStudioConnector
-                          key={studio.foreignId}
-                          performerId={id}
-                          studioForeignId={studio.foreignId}
-                          isExpanded={expandedState[studio.foreignId]}
-                          onExpandPress={this.onExpandPress}
-                        />
+                        <Delayed key={studio.foreignId} waitBeforeShow={50}>
+                          <PerformerDetailsStudioConnector
+                            key={studio.foreignId}
+                            performerId={id}
+                            studioForeignId={studio.foreignId}
+                            isExpanded={expandedState[studio.foreignId]}
+                            onExpandPress={this.onExpandPress}
+                          />
+                        </Delayed>
                       );
                     })
                     }

--- a/frontend/src/Store/Actions/movieActions.js
+++ b/frontend/src/Store/Actions/movieActions.js
@@ -344,6 +344,14 @@ function getSaveAjaxOptions({ ajaxOptions, payload }) {
 export const actionHandlers = handleThunks({
 
   [FETCH_MOVIES]: (getState, payload, dispatch) => {
+    if (getState().movies.isPopulated) {
+      return;
+    }
+
+    if (getState().movies.isFetching) {
+      return;
+    }
+
     dispatch(set({ section, isFetching: true }));
 
     const {

--- a/frontend/src/Studio/Details/StudioDetails.js
+++ b/frontend/src/Studio/Details/StudioDetails.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Alert from 'Components/Alert';
+import Delayed from 'Components/Delayed';
 import FieldSet from 'Components/FieldSet';
 import Icon from 'Components/Icon';
 import Label from 'Components/Label';
@@ -533,14 +534,16 @@ class StudioDetails extends Component {
                         {
                           years.slice(0).reverse().map((year) => {
                             return (
-                              <StudioDetailsYearConnector
-                                key={year}
-                                studioId={id}
-                                studioForeignId={foreignId}
-                                year={year}
-                                isExpanded={expandedState[year]}
-                                onExpandPress={this.onExpandPress}
-                              />
+                              <Delayed key={year} waitBeforeShow={50}>
+                                <StudioDetailsYearConnector
+                                  key={year}
+                                  studioId={id}
+                                  studioForeignId={foreignId}
+                                  year={year}
+                                  isExpanded={expandedState[year]}
+                                  onExpandPress={this.onExpandPress}
+                                />
+                              </Delayed>
                             );
                           })
                         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Alter studio and performer details
- Add a delay so that the top section is able to render to the user
- Change the way that the data is filtered and sorted (createClientSideCollectionSelector sorted the complete list of scenes causing a delay)

The sorting was a major contributor to the amount of time that that it took to render these routes.

Movie Action 
- FETCH_MOVIES may be called too much, as once populated any changes for a single scene would be sent through SET_MOVIE_VALUE

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX