### PR TITLE
New: Add tags to exclusion list

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportListExclusions/EditImportListExclusionModalContent.js
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/EditImportListExclusionModalContent.js
@@ -42,7 +42,8 @@ function EditImportListExclusionModalContent(props) {
     { key: 'movie', value: translate('Movie') },
     { key: 'scene', value: translate('Scene') },
     { key: 'studio', value: translate('Studio') },
-    { key: 'performer', value: translate('Performer') }
+    { key: 'performer', value: translate('Performer') },
+    { key: 'tag', value: translate('Tag') }
   ];
 
   return (

--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.js
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusions.js
@@ -103,7 +103,8 @@ class ImportListExclusions extends Component {
       { key: 'scene', value: translate('Scene') },
       { key: 'movie', value: translate('Movie') },
       { key: 'studio', value: translate('Studio') },
-      { key: 'performer', value: translate('Performer') }
+      { key: 'performer', value: translate('Performer') },
+      { key: 'tag', value: translate('Tag') }
     ];
 
     const allIds = filteredItems.map((item) => item.id);

--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusion.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusion.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
 
         public new string ToString()
         {
-            return string.Format("Excluded Movie: [{0}][{1}][{2} {3}]", Type, ForeignId, MovieTitle, MovieYear);
+            return string.Format("Exclusion: [{0}][{1}][{2} {3}]", Type, ForeignId, MovieTitle, MovieYear);
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusionType.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusionType.cs
@@ -5,6 +5,7 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
         Scene,
         Movie,
         Studio,
-        Performer
+        Performer,
+        Tag
     }
 }

--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusionsService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusionsService.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
 
         public List<ImportExclusion> GetAllByType(ImportExclusionType type)
         {
-            return _exclusionRepository.AllByType(type);
+            return _exclusionRepository.AllByType(type) ?? new List<ImportExclusion>();
         }
 
         public bool IsExcluded(string foreignId, ImportExclusionType type)

--- a/src/NzbDrone.Core/Movies/AddMovieService.cs
+++ b/src/NzbDrone.Core/Movies/AddMovieService.cs
@@ -227,7 +227,7 @@ namespace NzbDrone.Core.Movies
                     if (excludedStudio)
                     {
                         _importExclusionService.AddExclusion(newExclusion);
-                        throw new ValidationException($"Studio: {newMovie.MovieMetadata.Value.Studio.Title} has been excluded");
+                        throw new ValidationException($"Studio: [{newMovie.MovieMetadata.Value.Studio.Title}] has been excluded");
                     }
                     else
                     {
@@ -238,7 +238,7 @@ namespace NzbDrone.Core.Movies
                             if (newMovie.MovieMetadata?.Value?.ReleaseDateUtc < dateTime)
                             {
                                 _importExclusionService.AddExclusion(newExclusion);
-                                throw new ValidationException($"Date: {newMovie.MovieMetadata?.Value.ReleaseDate} has been excluded before {dateTime.ToString("yyyy-MM-dd")}");
+                                throw new ValidationException($"Date: [{newMovie.MovieMetadata?.Value.ReleaseDate}] has been excluded before {dateTime.ToString("yyyy-MM-dd")}");
                             }
                         }
                     }
@@ -252,8 +252,18 @@ namespace NzbDrone.Core.Movies
                     if (excludedPerformers.Any())
                     {
                         _importExclusionService.AddExclusion(newExclusion);
-                        throw new ValidationException($"Performer: {string.Join(",", excludedPerformers.Select(ep => ep.MovieTitle).ToList())} has been excluded");
+                        throw new ValidationException($"Performer: [{string.Join(",", excludedPerformers.Select(ep => ep.MovieTitle).ToList())}] has been excluded");
                     }
+                }
+
+                var tagNames = newMovie.MovieMetadata.Value.Genres;
+                var excludedTags = _importExclusionService.GetAllByType(ImportExclusionType.Tag);
+                var exclusions = excludedTags.Where(e => tagNames.Contains(e.MovieTitle, StringComparer.OrdinalIgnoreCase)).ToList();
+
+                if (exclusions.Any())
+                {
+                    _importExclusionService.AddExclusion(newExclusion);
+                    throw new ValidationException($"Tag(s): [{string.Join(",", excludedTags.Select(et => et.MovieTitle).ToList())}] excluded");
                 }
             }
             else


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Users may now manually add `Tags` to `Settings > Import Lists > Import List Exclusions`.  At present, the backend code is looking at case-insensitive tag names due to limitations in the v4 Skyhook API.  Expectation is that if  Skyhook can be updated, the backend code doing the comparisons can be easily shifted to compare by foreignId without any changes needed by the user.

I also slightly tweaked the log formatting to be more legible for all exclusion types.

#### Screenshot (if UI related)

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)