### PR TITLE
New: EMP parsing

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -29,6 +29,7 @@ namespace NzbDrone.Core.Test.ParserTests
 
         // [TestCase("Series.911.2023.DVDRip.DD2.0.x264-DEEP", "series 911")]
         [TestCase("www.Torrenting.org - Series.23.01.23.720p.HDTV.X264-DIMENSION", "series")]
+        [TestCase("Pure Taboo - Sarah Arabic, Lily LaBeau - A Costly Divorce (June 24, 2025) [1080p HEVC x265]", "puretaboo")]
         public void should_parse_series_name(string postTitle, string title)
         {
             var result = Parser.Parser.ParseSeriesName(postTitle).CleanSeriesTitle();
@@ -53,6 +54,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("1234.2022.23.01.23.720p.HDTV.X264-DIMENSION", "1234", 2022)]
         [TestCase("1234-2022-23-01-23-720p-HDTV-X264-DIMENSION", "1234", 2022)]
         [TestCase("1234_2022_23_01_23_720p_HDTV_X264-DIMENSION", "1234", 2022)]
+        [TestCase("Pure Taboo - Sarah Arabic, Lily LaBeau - A Costly Divorce (June 24, 2025) [1080p HEVC x265]", "Pure Taboo")]
         public void should_parse_series_title_info(string postTitle, string titleWithoutYear, int year = 0)
         {
             var seriesTitleInfo = Parser.Parser.ParseTitle(postTitle).SeriesTitleInfo;
@@ -61,10 +63,19 @@ namespace NzbDrone.Core.Test.ParserTests
         }
 
         [TestCase("Digital Playground - 2014-12-20 - Dirty Santa - Episode 4 - Candy Cane Lane - [WEBDL-1080p].mp4", " - Dirty Santa - Episode 4 - Candy Cane Lane - [WEBDL-1080p]")]
+        [TestCase("Pure Taboo - Sarah Arabic, Lily LaBeau - A Costly Divorce (June 24, 2025) [1080p HEVC x265]", " - Sarah Arabic, Lily LaBeau - A Costly Divorce")]
         public void should_parse_episode_string(string title, string expected)
         {
             var seriesTitleInfo = Parser.Parser.ParseTitle(title);
-            seriesTitleInfo.AirDate.Should().Be("2014-12-20");
+            if (title.Contains("2014-12-20"))
+            {
+                seriesTitleInfo.AirDate.Should().Be("2014-12-20");
+            }
+            else if (title.Contains("June 24, 2025"))
+            {
+                seriesTitleInfo.AirDate.Should().Be("2025-06-24");
+            }
+
             seriesTitleInfo.ReleaseTokens.Should().Be(expected);
         }
 

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -50,6 +50,11 @@ namespace NzbDrone.Core.Parser
                 new Regex("^\\[(?<title>.+?)\\](?<releasetoken>.+?)(?:( - |\\s)(\\[|\\()?(?<airyear>(19|20)\\d{2})[-_.](?<airmonth>[0-1][0-9])[-_.](?<airday>[0-3][0-9])(\\]|\\))?)",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
+                // Site - Performers - Title (Month DD, YYYY) [Quality]
+                // Pure Taboo - Sarah Arabic, Lily LaBeau - A Costly Divorce (June 24, 2025) [1080p HEVC x265]
+                new Regex(@"^(?<title>[^-]+?)(?<releasetoken>\s*-\s*.+?)\s*\(\s*(?<airmonthname>January|February|March|April|May|June|July|August|September|October|November|December)\s+(?<airday>[0-3]?\d),?\s+(?<airyear>(19|20)\d{2})\s*\)",
+                    RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
                 // Episodes with non-separated airdate after title (20180428)
                 new Regex(@"^(?<title>.+?)?[-_. ]+(?<airyear>(19|20)\d{2})(?<airmonth>[0-1][0-9])(?<airday>[0-3][0-9])",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
@@ -594,7 +599,18 @@ namespace NzbDrone.Core.Parser
                 }
 
                 // Try to Parse as a daily show
-                var airmonth = Convert.ToInt32(matchCollection[0].Groups["airmonth"].Value);
+                int airmonth;
+                if (matchCollection[0].Groups["airmonthname"].Success)
+                {
+                    // Convert month name to number
+                    var monthName = matchCollection[0].Groups["airmonthname"].Value;
+                    airmonth = DateTime.ParseExact(monthName, "MMMM", CultureInfo.InvariantCulture).Month;
+                }
+                else
+                {
+                    airmonth = Convert.ToInt32(matchCollection[0].Groups["airmonth"].Value);
+                }
+
                 var airday = Convert.ToInt32(matchCollection[0].Groups["airday"].Value);
 
                 // Swap day and month if month is bigger than 12 (scene fail)
@@ -629,7 +645,15 @@ namespace NzbDrone.Core.Parser
                 }
 
                 lastSeasonEpisodeStringIndex = Math.Max(lastSeasonEpisodeStringIndex, matchCollection[0].Groups["airyear"].EndIndex());
-                lastSeasonEpisodeStringIndex = Math.Max(lastSeasonEpisodeStringIndex, matchCollection[0].Groups["airmonth"].EndIndex());
+                if (matchCollection[0].Groups["airmonthname"].Success)
+                {
+                    lastSeasonEpisodeStringIndex = Math.Max(lastSeasonEpisodeStringIndex, matchCollection[0].Groups["airmonthname"].EndIndex());
+                }
+                else
+                {
+                    lastSeasonEpisodeStringIndex = Math.Max(lastSeasonEpisodeStringIndex, matchCollection[0].Groups["airmonth"].EndIndex());
+                }
+
                 lastSeasonEpisodeStringIndex = Math.Max(lastSeasonEpisodeStringIndex, matchCollection[0].Groups["airday"].EndIndex());
 
                 result = new ParsedEpisodeInfo


### PR DESCRIPTION
There are some releases on pvt trackers that use naming as such:

`Pure Taboo - Sarah Arabic, Lily LaBeau - A Costly Divorce (June 24, 2025) [1080p HEVC x265]`

This has 4 points of usable data. I had to make it so we could convert a word month into a number and then pass that number to the date format.