### PR TITLE
New: Cache API to memory Movie and Performer Resources

### DIFF
--- a/frontend/src/Settings/General/WhisparrSettings.js
+++ b/frontend/src/Settings/General/WhisparrSettings.js
@@ -15,7 +15,8 @@ function WhisparrSettings(props) {
   } = props;
 
   const {
-    whisparrAutoMatchOnDate
+    whisparrAutoMatchOnDate,
+    whisparrCacheMovieAPI
   } = settings;
 
   if (!advancedSettings) {
@@ -36,6 +37,20 @@ function WhisparrSettings(props) {
           helpText={translate('WhisparrAutoMatchOnDateHelpText')}
           onChange={onInputChange}
           {...whisparrAutoMatchOnDate}
+        />
+      </FormGroup>
+      <FormGroup
+        advancedSettings={advancedSettings}
+        isAdvanced={true}
+      >
+        <FormLabel>{translate('WhisparrCacheMovieAPI')}</FormLabel>
+
+        <FormInputGroup
+          type={inputTypes.CHECK}
+          name="whisparrCacheMovieAPI"
+          helpText={translate('WhisparrCacheMovieAPIHelpText')}
+          onChange={onInputChange}
+          {...whisparrCacheMovieAPI}
         />
       </FormGroup>
     </FieldSet>

--- a/src/NzbDrone.Common/Cache/ICached.cs
+++ b/src/NzbDrone.Common/Cache/ICached.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace NzbDrone.Common.Cache
 {
@@ -18,5 +19,6 @@ namespace NzbDrone.Common.Cache
         T Find(string key);
 
         ICollection<T> Values { get; }
+        SemaphoreSlim Lock { get; }
     }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -477,7 +477,7 @@ namespace NzbDrone.Core.Configuration
 
             set { SetValue("WhisparrCacheMovieAPI", value); }
         }
-        
+
         public bool WhisparrValidateRuntime
         {
             get { return GetValueBoolean("WhisparrValidateRuntime", false); }

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -471,6 +471,13 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("WhisparrAutoMatchOnDate", value); }
         }
 
+        public bool WhisparrCacheMovieAPI
+        {
+            get { return GetValueBoolean("WhisparrCacheMovieAPI", false); }
+
+            set { SetValue("WhisparrCacheMovieAPI", value); }
+        }
+
         private string GetValue(string key)
         {
             return GetValue(key, string.Empty);

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -108,6 +108,7 @@ namespace NzbDrone.Core.Configuration
 
         // Whisparr
         bool WhisparrAutoMatchOnDate { get; }
+        bool WhisparrCacheMovieAPI { get; }
 
         CertificateValidationType CertificateValidation { get; }
         string ApplicationUrl { get; }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1804,6 +1804,8 @@
   "WhatsNew": "What's new?",
   "WhisparrAutoMatchOnDate": "Match scene on Date Only",
   "WhisparrAutoMatchOnDateHelpText": "If checked Whisparr will accept a scene on just studio and date. Can cause false positives",
+  "WhisparrCacheMovieAPI": "Cache Movie API",
+  "WhisparrCacheMovieAPIHelpText": "Cache API calls to movie/scene",
   "WhisparrCalendarFeed": "{appName} Calendar Feed",
   "WhisparrSupportsAnyDownloadClient": "{appName} supports many popular torrent and usenet download clients.",
   "WhisparrSupportsAnyIndexer": "{appName} supports any indexer that uses the Newznab standard, as well as other indexers listed below.",

--- a/src/NzbDrone.Core/Movies/Performers/PerformerRepository.cs
+++ b/src/NzbDrone.Core/Movies/Performers/PerformerRepository.cs
@@ -9,6 +9,7 @@ namespace NzbDrone.Core.Movies.Performers
     public interface IPerformerRepository : IBasicRepository<Performer>
     {
         Performer FindByForeignId(string foreignId);
+        List<Performer> FindByForeignIds(List<string> foreignIds);
         List<string> AllPerformerForeignIds();
     }
 
@@ -22,6 +23,11 @@ namespace NzbDrone.Core.Movies.Performers
         public Performer FindByForeignId(string foreignId)
         {
             return Query(x => x.ForeignId == foreignId).FirstOrDefault();
+        }
+
+        public List<Performer> FindByForeignIds(List<string> foreignIds)
+        {
+            return Query(x => foreignIds.Contains(x.ForeignId)).ToList();
         }
 
         public List<string> AllPerformerForeignIds()

--- a/src/Whisparr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Whisparr.Api.V3/Config/HostConfigResource.cs
@@ -45,6 +45,7 @@ namespace Whisparr.Api.V3.Config
         public int BackupInterval { get; set; }
         public int BackupRetention { get; set; }
         public bool WhisparrAutoMatchOnDate { get; set; }
+        public bool WhisparrCacheMovieAPI { get; set; }
     }
 
     public static class HostConfigResourceMapper
@@ -89,7 +90,8 @@ namespace Whisparr.Api.V3.Config
                 BackupInterval = configService.BackupInterval,
                 BackupRetention = configService.BackupRetention,
                 ApplicationUrl = configService.ApplicationUrl,
-                WhisparrAutoMatchOnDate = configService.WhisparrAutoMatchOnDate
+                WhisparrAutoMatchOnDate = configService.WhisparrAutoMatchOnDate,
+                WhisparrCacheMovieAPI = configService.WhisparrCacheMovieAPI
             };
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Cache Performer and Movie Resources to memory, so they are faster to returned one populated. 

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX