### PR TITLE
Fix: Search Results Poster CSS 

### DIFF
--- a/frontend/src/AddSeries/AddNewSeries/AddNewSeriesSearchResult.css
+++ b/frontend/src/AddSeries/AddNewSeries/AddNewSeriesSearchResult.css
@@ -33,6 +33,7 @@
   margin-right: 20px;
   max-width: 250px;
   max-height: 250px;
+  object-fit: contain;
 }
 
 .content {


### PR DESCRIPTION
Small change to set the poster to contain so it does not stretch


Old:
<img width="1064" height="450" alt="old" src="https://github.com/user-attachments/assets/113c1363-40d1-4813-b127-693ecfbc5d1f" />

New:
<img width="916" height="421" alt="new" src="https://github.com/user-attachments/assets/6ffd1fde-17a4-4aa3-91f0-03f6b627a7d7" />

