### PR TITLE
New: Adding Scene Code as Naming Token

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -92,7 +92,8 @@ const sceneTokens = [
   { token: '{Scene PerformersFemaleAlias}', example: 'Female Performers (Alias)' },
   { token: '{Scene PerformersMaleAlias}', example: 'Male Performers (Alias)' },
   { token: '{Release Date}', example: '2009-02-04' },
-  { token: '{Release ShortDate}', example: '09 02 04' }
+  { token: '{Release ShortDate}', example: '09 02 04' },
+  { token: '{Scene ID}', example: '12345' }
 ];
 
 const studioTokens = [

--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.js
@@ -93,7 +93,7 @@ const sceneTokens = [
   { token: '{Scene PerformersMaleAlias}', example: 'Male Performers (Alias)' },
   { token: '{Release Date}', example: '2009-02-04' },
   { token: '{Release ShortDate}', example: '09 02 04' },
-  { token: '{Scene ID}', example: '12345' }
+  { token: '{Scene Code}', example: '12345' }
 ];
 
 const studioTokens = [

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -403,11 +403,11 @@ namespace NzbDrone.Core.Organizer
             if (!string.IsNullOrWhiteSpace(movie.MovieMetadata.Value.Code))
             {
                 var code = movie.MovieMetadata.Value.Code;
-                tokenHandlers["{Scene ID}"] = m => code;
+                tokenHandlers["{Scene Code}"] = m => code;
             }
             else
             {
-                tokenHandlers["{Scene ID}"] = m => string.Empty;
+                tokenHandlers["{Scene Code}"] = m => string.Empty;
             }
         }
 

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -399,6 +399,16 @@ namespace NzbDrone.Core.Organizer
                     .Take(4)
                     .Join(" ");
             }
+
+            if (!string.IsNullOrWhiteSpace(movie.MovieMetadata.Value.Code))
+            {
+                var code = movie.MovieMetadata.Value.Code;
+                tokenHandlers["{Scene ID}"] = m => code;
+            }
+            else
+            {
+                tokenHandlers["{Scene ID}"] = m => string.Empty;
+            }
         }
 
         private void AddSceneTitlePlaceholderTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie)


### PR DESCRIPTION
Adds in the ability to use the scene code as a naming token. If the token is Null from Skyhook then it will just be blank.


* Fixes #472