### PR TITLE
Fix: Exception handling when Skyhook is unreachable

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             var whisparrMetadata = configFileProvider.WhisparrMetadata;
             if (whisparrMetadata.IsNullOrWhiteSpace())
             {
-                whisparrMetadata  = "https://api.whisparr.com/v4/{route}";
+                whisparrMetadata = "https://api.whisparr.com/v4/{route}";
             }
 
             logger.Info($"Using WhisparrMetadata {whisparrMetadata}");
@@ -546,9 +546,17 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                     .Build();
 
                 request.AllowAutoRedirect = true;
-                request.SuppressHttpError = true;
 
-                var httpResponse = _httpClient.Get<List<MovieResource>>(request);
+                HttpResponse<List<MovieResource>> httpResponse;
+                try
+                {
+                    httpResponse = _httpClient.Get<List<MovieResource>>(request);
+                }
+                catch (HttpException ex)
+                {
+                    _logger.Warn(ex);
+                    throw new SkyHookException("Search for '{0}' failed. Unable to communicate with StashDb.", ex, title);
+                }
 
                 var performersAdded = new List<string>();
                 var studiosAdded = new List<string>();


### PR DESCRIPTION
#### Database Migration
NO

#### Description
With the recent short outage in Skyhook v4, an issue showed pretty poorly in Scene Search, where it was throwing an obscure error for users.  This was due to SkyhookProxy.cs having HTTP errors suppressed for this function, and having no exception handling.  To combat this, I:

1. Disabled HTTP error suppression for this function
2. Wrapped the Skyhook API call in a try...catch
3. Throw a Skyhook exception if there is an HTTP error in search

Reviewers: I don't know if SKyhook would respond with a non-2XX response in a normal use case of rthe `search` endpoint, as I am not aware of any documentation for the Skyhook API's operations.  If there is a legit use case for this to return a non-2XX response, I'll rework this change to accomodate.

#### Screenshot (if UI related)
<img width="800" alt="image" src="https://github.com/user-attachments/assets/7d737367-11b9-4702-91f8-86deb51a911c" />

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)