### PR TITLE
Fix: Adding `{Scene PerformersMale}` to Rename UI

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -87,7 +87,7 @@ const sceneTokens = [
   { token: '{Scene TitleFirstCharacter}', example: 'S' },
   { token: '{Scene Performers}', example: 'Abigail Mac Tera Patrick John Holmes' },
   { token: '{Scene PerformersFemale}', example: 'Abigail Mac Tera Patrick' },
-  { token: '{Scene PerformersMale}', example: 'Johnny Sins'},
+  { token: '{Scene PerformersMale}', example: 'Johnny Sins' },
   { token: '{Release Date}', example: '2009-02-04' },
   { token: '{Release ShortDate}', example: '09 02 04' }
 ];

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -87,6 +87,7 @@ const sceneTokens = [
   { token: '{Scene TitleFirstCharacter}', example: 'S' },
   { token: '{Scene Performers}', example: 'Abigail Mac Tera Patrick John Holmes' },
   { token: '{Scene PerformersFemale}', example: 'Abigail Mac Tera Patrick' },
+  { token: '{Scene PerformersMale}', example: 'Johnny Sins'},
   { token: '{Release Date}', example: '2009-02-04' },
   { token: '{Release ShortDate}', example: '09 02 04' }
 ];


### PR DESCRIPTION
Recently I made a PR to add `{Scene PerformersMale}` to the back end. I forgot to update the UI so that is is usable. 

Backend PR: https://github.com/Whisparr/Whisparr/pull/437