### PR TITLE
Fix: Handle duplicate studios during library import

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/SceneDiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/SceneDiskScanService.cs
@@ -183,7 +183,7 @@ namespace NzbDrone.Core.MediaFiles
                     Title = m.MovieMetadata.Value.StudioTitle,
                     RootFolderPath = m.RootFolderPath,
                     Monitored = false,
-                }).ToList());
+                }).ToList(), true);
 
                 _commandQueueManager.PushMany(scene_list.Select(s => new AddMoviesCommand(new List<Movie> { s })).ToList());
             }
@@ -242,7 +242,7 @@ namespace NzbDrone.Core.MediaFiles
 
         public List<string> FilterPaths(string basePath, IEnumerable<string> paths, bool filterExtras = true)
         {
-            var filteredPaths =  paths.Where(path => !ExcludedSubFoldersRegex.IsMatch(basePath.GetRelativePath(path)))
+            var filteredPaths = paths.Where(path => !ExcludedSubFoldersRegex.IsMatch(basePath.GetRelativePath(path)))
                                       .Where(path => !ExcludedFilesRegex.IsMatch(Path.GetFileName(path)))
                                       .ToList();
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fix recommended by @sampulsar to counter exceptions for adding studios while using library import.  The second line was just my editor trimming an errant extra space.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #510 