### PR TITLE
Fix: Studio logos use local cache

### DIFF
--- a/frontend/src/Movie/MovieImage.js
+++ b/frontend/src/Movie/MovieImage.js
@@ -10,7 +10,7 @@ function findImage(images, coverType) {
 
 function getUrl(image, coverType, size) {
   let imageUrl = image?.url ?? image?.remoteUrl;
-  if (coverType === 'clearlogo') {
+  if (coverType === 'clearlogo' && imageUrl.startsWith('/MediaCoverProxy/')) {
     imageUrl = image?.remoteUrl;
   }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When @Tom-Estes pushed #451 , it effectively negated my changes in #186 , as it had an uninteneded side effect of always loading Studio logos from StashDB remotely.  This change adds a simple tweak to allow for remote load when searching for a studio, which accounts for a more complex design issue with MediaCoverProxy always setting the file extension to .jpg.  

For Studios, the logo can be .jpg, .png, or .svg .  #186 handles this properly for the other studio views, but this isn't possible on search without reworking MediaCoverProxy.

It's an edge case, but I think this is a better fix with less effort.  If this isn't acceptable, I guess I can add mimetype detection to MediaCoverProxy.cs , but I feel like it's overkill.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)