### PR TITLE
Chore: Update ImageSharp to 3.1.11 due to vulnerability in v3.1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,4 +177,4 @@ node_modules.nosync
 .config/
 
 # Ignore global.json file for allowing builds on non-Widows systems
-src/global.json
+global.json

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Servarr.FluentMigrator.Runner.SQLite" Version="3.3.2.9" />
     <PackageReference Include="Servarr.FluentMigrator.Runner.Postgres" Version="3.3.2.9" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.2.3" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />


### PR DESCRIPTION
#### Description

Chore: Update ImageSharp to 3.1.11 due to vulnerability in v3.1.7

This also triggered some nuanced build issues locally, due to not disabling `AssemblyInfo.cs` auto-generation, but also providing them in each sub-project other than `Nzbdrone.Common` .  Made that consistent.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)