### PR TITLE
Fix: Correct QualityProfile if not known

### DIFF
--- a/src/NzbDrone.Core/Movies/MovieRepository.cs
+++ b/src/NzbDrone.Core/Movies/MovieRepository.cs
@@ -101,8 +101,7 @@ namespace NzbDrone.Core.Movies
                 {
                     movie.MovieFile = file;
                     movie.MovieMetadata = metadata;
-                    movie.QualityProfile = profiles[movie.QualityProfileId];
-
+                    movie.QualityProfile = profiles.ContainsKey(movie.QualityProfileId) ? profiles[movie.QualityProfileId] : profiles.First().Value;
                     return movie;
                 });
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Check that the profile exists, otherwise use the first defined quality profile. A null value displayed the first profile, so it should just be assigned so the backend behaves the way the data is displayed.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #455 