### PR TITLE
New: recreate the credit table

### DIFF
--- a/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/MovieTests/MovieServiceTests/FindByTitleFixture.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Credits;
 using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Test.Framework;

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -11,6 +11,7 @@ using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Credits;
 using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Qualities;

--- a/src/NzbDrone.Core/Datastore/Migration/008_add_credits.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/008_add_credits.cs
@@ -1,0 +1,23 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(008)]
+    public class add_credits : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Create.TableForModel("Credits").WithColumn("MovieMetadataId").AsInt32()
+                                  .WithColumn("PerformerForeignId").AsString()
+                                  .WithColumn("Character").AsString().Nullable()
+                                  .WithColumn("Job").AsString().Nullable()
+                                  .WithColumn("Type").AsInt32()
+                                  .WithColumn("Order").AsInt32();
+
+            // Indexes
+            Create.Index().OnTable("Credits").OnColumn("MovieMetadataId");
+            Create.Index().OnTable("Credits").OnColumn("PerformerForeignId");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -29,6 +29,7 @@ using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Movies.Credits;
 using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Notifications;
@@ -177,6 +178,8 @@ namespace NzbDrone.Core.Datastore
             Mapper.Entity<Studio>("Studios").RegisterModel();
 
             Mapper.Entity<AutoTagging.AutoTag>("AutoTagging").RegisterModel();
+
+            Mapper.Entity<Credit>("Credits").RegisterModel();
         }
 
         private static void RegisterMappers()

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -14,6 +14,7 @@ using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MetadataSource.SkyHook.Resource;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Movies.Credits;
 using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Movies.Studios;
 using NzbDrone.Core.Parser;
@@ -815,8 +816,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             {
                 Character = arg.Character,
                 Order = arg.Order,
-                CreditForeignId = arg.CreditId,
                 Type = CreditType.Cast,
+                PerformerForeignId = arg.Performer.ForeignIds.StashId,
                 Performer = new CreditPerformer
                 {
                     Name = arg.Performer.Name,
@@ -952,8 +953,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             {
                 Character = arg.Character,
                 Order = arg.Order,
-                CreditForeignId = $"{sceneForeignId} - {arg.Performer.ForeignIds.StashId}",
                 Type = CreditType.Cast,
+                PerformerForeignId = arg.Performer.ForeignIds.StashId,
                 Performer = new CreditPerformer
                 {
                     Name = arg.Performer.Name,

--- a/src/NzbDrone.Core/Movies/AddMovieService.cs
+++ b/src/NzbDrone.Core/Movies/AddMovieService.cs
@@ -232,8 +232,8 @@ namespace NzbDrone.Core.Movies
                     }
                 }
 
-                var creditForeignIds = newMovie.MovieMetadata.Value.Credits.Select(c => c.CreditForeignId);
-                var excludedPerformers = excludedItems.Where(e => creditForeignIds.Contains(e.ForeignId) && e.Type == ImportExclusionType.Performer).ToList();
+                var performerForeignIds = newMovie.MovieMetadata.Value.Credits.Select(c => c.PerformerForeignId);
+                var excludedPerformers = excludedItems.Where(e => performerForeignIds.Contains(e.ForeignId) && e.Type == ImportExclusionType.Performer).ToList();
                 if (excludedPerformers.Any())
                 {
                     var newExclusion = new ImportExclusion { ForeignId = newMovie.ForeignId, Type = newMovie.MovieMetadata.Value.ItemType == ItemType.Scene ? ImportExclusionType.Scene : ImportExclusionType.Movie, MovieTitle = newMovie.Title, MovieYear = newMovie.Year };

--- a/src/NzbDrone.Core/Movies/Credits/Credit.cs
+++ b/src/NzbDrone.Core/Movies/Credits/Credit.cs
@@ -1,13 +1,14 @@
 using System.Collections.Generic;
+using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Movies.Performers;
 
-namespace NzbDrone.Core.Movies
+namespace NzbDrone.Core.Movies.Credits
 {
-    public class Credit
+    public class Credit : ModelBase
     {
-        public string CreditForeignId { get; set; }
-        public string Department { get; set; }
         public string Job { get; set; }
+        public int MovieMetadataId { get; set; }
+        public string PerformerForeignId { get; set; }
         public string Character { get; set; }
         public int Order { get; set; }
         public CreditType Type { get; set; }

--- a/src/NzbDrone.Core/Movies/Credits/CreditRepository.cs
+++ b/src/NzbDrone.Core/Movies/Credits/CreditRepository.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Movies.Performers;
+
+namespace NzbDrone.Core.Movies.Credits
+{
+    public interface ICreditRepository : IBasicRepository<Credit>
+    {
+        List<Credit> FindByMovieMetadataId(int movieId);
+        List<Credit> GetPerformerMovies(string performerForeignId);
+        void DeleteForMovies(List<int> movieIds);
+    }
+
+    public class CreditRepository : BasicRepository<Credit>, ICreditRepository
+    {
+        public CreditRepository(IMainDatabase database, IEventAggregator eventAggregator)
+            : base(database, eventAggregator)
+        {
+        }
+
+        public List<Credit> FindByMovieMetadataId(int movieMetadataId)
+        {
+            var builder = new SqlBuilder(_database.DatabaseType)
+               .Join<Credit, Performer>((m, p) => m.PerformerForeignId == p.ForeignId)
+               .Where<Credit>(x => x.MovieMetadataId == movieMetadataId);
+
+            return _database.QueryJoined<Credit, Performer>(
+                builder,
+                (credit, performer) =>
+                {
+                    var creditPerformer = new CreditPerformer();
+                    creditPerformer.Name = performer.Name;
+                    credit.Performer = creditPerformer;
+
+                    return credit;
+                }).ToList();
+        }
+
+        public List<Credit> GetPerformerMovies(string performerForeignId)
+        {
+            var builder = new SqlBuilder(_database.DatabaseType)
+               .Join<Credit, Performer>((m, p) => m.PerformerForeignId == p.ForeignId)
+               .Where<Credit>(x => x.PerformerForeignId == performerForeignId);
+
+            return _database.QueryJoined<Credit, Performer>(
+                builder,
+                (credit, performer) =>
+                {
+                    var creditPerformer = new CreditPerformer();
+                    creditPerformer.Name = performer.Name;
+                    credit.Performer = creditPerformer;
+
+                    return credit;
+                }).ToList();
+        }
+
+        public void DeleteForMovies(List<int> movieIds)
+        {
+            Delete(x => movieIds.Contains(x.MovieMetadataId));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Movies/Credits/CreditService.cs
+++ b/src/NzbDrone.Core/Movies/Credits/CreditService.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Core.Movies.Events;
+
+namespace NzbDrone.Core.Movies.Credits
+{
+    public interface ICreditService
+    {
+        List<Credit> GetAllCreditsForMovieMetadata(int movieMetadataId);
+        Credit AddCredit(Credit credit, MovieMetadata movie);
+        List<Credit> AddCredits(List<Credit> credits, MovieMetadata movie);
+        Credit GetById(int id);
+        List<Credit> GetPerformerMovies(string performerForeignId);
+        List<Credit> GetAllCredits();
+        List<Credit> UpdateCredits(List<Credit> credits, MovieMetadata movie);
+    }
+
+    public class CreditService : ICreditService
+    {
+        private readonly ICreditRepository _creditRepo;
+
+        public CreditService(ICreditRepository creditRepo)
+        {
+            _creditRepo = creditRepo;
+        }
+
+        public List<Credit> GetAllCreditsForMovieMetadata(int movieMetadataId)
+        {
+            return _creditRepo.FindByMovieMetadataId(movieMetadataId).ToList();
+        }
+
+        public Credit AddCredit(Credit credit, MovieMetadata movie)
+        {
+            credit.MovieMetadataId = movie.Id;
+            return _creditRepo.Insert(credit);
+        }
+
+        public List<Credit> AddCredits(List<Credit> credits, MovieMetadata movie)
+        {
+            credits.ForEach(t => t.MovieMetadataId = movie.Id);
+            _creditRepo.InsertMany(credits);
+            return credits;
+        }
+
+        public Credit GetById(int id)
+        {
+            return _creditRepo.Get(id);
+        }
+
+        public List<Credit> GetPerformerMovies(string performerForeignId)
+        {
+            return _creditRepo.GetPerformerMovies(performerForeignId).ToList();
+        }
+
+        public List<Credit> GetAllCredits()
+        {
+            return _creditRepo.All().ToList();
+        }
+
+        public void RemoveTitle(Credit credit)
+        {
+            _creditRepo.Delete(credit);
+        }
+
+        public List<Credit> UpdateCredits(List<Credit> credits, MovieMetadata movieMetadata)
+        {
+            var movieMetadataId = movieMetadata.Id;
+
+            // First update the movie ids so we can correlate them later.
+            credits.ForEach(t => t.MovieMetadataId = movieMetadataId);
+
+            // Now find credits to delete, update and insert.
+            var existingCredits = _creditRepo.FindByMovieMetadataId(movieMetadataId);
+
+            // Should never have multiple credits with same credit_id, but check to ensure incase TMDB is on fritz
+            var dupeFreeCredits = credits.DistinctBy(m => m.PerformerForeignId).ToList();
+
+            dupeFreeCredits.ForEach(c => c.Id = existingCredits.FirstOrDefault(t => t.PerformerForeignId == c.PerformerForeignId)?.Id ?? 0);
+
+            var insert = dupeFreeCredits.Where(t => t.Id == 0).ToList();
+            var update = dupeFreeCredits.Where(t => t.Id > 0).ToList();
+            var delete = existingCredits.Where(t => !dupeFreeCredits.Any(c => c.PerformerForeignId == t.PerformerForeignId)).ToList();
+
+            _creditRepo.DeleteMany(delete);
+            _creditRepo.UpdateMany(update);
+            _creditRepo.InsertMany(insert);
+
+            return credits;
+        }
+
+        public void HandleAsync(MoviesDeletedEvent message)
+        {
+            // TODO handle metadata deletions and not movie deletions
+            _creditRepo.DeleteForMovies(message.Movies.Select(m => m.MovieMetadataId).ToList());
+        }
+    }
+}

--- a/src/NzbDrone.Core/Movies/MovieMetadata.cs
+++ b/src/NzbDrone.Core/Movies/MovieMetadata.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Equ;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.MetadataSource.SkyHook.Resource;
+using NzbDrone.Core.Movies.Credits;
 
 namespace NzbDrone.Core.Movies
 {

--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -6,6 +6,7 @@ using NzbDrone.Core.Datastore;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies.AlternativeTitles;
+using NzbDrone.Core.Movies.Credits;
 using NzbDrone.Core.Profiles.Qualities;
 using NzbDrone.Core.Qualities;
 
@@ -205,7 +206,8 @@ namespace NzbDrone.Core.Movies
         {
             var builder = new SqlBuilder(_database.DatabaseType)
                 .Join<Movie, MovieMetadata>((m, p) => m.MovieMetadataId == p.Id)
-                .Where($"\"MovieMetadata\".\"Credits\" LIKE \'%{performerForeignId}%\'");
+                .Join<MovieMetadata, Credit>((m, p) => m.Id == p.MovieMetadataId)
+                .Where<Credit>(x => x.PerformerForeignId == performerForeignId);
 
             return _database.QueryJoined<Movie, MovieMetadata>(
                 builder,

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -15,6 +15,7 @@ using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.MetadataSource;
 using NzbDrone.Core.Movies.AlternativeTitles;
 using NzbDrone.Core.Movies.Commands;
+using NzbDrone.Core.Movies.Credits;
 using NzbDrone.Core.Movies.Events;
 using NzbDrone.Core.Movies.Performers;
 using NzbDrone.Core.Movies.Studios;
@@ -32,6 +33,7 @@ namespace NzbDrone.Core.Movies
         private readonly IBuildMoviePaths _buildMoviePaths;
         private readonly IAlternativeTitleService _titleService;
         private readonly IAddPerformerService _performerService;
+        private readonly ICreditService _creditService;
         private readonly IAddStudioService _studioService;
         private readonly IEventAggregator _eventAggregator;
         private readonly IDiskScanService _diskScanService;
@@ -49,6 +51,7 @@ namespace NzbDrone.Core.Movies
                                     IAlternativeTitleService titleService,
                                     IAddStudioService studioService,
                                     IAddPerformerService performerService,
+                                    ICreditService creditService,
                                     IEventAggregator eventAggregator,
                                     IDiskScanService diskScanService,
                                     ICheckIfMovieShouldBeRefreshed checkIfMovieShouldBeRefreshed,
@@ -65,6 +68,7 @@ namespace NzbDrone.Core.Movies
             _titleService = titleService;
             _studioService = studioService;
             _performerService = performerService;
+            _creditService = creditService;
             _eventAggregator = eventAggregator;
             _diskScanService = diskScanService;
             _checkIfMovieShouldBeRefreshed = checkIfMovieShouldBeRefreshed;
@@ -125,8 +129,7 @@ namespace NzbDrone.Core.Movies
             movieMetadata.ItemType = movieInfo.ItemType;
             movieMetadata.MetadataSource = movieInfo.MetadataSource;
             movieMetadata.Credits = movieInfo.Credits;
-
-            // movie.Genres = movieInfo.Genres;
+            movieMetadata.Genres = movieInfo.Genres;
             movieMetadata.Website = movieInfo.Website;
 
             movieMetadata.Year = movieInfo.Year;
@@ -171,6 +174,7 @@ namespace NzbDrone.Core.Movies
             _performerService.AddPerformers(performerInfo, true);
 
             _movieMetadataService.Upsert(movieMetadata);
+            _creditService.UpdateCredits(movieInfo.Credits, movieMetadata);
 
             movie.MovieMetadata = movieMetadata;
 

--- a/src/Whisparr.Api.V3/Credits/CreditController.cs
+++ b/src/Whisparr.Api.V3/Credits/CreditController.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Credits;
+using Whisparr.Http;
+using Whisparr.Http.REST;
+
+namespace NzbDrone.Api.V3.Credits
+{
+    [V3ApiController]
+    public class CreditController : RestController<CreditResource>
+    {
+        private readonly ICreditService _creditService;
+        private readonly IMovieService _movieService;
+        private readonly IMapCoversToLocal _coverMapper;
+
+        public CreditController(ICreditService creditService, IMovieService movieService, IMapCoversToLocal coverMapper)
+        {
+            _creditService = creditService;
+            _movieService = movieService;
+            _coverMapper = coverMapper;
+        }
+
+        protected override CreditResource GetResourceById(int id)
+        {
+            return _creditService.GetById(id).ToResource();
+        }
+
+        [HttpGet]
+        public List<CreditResource> GetCredits(int? movieId, int? movieMetadataId, string performerId)
+        {
+            if (movieMetadataId.HasValue)
+            {
+                return MapToResource(_creditService.GetAllCreditsForMovieMetadata(movieMetadataId.Value)).ToList();
+            }
+
+            if (movieId.HasValue)
+            {
+                var movie = _movieService.GetMovie(movieId.Value);
+
+                return MapToResource(_creditService.GetAllCreditsForMovieMetadata(movie.MovieMetadataId)).ToList();
+            }
+
+            if (performerId.IsNotNullOrWhiteSpace())
+            {
+                return MapToResource(_creditService.GetPerformerMovies(performerId)).ToList();
+            }
+
+            return MapToResource(_creditService.GetAllCredits()).ToList();
+        }
+
+        private IEnumerable<CreditResource> MapToResource(IEnumerable<Credit> credits)
+        {
+            foreach (var currentCredits in credits)
+            {
+                var resource = currentCredits.ToResource();
+                if (resource.Images.Any())
+                {
+                    _coverMapper.ConvertToLocalUrls(0, resource.Images);
+                }
+
+                yield return resource;
+            }
+        }
+    }
+}

--- a/src/Whisparr.Api.V3/Credits/CreditResource.cs
+++ b/src/Whisparr.Api.V3/Credits/CreditResource.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.Movies.Credits;
+using Whisparr.Http.REST;
+
+namespace NzbDrone.Api.V3.Credits
+{
+    public class CreditResource : RestResource
+    {
+        public CreditResource()
+        {
+            Images = new List<MediaCover>();
+        }
+
+        public string PersonName { get; set; }
+        public string PerformerForeignId { get; set; }
+        public int MovieMetadataId { get; set; }
+        public List<MediaCover> Images { get; set; }
+        public string Job { get; set; }
+        public string Character { get; set; }
+        public int Order { get; set; }
+        public CreditType Type { get; set; }
+    }
+
+    public static class CreditResourceMapper
+    {
+        public static CreditResource ToResource(this Credit model)
+        {
+            if (model == null)
+            {
+                return null;
+            }
+
+            return new CreditResource
+            {
+                Id = model.Id,
+                MovieMetadataId = model.MovieMetadataId,
+                PerformerForeignId = model.PerformerForeignId,
+                PersonName = model.Performer?.Name,
+                Character = model.Character,
+                Order = model.Order,
+                Type = model.Type
+            };
+        }
+
+        public static List<CreditResource> ToResource(this IEnumerable<Credit> credits)
+        {
+            return credits.Select(ToResource).ToList();
+        }
+
+        public static Credit ToModel(this CreditResource resource)
+        {
+            if (resource == null)
+            {
+                return null;
+            }
+
+            return new Credit
+            {
+                Id = resource.Id,
+                MovieMetadataId = resource.MovieMetadataId,
+                Character = resource.Character,
+                PerformerForeignId = resource.PerformerForeignId,
+                Order = resource.Order,
+                Type = resource.Type
+            };
+        }
+    }
+}

--- a/src/Whisparr.Api.V3/Movies/MovieResource.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieResource.cs
@@ -7,6 +7,7 @@ using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Movies.Credits;
 using NzbDrone.Core.Parser;
 using Whisparr.Api.V3.MovieFiles;
 using Whisparr.Api.V3.Movies;
@@ -18,6 +19,7 @@ namespace Whisparr.Api.V3.Movies
     {
         public MovieResource()
         {
+            Genres = new List<string>();
             Monitored = true;
         }
 

--- a/src/Whisparr.Api.V3/Performers/PerformerResource.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerResource.cs
@@ -25,6 +25,18 @@ namespace Whisparr.Api.V3.Performers
         public HashSet<int> Tags { get; set; }
         public string RemotePoster { get; internal set; }
         public DateTime Added { get; internal set; }
+        public bool HasMovies { get; set; }
+        public bool HasScenes { get; set; }
+        public int TotalSceneCount { get; internal set; }
+        public int SceneCount { get; set; }
+        public List<StudioResource> Studios { get; set; }
+        public long SizeOnDisk { get; set; }
+    }
+
+    public class StudioResource
+    {
+        public string Title { get; set; }
+        public string ForeignId { get; set; }
     }
 
     public static class PerformerResourceMapper

--- a/src/Whisparr.Api.V3/Search/SearchResource.cs
+++ b/src/Whisparr.Api.V3/Search/SearchResource.cs
@@ -1,6 +1,5 @@
 using Whisparr.Api.V3.Movies;
 using Whisparr.Api.V3.Performers;
-using Whisparr.Api.V3.Studios;
 using Whisparr.Http.REST;
 
 namespace Whisparr.Api.V3.Search
@@ -11,6 +10,6 @@ namespace Whisparr.Api.V3.Search
         public string ForeignId { get; set; }
         public MovieResource Movie { get; set; }
         public PerformerResource Performer { get; set; }
-        public StudioResource Studio { get; set; }
+        public Studios.StudioResource Studio { get; set; }
     }
 }

--- a/src/Whisparr.Api.V3/Studios/StudioResource.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioResource.cs
@@ -21,6 +21,12 @@ namespace Whisparr.Api.V3.Studios
         public int QualityProfileId { get; set; }
         public bool SearchOnAdd { get; set; }
         public HashSet<int> Tags { get; set; }
+        public bool HasMovies { get; set; }
+        public bool HasScenes { get; set; }
+        public int TotalSceneCount { get; internal set; }
+        public int SceneCount { get; set; }
+        public List<int> Years { get; set; }
+        public long SizeOnDisk { get; set; }
         public string RemotePoster { get; internal set; }
     }
 


### PR DESCRIPTION
#### Database Migration
YES - 008 

#### Description
Radarr uses a credits table to store, and has an endpoint to return the data. This data needs to be populated via a movie refresh before it can be used.

Allow GetByPerformerForeignId to use the database structure to return a list of movies, compared to a like statement.

Provide additional stats when retrieving a single studio or performer. (Can now be used with stasharr)

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX