### PR TITLE
FIX: Validate ShortDate in Episode Format

### DIFF
--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -14,6 +14,8 @@ namespace NzbDrone.Core.Organizer
 
         internal static readonly Regex OriginalTokenRegex = new Regex(@"(\{original[- ._](?:title|filename)\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        internal static readonly Regex ShortDateTokenRegex = new Regex(@"\{release[- _\.]?shortdate\}",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static IRuleBuilderOptions<T, string> ValidEpisodeFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
@@ -42,7 +44,7 @@ namespace NzbDrone.Core.Organizer
 
     public class ValidStandardEpisodeFormatValidator : PropertyValidator
     {
-        protected override string GetDefaultMessageTemplate() => "Must contain release date OR Original Title";
+        protected override string GetDefaultMessageTemplate() => "Must contain Release Date, Release ShortDate OR Original Title";
 
         protected override bool IsValid(PropertyValidatorContext context)
         {
@@ -52,7 +54,8 @@ namespace NzbDrone.Core.Organizer
             }
 
             return FileNameBuilder.AirDateRegex.IsMatch(value) ||
-                   FileNameValidation.OriginalTokenRegex.IsMatch(value);
+                   FileNameValidation.OriginalTokenRegex.IsMatch(value) ||
+                   FileNameValidation.ShortDateTokenRegex.IsMatch(value);
         }
     }
 


### PR DESCRIPTION
When I added in `Release-shortDate` I forgot to add it as a valid version in the renamer. This will allow people to use short date in their filenames as a replacement of `Release-Date` 

Bug
<img width="956" height="109" alt="image" src="https://github.com/user-attachments/assets/a178ead5-e851-481f-8697-5f47431e81a6" />

Fix: 
<img width="1368" height="136" alt="4211f32a2e7aa326a676b07df350a86e" src="https://github.com/user-attachments/assets/c2ce98db-cab0-4d2f-a746-53bc9bf96485" />
