### PR TITLE
New: Performer Aliases Naming Token

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -88,6 +88,9 @@ const sceneTokens = [
   { token: '{Scene Performers}', example: 'Abigail Mac Tera Patrick John Holmes' },
   { token: '{Scene PerformersFemale}', example: 'Abigail Mac Tera Patrick' },
   { token: '{Scene PerformersMale}', example: 'Johnny Sins' },
+  { token: '{Scene PerformersAlias}', example: 'Performers (Alias)' },
+  { token: '{Scene PerformersFemaleAlias}', example: 'Female Performers (Alias)' },
+  { token: '{Scene PerformersMaleAlias}', example: 'Male Performers (Alias)' },
   { token: '{Release Date}', example: '2009-02-04' },
   { token: '{Release ShortDate}', example: '09 02 04' }
 ];

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -54,7 +54,12 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                 new Credit { Performer = new CreditPerformer { Name = "Hollywood Cash", Gender = Gender.Female } },
                 new Credit { Performer = new CreditPerformer { Name = "Monique Alexander", Gender = Gender.Female } },
                 new Credit { Performer = new CreditPerformer { Name = "Abigaiil Morris", Gender = Gender.Female } },
-                new Credit { Performer = new CreditPerformer { Name = "Luna Star", Gender = Gender.Female } }
+                new Credit { Performer = new CreditPerformer { Name = "Luna Star", Gender = Gender.Female } },
+                new Credit { Character = "Luna", Performer = new CreditPerformer { Name = "Luna Star", Gender = Gender.Female } },
+                new Credit { Character = "Johnny Hammer", Performer = new CreditPerformer { Name = "Johnny Sins", Gender = Gender.Male } },
+                new Credit { Character = "", Performer = new CreditPerformer { Name = "Angela White", Gender = Gender.Female } },
+                new Credit { Character = "Scott the Hammer", Performer = new CreditPerformer { Name = "Scott Nails", Gender = Gender.Male } },
+                new Credit { Character = null, Performer = new CreditPerformer { Name = "Manuel Ferrara", Gender = Gender.Male } }
             };
 
             _movie = Builder<Movie>
@@ -100,6 +105,36 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
         private void GivenReal()
         {
             _movieFile.Quality.Revision.Real = 1;
+        }
+
+        [Test]
+        public void scene_performers_alias_format()
+        {
+            _namingConfig.StandardSceneFormat = "{Studio Title} - {Release-Date} - {Scene Title} [{Scene PerformersAlias}]";
+
+            // Aliases should be used if present, otherwise fallback to real name.
+            Subject.BuildFileName(_scene, _movieFile)
+                .Should().Be("Brazzers Exxtra - 2024-06-20 - Brazzers Presents 20 For 20 [Luna Johnny Hammer Angela White Scott the Hammer]");
+        }
+
+        [Test]
+        public void scene_female_performers_alias_format()
+        {
+            _namingConfig.StandardSceneFormat = "{Studio Title} - {Release-Date} - {Scene Title} [{Scene PerformersFemaleAlias}]";
+
+            // Only female aliases, fallback to real name if alias is not present
+            Subject.BuildFileName(_scene, _movieFile)
+                .Should().Be("Brazzers Exxtra - 2024-06-20 - Brazzers Presents 20 For 20 [Luna Angela White]");
+        }
+
+        [Test]
+        public void scene_male_performers_alias_format()
+        {
+            _namingConfig.StandardSceneFormat = "{Studio Title} - {Release-Date} - {Scene Title} [{Scene PerformersMaleAlias}]";
+
+            // Only male aliases, fallback to real name if alias is not present
+            Subject.BuildFileName(_scene, _movieFile)
+                .Should().Be("Brazzers Exxtra - 2024-06-20 - Brazzers Presents 20 For 20 [Johnny Hammer Scott the Hammer Manuel Ferrara]");
         }
 
         [Test]

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -384,6 +384,20 @@ namespace NzbDrone.Core.Organizer
                     .Select(p => p.Performer.Name)
                     .Take(4)
                     .Join(" ");
+                tokenHandlers["{Scene PerformersFemaleAlias}"] = m => credits.Where(p => p.Performer.Gender == Gender.Female)
+                    .OrderBy(p => p.Performer.Name)
+                    .Select(p => !string.IsNullOrWhiteSpace(p.Character) ? p.Character : p.Performer.Name)
+                    .Take(4)
+                    .Join(" ");
+                tokenHandlers["{Scene PerformersMaleAlias}"] = m => credits.Where(p => p.Performer.Gender == Gender.Male)
+                    .OrderBy(p => p.Performer.Name)
+                    .Select(p => !string.IsNullOrWhiteSpace(p.Character) ? p.Character : p.Performer.Name)
+                    .Take(4)
+                    .Join(" ");
+                tokenHandlers["{Scene PerformersAlias}"] = m => credits.OrderBy(p => p.Performer.Name)
+                    .Select(p => !string.IsNullOrWhiteSpace(p.Character) ? p.Character : p.Performer.Name)
+                    .Take(4)
+                    .Join(" ");
             }
         }
 


### PR DESCRIPTION
Adding in performer aliases as a naming token. If no alias is found it will revert to the main performer name.

* Fixes #477 