### PR TITLE
New: Indexer Search Changes

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -13,6 +14,7 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
     public class NewznabRequestGeneratorFixture : CoreTest<NewznabRequestGenerator>
     {
         private SingleEpisodeSearchCriteria _singleEpisodeSearchCriteria;
+        private SeasonSearchCriteria _seasonSearchCriteria;
         private NewznabCapabilities _capabilities;
 
         [SetUp]
@@ -32,8 +34,17 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 
             _singleEpisodeSearchCriteria = new SingleEpisodeSearchCriteria
             {
-                Series = new Tv.Series { TvdbId = 20 },
+                Series = new Tv.Series { TvdbId = 20, Title = "Monkey Island", Network = "HBO" },
                 SceneTitles = new List<string> { "Monkey Island" },
+                EpisodeTitle = "Pilot Episode",
+                ReleaseDate = new DateOnly(2021, 3, 15)
+            };
+
+            _seasonSearchCriteria = new SeasonSearchCriteria
+            {
+                Series = new Tv.Series { TvdbId = 20, Title = "Monkey Island", Network = "HBO" },
+                SceneTitles = new List<string> { "Monkey Island" },
+                Year = 2021
             };
 
             _capabilities = new NewznabCapabilities();
@@ -146,6 +157,155 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
             pageTier.Url.Query.Should().Contain("and");
             pageTier.Url.Query.Should().NotContain(" & ");
             pageTier.Url.Query.Should().NotContain("%26");
+        }
+
+        [Test]
+        public void should_search_title_only_when_enabled()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q" };
+            Subject.Settings.SearchTitleOnly = true;
+
+            var results = Subject.GetSearchRequests(_singleEpisodeSearchCriteria);
+            var requests = results.GetAllTiers().SelectMany(x => x).ToList();
+
+            // Should have default search requests plus title-only search
+            requests.Should().HaveCountGreaterThan(0);
+            requests.Should().Contain(x => x.Url.Query.Contains("Pilot") && x.Url.Query.Contains("Episode"));
+        }
+
+        [Test]
+        public void should_search_site_plus_title_when_enabled()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q" };
+            Subject.Settings.SearchSiteTitleOnly = true;
+
+            var results = Subject.GetSearchRequests(_singleEpisodeSearchCriteria);
+            var requests = results.GetAllTiers().SelectMany(x => x).ToList();
+
+            requests.Should().HaveCountGreaterThan(0);
+
+            // Should have some request containing both series and episode info
+
+            requests.Should().Contain(x => x.Url.Query.Contains("Monkey") && x.Url.Query.Contains("Pilot"));
+        }
+
+        [Test]
+        public void should_use_both_date_formats_when_configured()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q" };
+            Subject.Settings.DateSearchFormat = DateSearchFormat.Both;
+
+            var results = Subject.GetSearchRequests(_singleEpisodeSearchCriteria);
+            var requests = results.GetAllTiers().SelectMany(x => x).ToList();
+
+            requests.Should().HaveCountGreaterThan(0);
+
+            // Should have requests with both YY.MM.DD (21.03.15) and DD.MM.YY (15.03.21) formats
+            // The dots might be URL encoded as %2E
+            var allQueries = string.Join(" ", requests.Select(x => x.Url.Query));
+            allQueries.Should().Match("*21*03*15*"); // YY.MM.DD format
+            allQueries.Should().Match("*15*03*21*"); // DD.MM.YY format
+        }
+
+        [Test]
+        public void should_use_day_month_year_format_when_configured()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q" };
+            Subject.Settings.DateSearchFormat = DateSearchFormat.DayMonthYear;
+
+            var results = Subject.GetSearchRequests(_singleEpisodeSearchCriteria);
+            var requests = results.GetAllTiers().SelectMany(x => x).ToList();
+
+            requests.Should().HaveCountGreaterThan(0);
+
+            // When DateSearchFormat.DayMonthYear is set, should have DD.MM.YY format
+            var allQueries = string.Join(" ", requests.Select(x => x.Url.Query));
+            allQueries.Should().Match("*15*03*21*"); // Should have DD.MM.YY format
+        }
+
+        [Test]
+        public void should_use_network_name_when_series_name_source_is_network()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q" };
+            Subject.Settings.SearchSiteTitleOnly = true;
+            Subject.Settings.SeriesNameSource = SeriesNameSource.Network;
+
+            var results = Subject.GetSearchRequests(_singleEpisodeSearchCriteria);
+            var requests = results.GetAllTiers().SelectMany(x => x).ToList();
+
+            requests.Should().HaveCountGreaterThan(0);
+            requests.Should().Contain(x => x.Url.Query.Contains("HBO"));
+        }
+
+        [Test]
+        public void should_use_both_network_and_site_when_series_name_source_is_both()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q" };
+            Subject.Settings.SearchSiteTitleOnly = true;
+            Subject.Settings.SeriesNameSource = SeriesNameSource.Both;
+
+            var results = Subject.GetSearchRequests(_singleEpisodeSearchCriteria);
+            var requests = results.GetAllTiers().SelectMany(x => x).ToList();
+
+            requests.Should().HaveCountGreaterThan(0);
+
+            // Should have requests with both site name and network name variations
+            requests.Should().Contain(x => x.Url.Query.Contains("Monkey"));
+            requests.Should().Contain(x => x.Url.Query.Contains("HBO"));
+        }
+
+        [Test]
+        public void should_search_season_with_title_only_when_enabled()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q" };
+            Subject.Settings.SearchTitleOnly = true;
+
+            var results = Subject.GetSearchRequests(_seasonSearchCriteria);
+            var requests = results.GetAllTiers().SelectMany(x => x).ToList();
+
+            requests.Should().HaveCountGreaterThan(0);
+
+            // For season searches, SearchTitleOnly should include requests with just the series title
+            requests.Should().Contain(x => x.Url.Query.Contains("Monkey") && x.Url.Query.Contains("Island"));
+        }
+
+        [Test]
+        public void should_search_season_with_site_plus_title_when_enabled()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q" };
+            Subject.Settings.SearchSiteTitleOnly = true;
+
+            var results = Subject.GetSearchRequests(_seasonSearchCriteria);
+            var requests = results.GetAllTiers().SelectMany(x => x).ToList();
+
+            requests.Should().HaveCountGreaterThan(0);
+            requests.Should().Contain(x => x.Url.Query.Contains("Monkey") && x.Url.Query.Contains("Island"));
+        }
+
+        [Test]
+        public void should_search_season_with_network_name_when_series_name_source_is_network()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q" };
+            Subject.Settings.SearchSiteTitleOnly = true;
+            Subject.Settings.SeriesNameSource = SeriesNameSource.Network;
+
+            var results = Subject.GetSearchRequests(_seasonSearchCriteria);
+            var requests = results.GetAllTiers().SelectMany(x => x).ToList();
+
+            requests.Should().HaveCountGreaterThan(0);
+            requests.Should().Contain(x => x.Url.Query.Contains("HBO"));
+        }
+
+        [Test]
+        public void should_search_season_with_both_years()
+        {
+            _capabilities.SupportedSearchParameters = new[] { "q" };
+
+            var results = Subject.GetSearchRequests(_seasonSearchCriteria);
+            var requests = results.GetAllTiers().SelectMany(x => x).ToList();
+
+            requests.Should().Contain(x => x.Url.Query.Contains("21"));
+            requests.Should().Contain(x => x.Url.Query.Contains("2021"));
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -78,17 +78,50 @@ namespace NzbDrone.Core.Indexers.Newznab
         {
             var pageableRequests = new IndexerPageableRequestChain();
 
-            var releaseDate = searchCriteria.ReleaseDate?.ToString("yy.MM.dd") ?? string.Empty;
-
             if (SupportsSearch)
             {
                 var queryTitles = TextSearchEngine == "raw" ? searchCriteria.SceneTitles : searchCriteria.CleanSceneTitles;
+
+                // Pre-calculate commonly used values to avoid repeated processing
+                var dateFormats = GetDateFormats(searchCriteria.ReleaseDate, Settings.DateSearchFormat);
+                var episodeTitle = Settings.SearchTitleOnly ? NewsnabifyTitle(searchCriteria.EpisodeTitle) : null;
+                var sitePlusEpisodeTitle = Settings.SearchSiteTitleOnly ? NewsnabifyTitle(searchCriteria.EpisodeTitle) : null;
+
                 foreach (var queryTitle in queryTitles)
                 {
-                    pageableRequests.Add(GetPagedRequests(MaxPages,
-                        Settings.Categories,
-                        "search",
-                        $"&q={NewsnabifyTitle(queryTitle)}+{releaseDate}"));
+                    var normalizedQueryTitle = NewsnabifyTitle(queryTitle);
+
+                    // ALWAYS do default search with site + date
+                    foreach (var dateFormat in dateFormats)
+                    {
+                        var searchQuery = $"&q={normalizedQueryTitle}+{dateFormat}";
+                        pageableRequests.Add(GetPagedRequests(MaxPages,
+                            Settings.Categories,
+                            "search",
+                            searchQuery));
+                    }
+
+                    // Add Site + Title search if selected
+                    if (Settings.SearchSiteTitleOnly)
+                    {
+                        // Use Site name
+                        var siteTitle = NewsnabifyTitle(searchCriteria.Series.Title);
+                        var searchQuery = $"&q={siteTitle}+{sitePlusEpisodeTitle}";
+                        pageableRequests.Add(GetPagedRequests(MaxPages, Settings.Categories, "search", searchQuery));
+
+                        // Add network search if needed
+                        AddNetworkSearchIfNeeded(pageableRequests, searchCriteria.Series, sitePlusEpisodeTitle, "Episode");
+                    }
+
+                    // Add Title Only search if selected
+                    if (Settings.SearchTitleOnly)
+                    {
+                        var searchQuery = $"&q={episodeTitle}";
+                        pageableRequests.Add(GetPagedRequests(MaxPages,
+                            Settings.Categories,
+                            "search",
+                            searchQuery));
+                    }
                 }
             }
 
@@ -98,23 +131,52 @@ namespace NzbDrone.Core.Indexers.Newznab
         public virtual IndexerPageableRequestChain GetSearchRequests(SeasonSearchCriteria searchCriteria)
         {
             var pageableRequests = new IndexerPageableRequestChain();
-
-            var twoDigitYear = new DateTime(searchCriteria.Year, 1, 31).ToString("yy");
-
             if (SupportsSearch)
             {
                 var queryTitles = TextSearchEngine == "raw" ? searchCriteria.SceneTitles : searchCriteria.CleanSceneTitles;
+
+                // Pre-calculate commonly used values to avoid repeated processing
+                var twoDigitYear = new DateTime(searchCriteria.Year, 1, 31).ToString("yy");
+
                 foreach (var queryTitle in queryTitles)
                 {
-                    pageableRequests.Add(GetPagedRequests(MaxPages,
-                        Settings.Categories,
-                        "search",
-                        $"&q={NewsnabifyTitle(queryTitle)}+{twoDigitYear}"));
+                    var normalizedQueryTitle = NewsnabifyTitle(queryTitle);
+
+                    // ALWAYS do default search with site + year
+                    var searchQuery1 = $"&q={normalizedQueryTitle}+{twoDigitYear}";
+                    var searchQuery2 = $"&q={normalizedQueryTitle}+{searchCriteria.Year}";
 
                     pageableRequests.Add(GetPagedRequests(MaxPages,
                         Settings.Categories,
                         "search",
-                        $"&q={NewsnabifyTitle(queryTitle)}+{searchCriteria.Year}"));
+                        searchQuery1));
+
+                    pageableRequests.Add(GetPagedRequests(MaxPages,
+                        Settings.Categories,
+                        "search",
+                        searchQuery2));
+
+                    // Add Site + Title search if selected
+                    if (Settings.SearchSiteTitleOnly)
+                    {
+                        // Use Site name
+                        var siteTitle = NewsnabifyTitle(searchCriteria.Series.Title);
+                        var searchQuery = $"&q={siteTitle}+{normalizedQueryTitle}";
+                        pageableRequests.Add(GetPagedRequests(MaxPages, Settings.Categories, "search", searchQuery));
+
+                        // Add network search if needed
+                        AddNetworkSearchIfNeeded(pageableRequests, searchCriteria.Series, normalizedQueryTitle, "Season");
+                    }
+
+                    // Add Title Only search if selected
+                    if (Settings.SearchTitleOnly)
+                    {
+                        var searchQuery = $"&q={normalizedQueryTitle}";
+                        pageableRequests.Add(GetPagedRequests(MaxPages,
+                            Settings.Categories,
+                            "search",
+                            searchQuery));
+                    }
                 }
             }
 
@@ -155,6 +217,52 @@ namespace NzbDrone.Core.Indexers.Newznab
         {
             title = title.Replace("+", " ");
             return Uri.EscapeDataString(title);
+        }
+
+        private static string FormatDate(DateOnly? releaseDate, DateSearchFormat format)
+        {
+            if (!releaseDate.HasValue)
+            {
+                return string.Empty;
+            }
+
+            return format switch
+            {
+                DateSearchFormat.YearMonthDay => releaseDate.Value.ToString("yy.MM.dd"),
+                DateSearchFormat.DayMonthYear => releaseDate.Value.ToString("dd.MM.yy"),
+                _ => releaseDate.Value.ToString("yy.MM.dd")
+            };
+        }
+
+        private static List<string> GetDateFormats(DateOnly? releaseDate, DateSearchFormat format)
+        {
+            if (!releaseDate.HasValue)
+            {
+                return new List<string>();
+            }
+
+            return format switch
+            {
+                DateSearchFormat.YearMonthDay => new List<string> { releaseDate.Value.ToString("yy.MM.dd") },
+                DateSearchFormat.DayMonthYear => new List<string> { releaseDate.Value.ToString("dd.MM.yy") },
+                DateSearchFormat.Both => new List<string>
+                {
+                    releaseDate.Value.ToString("yy.MM.dd"),
+                    releaseDate.Value.ToString("dd.MM.yy")
+                },
+                _ => new List<string> { releaseDate.Value.ToString("yy.MM.dd") }
+            };
+        }
+
+        private void AddNetworkSearchIfNeeded(IndexerPageableRequestChain pageableRequests, Tv.Series series, string additionalTitle, string logPrefix)
+        {
+            if ((Settings.SeriesNameSource == SeriesNameSource.Network || Settings.SeriesNameSource == SeriesNameSource.Both)
+                && !string.IsNullOrWhiteSpace(series.Network))
+            {
+                var networkTitle = NewsnabifyTitle(series.Network);
+                var networkSearchQuery = $"&q={networkTitle}+{additionalTitle}";
+                pageableRequests.Add(GetPagedRequests(MaxPages, Settings.Categories, "search", networkSearchQuery));
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
@@ -8,6 +8,20 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Indexers.Newznab
 {
+    public enum DateSearchFormat
+    {
+        YearMonthDay = 0,
+        DayMonthYear = 1,
+        Both = 2
+    }
+
+    public enum SeriesNameSource
+    {
+        Site = 0,
+        Network = 1,
+        Both = 2
+    }
+
     public class NewznabSettingsValidator : AbstractValidator<NewznabSettings>
     {
         private static readonly string[] ApiKeyWhiteList =
@@ -54,6 +68,8 @@ namespace NzbDrone.Core.Indexers.Newznab
         {
             ApiPath = "/api";
             Categories = new[] { 6000, 6010, 6020, 6030, 6040, 6045, 6050, 6070, 6080, 6090 };
+            DateSearchFormat = DateSearchFormat.YearMonthDay;
+            SeriesNameSource = SeriesNameSource.Site;
         }
 
         [FieldDefinition(0, Label = "URL")]
@@ -71,7 +87,19 @@ namespace NzbDrone.Core.Indexers.Newznab
         [FieldDefinition(6, Label = "Additional Parameters", HelpText = "Additional Newznab parameters", Advanced = true)]
         public string AdditionalParameters { get; set; }
 
-        // Field 7 is used by TorznabSettings MinimumSeeders
+        [FieldDefinition(7, Label = "Search Title Only", Type = FieldType.Checkbox, HelpText = "Search using title only (without date/year). Default searches include date/year with title.", Advanced = true)]
+        public bool SearchTitleOnly { get; set; }
+
+        [FieldDefinition(8, Label = "Search Site + Title", Type = FieldType.Checkbox, HelpText = "Search using site name + title (without date/year). Overrides 'Search Title Only' if both are enabled.", Advanced = true)]
+        public bool SearchSiteTitleOnly { get; set; }
+
+        [FieldDefinition(9, Label = "Date Format", Type = FieldType.Select, SelectOptions = typeof(DateSearchFormat), HelpText = "Date format to use in searches: YY.MM.DD, DD.MM.YY, or Both", Advanced = true)]
+        public DateSearchFormat DateSearchFormat { get; set; }
+
+        [FieldDefinition(10, Label = "Network or Site", Type = FieldType.Select, SelectOptions = typeof(SeriesNameSource), HelpText = "Choose between Site Name (from indexer), Network Name (from TPDB), or Both for series searches", Advanced = true)]
+        public SeriesNameSource SeriesNameSource { get; set; }
+
+        // Field 11 is used by TorznabSettings MinimumSeeders
         // If you need to add another field here, update TorznabSettings as well and this comment
 
         public virtual NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
@@ -49,10 +49,10 @@ namespace NzbDrone.Core.Indexers.Torznab
             MinimumSeeders = IndexerDefaults.MINIMUM_SEEDERS;
         }
 
-        [FieldDefinition(7, Type = FieldType.Number, Label = "Minimum Seeders", HelpText = "Minimum number of seeders required.", Advanced = true)]
+        [FieldDefinition(11, Type = FieldType.Number, Label = "Minimum Seeders", HelpText = "Minimum number of seeders required.", Advanced = true)]
         public int MinimumSeeders { get; set; }
 
-        [FieldDefinition(8)]
+        [FieldDefinition(12)]
         public SeedCriteriaSettings SeedCriteria { get; set; } = new SeedCriteriaSettings();
 
         public override NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Servarr.FluentMigrator.Runner.SQLite" Version="3.3.2.9" />
     <PackageReference Include="Servarr.FluentMigrator.Runner.Postgres" Version="3.3.2.9" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="MonoTorrent" Version="2.0.7" />

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Servarr.FluentMigrator.Runner.SQLite" Version="3.3.2.9" />
     <PackageReference Include="Servarr.FluentMigrator.Runner.Postgres" Version="3.3.2.9" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="MonoTorrent" Version="2.0.7" />


### PR DESCRIPTION
Firstly, I wanted to note I am kind of against this. People can abuse it and get bad matches/banned from their trackers if they just spam API requests all day long. If you have all options selected it can essentially send 7 requests for 1 scene. Users should know that they should only really select what is needed to help prevent tracker bans

Adds the ability to change the individual indexer searches. I made it individual as some trackers have better naming standards than others and no point making unnecessary API calls if the naming is "normal". This, for the most part, is the same setup as V3 currently has.

- Site + Title only
- Title Only
- yy.mm.dd, dd.mm.yy or both date variatioinis
- Use the Site, Network, or both

This is tucked away behind the advanced features inside of Newznab and Torznab

Edit: Users should be aware that just because a search was found and downloaded does not mean that it can be imported. A lot of things will need to be manually imported due to not having the correct formatting. 