### PR TITLE
Fix: Remove HTTP HEAD requests for StashDB images

### DIFF
--- a/src/NzbDrone.Core.Test/MediaCoverTests/CoverExistsSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaCoverTests/CoverExistsSpecificationFixture.cs
@@ -40,27 +40,11 @@ namespace NzbDrone.Core.Test.MediaCoverTests
         }
 
         [Test]
-        public void should_return_false_if_file_exists_but_diffrent_size()
-        {
-            GivenExistingFileSize(100);
-            _httpResponse.Headers.ContentLength = 200;
-
-            Subject.AlreadyExists("http://url", "c:\\file.exe").Should().BeFalse();
-        }
-
-        [Test]
         public void should_return_true_if_file_exists_and_same_size_and_not_corrupt()
         {
             GivenExistingFileSize(100);
             _httpResponse.Headers.ContentLength = 100;
             Subject.AlreadyExists("http://url", "c:\\file.exe").Should().BeTrue();
-        }
-
-        [Test]
-        public void should_return_true_if_there_is_no_size_header_and_file_exist()
-        {
-            GivenExistingFileSize(100);
-            Subject.AlreadyExists("http://url", "c:\\file.exe").Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Core/MediaCover/CoverAlreadyExistsSpecification.cs
+++ b/src/NzbDrone.Core/MediaCover/CoverAlreadyExistsSpecification.cs
@@ -24,14 +24,7 @@ namespace NzbDrone.Core.MediaCover
 
         public bool AlreadyExists(string url, string path)
         {
-            if (!_diskProvider.FileExists(path))
-            {
-                return false;
-            }
-
-            var headers = _httpClient.Head(new HttpRequest(url)).Headers;
-            var fileSize = _diskProvider.GetFileSize(path);
-            return fileSize == headers.ContentLength;
+            return _diskProvider.FileExists(path);
         }
     }
 }

--- a/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
+++ b/src/NzbDrone.Core/MediaCover/MediaCoverService.cs
@@ -484,7 +484,7 @@ namespace NzbDrone.Core.MediaCover
         {
             var fileName = GetMovieCoverPath(movie.Id, cover.CoverType);
 
-            _logger.Info("Downloading {0} for {1} {2}", cover.CoverType, movie, cover.RemoteUrl);
+            _logger.Info("Downloading {0} for {1} {2}", cover.CoverType, movie.ToString(), cover.RemoteUrl);
             _httpClient.DownloadFile(cover.RemoteUrl, fileName);
         }
 
@@ -492,13 +492,14 @@ namespace NzbDrone.Core.MediaCover
         {
             var fileName = GetPerformerCoverPath(performer.Id, cover.CoverType);
 
-            _logger.Info("Downloading {0} for {1} {2}", cover.CoverType, performer, cover.RemoteUrl);
+            _logger.Info("Downloading {0} for {1} {2}", cover.CoverType, performer.ToString(), cover.RemoteUrl);
             _httpClient.DownloadFile(cover.RemoteUrl, fileName);
         }
 
         private void DownloadCover(Studio studio, MediaCover cover)
         {
             var req = new HttpRequest(cover.RemoteUrl);
+            _logger.Info("Downloading {0} for {1} {2}", cover.CoverType, studio.ToString(), cover.RemoteUrl);
             var imageResponse = _httpClient.Execute(req);
             var extension = imageResponse.Headers.ContentType switch
             {

--- a/src/NzbDrone.Core/Movies/Performers/Performer.cs
+++ b/src/NzbDrone.Core/Movies/Performers/Performer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.Movies.Performers
@@ -40,6 +41,11 @@ namespace NzbDrone.Core.Movies.Performers
 
             RootFolderPath = otherPerformer.RootFolderPath;
             Tags = otherPerformer.Tags;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("[{0}]", Name.NullSafe());
         }
     }
 

--- a/src/NzbDrone.Core/Movies/Studios/Studio.cs
+++ b/src/NzbDrone.Core/Movies/Studios/Studio.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.Movies.Studios
@@ -43,6 +44,11 @@ namespace NzbDrone.Core.Movies.Studios
 
             RootFolderPath = otherStudio.RootFolderPath;
             Tags = otherStudio.Tags;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("[{0}]", Title.NullSafe());
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
- Removed HEAD requests for fetching cover images from StashDB.  They don't allow them and they also don't update existing images.  Whisparr will still download (once) and serve local images, which is basically what is happening already due to these HEAD request failures.
- (Slightly) Improved logging output when downloading cover images
- This applies to Studio, Performer, and Scene/Movie

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #517 