### PR TITLE
New: Add "Refreshed" badge to Import List cards

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportLists/ImportList.js
+++ b/frontend/src/Settings/ImportLists/ImportLists/ImportList.js
@@ -5,6 +5,7 @@ import Label from 'Components/Label';
 import ConfirmModal from 'Components/Modal/ConfirmModal';
 import { kinds } from 'Helpers/Props';
 import formatShortTimeSpan from 'Utilities/Date/formatShortTimeSpan';
+import getRelativeDate from 'Utilities/Date/getRelativeDate';
 import translate from 'Utilities/String/translate';
 import EditImportListModalConnector from './EditImportListModalConnector';
 import styles from './ImportList.css';
@@ -58,7 +59,8 @@ class ImportList extends Component {
       name,
       enabled,
       enableAuto,
-      minRefreshInterval
+      minRefreshInterval,
+      lastInfoSync
     } = this.props;
 
     return (
@@ -100,6 +102,22 @@ class ImportList extends Component {
           </Label>
         </div>
 
+        {lastInfoSync && <div className={styles.enabled}>
+          <Label kind={kinds.DEFAULT} title='List Refresh Time'>
+            {`${translate('Refreshed')}: ${getRelativeDate(
+              lastInfoSync,
+              'MM/DD/YYYY',
+              true,
+              {
+                timeFormat: 'HH:mm',
+                includeSeconds: false,
+                timeForToday: true
+              })
+            }`}
+          </Label>
+        </div>
+        }
+
         <EditImportListModalConnector
           id={id}
           isOpen={this.state.isEditImportListModalOpen}
@@ -127,7 +145,8 @@ ImportList.propTypes = {
   enabled: PropTypes.bool.isRequired,
   enableAuto: PropTypes.bool.isRequired,
   minRefreshInterval: PropTypes.string.isRequired,
-  onConfirmDeleteImportList: PropTypes.func.isRequired
+  onConfirmDeleteImportList: PropTypes.func.isRequired,
+  lastInfoSync: PropTypes.string
 };
 
 export default ImportList;

--- a/frontend/src/Utilities/Date/formatDateTime.js
+++ b/frontend/src/Utilities/Date/formatDateTime.js
@@ -31,7 +31,7 @@ function formatDateTime(date, dateFormat, timeFormat, { includeSeconds = false, 
   }
 
   const relativeDay = getRelativeDay(date, includeRelativeDay);
-  const formattedDate = moment(date).format(dateFormat);
+  const formattedDate = dateFormat ? moment(date).format(dateFormat) : '';
   const formattedTime = formatTime(date, timeFormat, { includeMinuteZero: true, includeSeconds });
 
   if (relativeDay) {

--- a/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
+++ b/src/NzbDrone.Core/ImportLists/FetchAndParseImportListService.cs
@@ -57,7 +57,7 @@ namespace NzbDrone.Core.ImportLists
                 return result;
             }
 
-            _logger.Debug("Available import lists {0}", importLists.Count);
+            _logger.Trace("Available import lists {0}", importLists.Count);
 
             var taskList = new List<Task>();
             var taskFactory = new TaskFactory(TaskCreationOptions.LongRunning, TaskContinuationOptions.None);
@@ -73,19 +73,29 @@ namespace NzbDrone.Core.ImportLists
 
                     if (DateTime.UtcNow < importListNextSync)
                     {
-                        _logger.Trace("Skipping refresh of Import List {0} ({1}) due to minimum refresh interval. Next Sync after {2}", importList.Name, importListLocal.Definition.Name, importListNextSync);
+                        _logger.Trace(
+                            "Skipping refresh of Import List {0} ({1}) due to minimum refresh interval. Next Sync after {2}",
+                            importList.Name,
+                            importListLocal.Definition.Name,
+                            importListNextSync);
 
                         continue;
                     }
                 }
 
-                _logger.ProgressInfo("Syncing Movies for Import List {0} ({1})", importList.Name, importListLocal.Definition.Name);
+                _logger.ProgressInfo("Syncing Movies for Import List {0} ({1})",
+                    importList.Name,
+                    importListLocal.Definition.Name);
 
-                var blockedLists = _importListStatusService.GetBlockedProviders().ToDictionary(v => v.ProviderId, v => v);
+                var blockedLists = _importListStatusService.GetBlockedProviders()
+                    .ToDictionary(v => v.ProviderId, v => v);
 
                 if (blockedLists.TryGetValue(importList.Definition.Id, out var blockedListStatus))
                 {
-                    _logger.Debug("Temporarily ignoring Import List {0} ({1}) till {2} due to recent failures.", importList.Name, importListLocal.Definition.Name, blockedListStatus.DisabledTill.Value.ToLocalTime());
+                    _logger.Debug("Temporarily ignoring Import List {0} ({1}) till {2} due to recent failures.",
+                        importList.Name,
+                        importListLocal.Definition.Name,
+                        blockedListStatus.DisabledTill.Value.ToLocalTime());
                     result.AnyFailure |= true; // Ensure we don't clean if a list is down
                     continue;
                 }
@@ -98,12 +108,21 @@ namespace NzbDrone.Core.ImportLists
 
                         lock (result)
                         {
-                            _logger.Debug("Found {0} from Import List {1} ({2})", importListReports.Movies.Count, importList.Name, importListLocal.Definition.Name);
+                            _logger.Debug("Found {0} from Import List {1} ({2})",
+                                importListReports.Movies.Count,
+                                importList.Name,
+                                importListLocal.Definition.Name);
 
                             if (!importListReports.AnyFailure)
                             {
-                                var alreadyMapped = result.Movies.Where(x => importListReports.Movies.Any(r => r.ForeignId == x.TmdbId.ToString() || r.ForeignId == x.StashId));
-                                var listMovies = MapMovieReports(importListReports.Movies.Where(x => result.Movies.All(r => r.ForeignId != x.TmdbId.ToString() && r.ForeignId != x.StashId))).Where(x => x.ForeignId.IsNotNullOrWhiteSpace()).ToList();
+                                var alreadyMapped = result.Movies.Where(x =>
+                                    importListReports.Movies.Any(r =>
+                                        r.ForeignId == x.TmdbId.ToString() || r.ForeignId == x.StashId));
+                                var listMovies =
+                                    MapMovieReports(importListReports.Movies.Where(x =>
+                                            result.Movies.All(r =>
+                                                r.ForeignId != x.TmdbId.ToString() && r.ForeignId != x.StashId)))
+                                        .Where(x => x.ForeignId.IsNotNullOrWhiteSpace()).ToList();
 
                                 listMovies.AddRange(alreadyMapped);
                                 listMovies = listMovies.DistinctBy(x => x.ForeignId).ToList();
@@ -121,7 +140,10 @@ namespace NzbDrone.Core.ImportLists
                     }
                     catch (Exception e)
                     {
-                        _logger.Error(e, "Error during Import List Sync of {0} ({1})", importList.Name, importListLocal.Definition.Name);
+                        _logger.Error(e,
+                            "Error during Import List Sync of {0} ({1})",
+                            importList.Name,
+                            importListLocal.Definition.Name);
                     }
                 }).LogExceptions();
 
@@ -132,10 +154,14 @@ namespace NzbDrone.Core.ImportLists
 
             result.Movies = result.Movies.DistinctBy(r => new { r.ForeignId, r.ImdbId, r.Title }).ToList();
 
-            _logger.Debug("Found {0} total reports from {1} lists", result.Movies.Count, result.SyncedLists);
+            // Don't log empty results every 5 minutes
+            if (result.Movies.Count > 0)
+            {
+                _logger.Debug("Found {0} total reports from {1} lists", result.Movies.Count, result.SyncedLists);
+            }
 
             return result;
-        }
+            }
 
         public ImportListFetchResult FetchSingleList(ImportListDefinition definition)
         {
@@ -175,6 +201,7 @@ namespace NzbDrone.Core.ImportLists
                     result.AnyFailure |= importListReports.AnyFailure;
 
                     _importListStatusService.UpdateListSyncStatus(importList.Definition.Id);
+                    _logger.Debug("Import list [{importList}] updated at {now}", importList.Name, DateTime.UtcNow);
                 }
             }
             catch (Exception e)

--- a/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSyncService.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.ImportLists
 
         private void SyncAll()
         {
-            _logger.Debug("Starting Import List Sync All");
+            _logger.Trace("Starting Import List Sync All");
 
             if (_importListFactory.Enabled().Empty())
             {

--- a/src/Whisparr.Api.V3/ImportLists/ImportListController.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListController.cs
@@ -8,11 +8,12 @@ namespace Whisparr.Api.V3.ImportLists
     [V3ApiController]
     public class ImportListController : ProviderControllerBase<ImportListResource, ImportListBulkResource, IImportList, ImportListDefinition>
     {
-        public static readonly ImportListResourceMapper ResourceMapper = new ();
         public static readonly ImportListBulkResourceMapper BulkResourceMapper = new ();
-
-        public ImportListController(IImportListFactory importListFactory, QualityProfileExistsValidator qualityProfileExistsValidator)
-            : base(importListFactory, "importlist", ResourceMapper, BulkResourceMapper)
+        public ImportListController(
+            IImportListFactory importListFactory,
+            QualityProfileExistsValidator qualityProfileExistsValidator,
+            ImportListResourceMapper resourceMapper)
+            : base(importListFactory, "importlist", resourceMapper, BulkResourceMapper)
         {
             SharedValidator.RuleFor(c => c.RootFolderPath).IsValidPath();
             SharedValidator.RuleFor(c => c.QualityProfileId).ValidId();

--- a/src/Whisparr.Api.V3/ImportLists/ImportListResource.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListResource.cs
@@ -15,10 +15,18 @@ namespace Whisparr.Api.V3.ImportLists
         public ImportListType ListType { get; set; }
         public int ListOrder { get; set; }
         public TimeSpan MinRefreshInterval { get; set; }
+        public DateTime? LastInfoSync { get; set; }
     }
 
     public class ImportListResourceMapper : ProviderResourceMapper<ImportListResource, ImportListDefinition>
     {
+        private readonly IImportListStatusService _importListStatusService;
+
+        public ImportListResourceMapper(IImportListStatusService importListStatusService)
+        {
+            _importListStatusService = importListStatusService;
+        }
+
         public override ImportListResource ToResource(ImportListDefinition definition)
         {
             if (definition == null)
@@ -37,6 +45,7 @@ namespace Whisparr.Api.V3.ImportLists
             resource.ListType = definition.ListType;
             resource.ListOrder = (int)definition.ListType;
             resource.MinRefreshInterval = definition.MinRefreshInterval;
+            resource.LastInfoSync = _importListStatusService.GetLastSyncListInfo(definition.Id);
 
             return resource;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added a `Refreshed` badge to the Import List cards, so users can see the last time they were updated.  Badge will not display until the list has been refreshed at least once.

#### Screenshot (if UI related)
<img width="944" height="400" alt="image" src="https://github.com/user-attachments/assets/774886d7-72a1-47f2-a770-c38be6731c52" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX