### PR TITLE
NEW: Add ShowOnlyUnmatched filter

### DIFF
--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.tsx
@@ -252,6 +252,7 @@ function InteractiveImportModalContent(
     createClientSideCollectionSelector('interactiveImport')
   );
 
+  const [showOnlyUnmatched, setShowOnlyUnmatched] = useState(false);
   const { isDeleting, deleteError } = useSelector(episodeFilesInfoSelector);
   const importMode = useSelector(importModeSelector);
 
@@ -398,6 +399,10 @@ function InteractiveImportModalContent(
       setWithoutEpisodeFileIdRowsSelected,
     ]
   );
+
+  const onShowOnlyUnmatchedToggle = useCallback(() => {
+    setShowOnlyUnmatched((prev) => !prev);
+  }, []);
 
   const onValidRowChange = useCallback(
     (id: number, isValid: boolean) => {
@@ -732,6 +737,10 @@ function InteractiveImportModalContent(
     error,
     translate('InteractiveImportLoadError')
   );
+  const filteredItems = useMemo(() => {
+    if (!showOnlyUnmatched) return items;
+    return items.filter((item) => item.episodes.length === 0);
+  }, [items, showOnlyUnmatched]);
 
   return (
     <ModalContent onModalClose={onModalClose}>
@@ -774,11 +783,22 @@ function InteractiveImportModalContent(
           </div>
         )}
 
+        <div className={styles.filterContainer}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <input
+              type="checkbox"
+              checked={showOnlyUnmatched}
+              onChange={onShowOnlyUnmatchedToggle}
+            />
+            {translate('ShowOnlyUnmatched')}
+          </label>
+        </div>
+
         {isFetching ? <LoadingIndicator /> : null}
 
         {error ? <div>{errorMessage}</div> : null}
 
-        {isPopulated && !!items.length && !isFetching && !isFetching ? (
+        {isPopulated && !!filteredItems.length && !isFetching ? (
           <Table
             columns={columns}
             horizontalScroll={true}
@@ -791,25 +811,23 @@ function InteractiveImportModalContent(
             onSelectAllChange={onSelectAllChange}
           >
             <TableBody>
-              {items.map((item) => {
-                return (
-                  <InteractiveImportRow
-                    key={item.id}
-                    isSelected={selectedState[item.id]}
-                    {...item}
-                    allowSeriesChange={allowSeriesChange}
-                    columns={columns}
-                    modalTitle={modalTitle}
-                    onSelectedChange={onSelectedChange}
-                    onValidRowChange={onValidRowChange}
-                  />
-                );
-              })}
+              {filteredItems.map((item) => (
+                <InteractiveImportRow
+                  key={item.id}
+                  isSelected={selectedState[item.id]}
+                  {...item}
+                  allowSeriesChange={allowSeriesChange}
+                  columns={columns}
+                  modalTitle={modalTitle}
+                  onSelectedChange={onSelectedChange}
+                  onValidRowChange={onValidRowChange}
+                />
+              ))}
             </TableBody>
           </Table>
         ) : null}
 
-        {isPopulated && !items.length && !isFetching
+        {isPopulated && !filteredItems.length && !isFetching
           ? translate('InteractiveImportNoFilesFound')
           : null}
       </ModalBody>


### PR DESCRIPTION
Adds in the ability to filter by unmatched files in "Manage Episodes" section. As you can see in the images, when the box is checked, anything that was either automatically or manually matched gets hidden from the list to make it easier to look at and scroll through.

* Fixes #62

Unfiltered:
![unfiltered](https://github.com/user-attachments/assets/dcbde7c3-cf25-4254-b2c8-ac24eb3c3f1c)

Filtered: 

![filtered](https://github.com/user-attachments/assets/2e9d5e45-bc89-45a5-925f-faa1a2e2a715)


