### PR TITLE
Fix invalid root folders in edit modals

### DIFF
--- a/frontend/src/Performer/Edit/EditPerformerModalContent.js
+++ b/frontend/src/Performer/Edit/EditPerformerModalContent.js
@@ -107,7 +107,7 @@ class EditPerformerModalContent extends Component {
                     type={inputTypes.ROOT_FOLDER_SELECT}
                     name="rootFolderPath"
                     {...rootFolderPath}
-                    includeMissingValue={true}
+                    includeMissingValue={false}
                     onChange={onInputChange}
                   />
                 </FormGroup>

--- a/frontend/src/Studio/Edit/EditStudioModalContent.js
+++ b/frontend/src/Studio/Edit/EditStudioModalContent.js
@@ -124,7 +124,7 @@ class EditStudioModalContent extends Component {
                     type={inputTypes.ROOT_FOLDER_SELECT}
                     name="rootFolderPath"
                     {...rootFolderPath}
-                    includeMissingValue={true}
+                    includeMissingValue={false}
                     onChange={onInputChange}
                   />
                 </FormGroup>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixes a UI bug when in the Edit modal for Studio or Performer.  The Scene edit modal didn't have the property I'm now setting to false, but my testing indicated no harm in doing that vs. just removing it entirely and hoping that was the default in the FormInputGroup or upstream includes.

#### Screenshot (if UI related)
See #529 

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #529