### PR TITLE
Fix: Tag exclusion output logging

### DIFF
--- a/src/NzbDrone.Core/Movies/AddMovieService.cs
+++ b/src/NzbDrone.Core/Movies/AddMovieService.cs
@@ -263,7 +263,7 @@ namespace NzbDrone.Core.Movies
                 if (exclusions.Any())
                 {
                     _importExclusionService.AddExclusion(newExclusion);
-                    throw new ValidationException($"Tag(s): [{string.Join(",", excludedTags.Select(et => et.MovieTitle).ToList())}] excluded");
+                    throw new ValidationException($"Tag(s): [{string.Join(",", exclusions.Select(et => et.MovieTitle).ToList())}] excluded");
                 }
             }
             else

--- a/src/NzbDrone.Integration.Test/ApiTests/MovieEditorFixture.cs
+++ b/src/NzbDrone.Integration.Test/ApiTests/MovieEditorFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using FluentAssertions;
 using NUnit.Framework;
@@ -13,10 +14,15 @@ namespace NzbDrone.Integration.Test.ApiTests
         {
             WaitForCompletion(() => QualityProfiles.All().Count > 0);
 
-            foreach (var title in new[] { "Taboo", "Pulp Fiction" })
+            foreach (var title in new[] { "Taboo", "Sinner" })
             {
-                var newMovie = Movies.Lookup(title).First();
+                var lookupResults = Movies.Lookup(title);
+                if (!lookupResults.Any())
+                {
+                    throw new InvalidOperationException($"No movie found for title '{title}' in Movies.Lookup.");
+                }
 
+                var newMovie = lookupResults.First();
                 newMovie.QualityProfileId = 1;
                 newMovie.Path = string.Format(@"C:\Test\{0}", title).AsOsAgnostic();
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
My previous PR had a small bug in the output logging, so it was logging the names of the configured tag exclusions, not the ones that matched the scene's genres array.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)