### PR TITLE
Fix: Search Results Credits for existing enteries

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -816,13 +816,13 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             if (movie == null)
             {
                 movie = new Movie { MovieMetadata = MapMovie(result) };
-            }
 
-            if (result.ItemType == ItemType.Scene)
-            {
-                foreach (var performer in result.Credits)
+                if (result.ItemType == ItemType.Scene)
                 {
-                    movie.MovieMetadata.Value.Credits.Add(MapCast(performer));
+                    foreach (var performer in result.Credits)
+                    {
+                        movie.MovieMetadata.Value.Credits.Add(MapCast(performer));
+                    }
                 }
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Correct the Search Result data so that credits are not duplicated if the scene exists within the Whisparr database. This data is used for the import folder scan, and can produce a bad folder name.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #523 