### PR TITLE
Fix: Studio index will fail to load if some studios have bad cover image data

### DIFF
--- a/frontend/src/Movie/MovieImage.js
+++ b/frontend/src/Movie/MovieImage.js
@@ -10,7 +10,7 @@ function findImage(images, coverType) {
 
 function getUrl(image, coverType, size) {
   let imageUrl = image?.url ?? image?.remoteUrl;
-  if (coverType === 'clearlogo' && imageUrl.startsWith('/MediaCoverProxy/')) {
+  if (coverType === 'clearlogo' && imageUrl?.startsWith('/MediaCoverProxy/')) {
     imageUrl = image?.remoteUrl;
   }
 


### PR DESCRIPTION
…age data

#### Database Migration
NO

#### Description
Quick fix on this function.  It was fine in local build, but seemed to have issues in a larger deployment.  I don't really understand how a studio could be missing both a local and remote URL for the cover image, but this should account for that gracefully.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)