### PR TITLE
Fix: Load optimized image thumbnails on scene index view

### DIFF
--- a/frontend/src/Scene/Index/Overview/SceneIndexOverview.tsx
+++ b/frontend/src/Scene/Index/Overview/SceneIndexOverview.tsx
@@ -150,7 +150,7 @@ function SceneIndexOverview(props: SceneIndexOverviewProps) {
                 className={styles.poster}
                 style={elementStyle}
                 images={images}
-                size={250}
+                size={180}
                 lazy={false}
                 overflow={true}
               />

--- a/frontend/src/Scene/Index/Posters/SceneIndexPoster.tsx
+++ b/frontend/src/Scene/Index/Posters/SceneIndexPoster.tsx
@@ -179,7 +179,7 @@ function SceneIndexPoster(props: SceneIndexPosterProps) {
             blur={safeForWorkMode}
             style={elementStyle}
             images={images}
-            size={250}
+            size={180}
             lazy={false}
             overflow={true}
             onError={onPosterLoadError}


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Expanding on #462, this change allows Whisparr to use the resized cover images for scenes on the scene index page.  This should further improve the load time when using the posters or overview views on this page.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)