### PR TITLE
Fix: No rejections to the Top in Interactive Search

### DIFF
--- a/frontend/src/Store/Actions/releaseActions.js
+++ b/frontend/src/Store/Actions/releaseActions.js
@@ -57,6 +57,19 @@ export const defaultState = {
       }
 
       return releaseWeight;
+    },
+
+    releaseWeight: function(item, direction) {
+      const rejections = item.rejections;
+      const releaseWeight = item.releaseWeight;
+
+      // Prioritize approved releases (no rejections) at the top
+      if (rejections.length === 0) {
+        return releaseWeight;
+      }
+
+      // Push rejected releases to the bottom
+      return releaseWeight + 1000000;
     }
   },
 


### PR DESCRIPTION
Currently, rejected releases get mixed in with approved ones in the interactive search. This will make it so that releases with 0 rejections get put above release with greater than 0 rejections.

Fixes: #572 