### PR TITLE
Fix: Environment Variables

### DIFF
--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -125,12 +125,12 @@ namespace NzbDrone.Host
         {
             var config = GetConfiguration(context);
 
-            var bindAddress = config.GetValue(nameof(ConfigFileProvider.BindAddress), "*");
-            var port = config.GetValue(nameof(ConfigFileProvider.Port), 6969);
-            var sslPort = config.GetValue(nameof(ConfigFileProvider.SslPort), 8008);
-            var enableSsl = config.GetValue(nameof(ConfigFileProvider.EnableSsl), false);
-            var sslCertPath = config.GetValue<string>(nameof(ConfigFileProvider.SslCertPath));
-            var sslCertPassword = config.GetValue<string>(nameof(ConfigFileProvider.SslCertPassword));
+            var bindAddress = config.GetValue("Whisparr:Server:BindAddress", config.GetValue(nameof(ConfigFileProvider.BindAddress), "*"));
+            var port = config.GetValue("Whisparr:Server:Port", config.GetValue(nameof(ConfigFileProvider.Port), 6969));
+            var sslPort = config.GetValue("Whisparr:Server:SslPort", config.GetValue(nameof(ConfigFileProvider.SslPort), 8008));
+            var enableSsl = config.GetValue("Whisparr:Server:EnableSsl", config.GetValue(nameof(ConfigFileProvider.EnableSsl), false));
+            var sslCertPath = config.GetValue("Whisparr:Server:SslCertPath", config.GetValue<string>(nameof(ConfigFileProvider.SslCertPath)));
+            var sslCertPassword = config.GetValue("Whisparr:Server:SslCertPassword", config.GetValue<string>(nameof(ConfigFileProvider.SslCertPassword)));
 
             var urls = new List<string> { BuildUrl("http", bindAddress, port) };
 


### PR DESCRIPTION
Environment variables for server configuration (WHISPARR__SERVER__*) were being ignored, causing Docker deployments and environment-based configuration to fail for basic server settings.

Bootstrap.cs was reading server configuration using flat property names ("EnableSsl", "Port", etc.) instead of the hierarchical configuration paths ("Whisparr:Server:EnableSsl", "Whisparr:Server:Port", etc.) that Microsoft.Extensions.Configuration creates from environment variables.

I am unable to test this so will request that the original requester test this before merging. Please don't merge until proper testing is done.

Fixes: #520