### PR TITLE
Chore/cherrypick 3

### DIFF
--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/Sabnzbd.cs
@@ -503,6 +503,25 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
                 };
             }
 
+            // New in SABnzbd 4.1, but on older versions this will be empty and not apply
+            if (config.Sorters.Any(s => s.is_active && ContainsCategory(s.sort_cats, Settings.MovieCategory)))
+            {
+                return new NzbDroneValidationFailure("MovieCategory", "Disable TV Sorting")
+                {
+                    InfoLink = _proxy.GetBaseUrl(Settings, "config/sorting/"),
+                    DetailedDescription = "You must disable sorting for the category Radarr uses to prevent import issues. Go to Sabnzbd to fix it."
+                };
+            }
+
+            if (config.Misc.enable_tv_sorting && ContainsCategory(config.Misc.tv_categories, Settings.MovieCategory))
+            {
+                return new NzbDroneValidationFailure("MovieCategory", _localizationService.GetLocalizedString("DownloadClientSabnzbdValidationEnableDisableTvSorting"))
+                {
+                    InfoLink = _proxy.GetBaseUrl(Settings, "config/sorting/"),
+                    DetailedDescription = _localizationService.GetLocalizedString("DownloadClientSabnzbdValidationEnableDisableTvSortingDetail")
+                };
+            }
+
             if (config.Misc.enable_tv_sorting && ContainsCategory(config.Misc.tv_categories, Settings.MovieCategory))
             {
                 return new NzbDroneValidationFailure("MovieCategory", _localizationService.GetLocalizedString("DownloadClientSabnzbdValidationEnableDisableTvSorting"))

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         private readonly List<FFProbePixelFormat> _pixelFormats;
 
         public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 8;
-        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 11;
+        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 12;
 
         private static readonly string[] ValidHdrColourPrimaries = { "bt2020" };
         private static readonly string[] HlgTransferFunctions = { "bt2020-10", "arib-std-b67" };

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -489,7 +489,7 @@ namespace NzbDrone.Core.Organizer
             new Dictionary<string, int>(FileNameBuilderTokenEqualityComparer.Instance)
         {
             { MediaInfoVideoDynamicRangeToken, 5 },
-            { MediaInfoVideoDynamicRangeTypeToken, 11 }
+            { MediaInfoVideoDynamicRangeTypeToken, 12 }
         };
 
         private void AddMediaInfoTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, MovieFile movieFile)

--- a/src/Whisparr.Api.V3/History/HistoryController.cs
+++ b/src/Whisparr.Api.V3/History/HistoryController.cs
@@ -68,8 +68,7 @@ namespace Whisparr.Api.V3.History
 
             if (eventTypes != null && eventTypes.Any())
             {
-                var filterValues = eventTypes.Cast<MovieHistoryEventType>().ToArray();
-                pagingSpec.FilterExpressions.Add(v => filterValues.Contains(v.EventType));
+                 pagingSpec.FilterExpressions.Add(v => eventTypes.Contains((int)v.EventType));
             }
 
             if (downloadId.IsNotNullOrWhiteSpace())

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -184,6 +184,7 @@ namespace Whisparr.Api.V3.Movies
             }
 
             var movie = _moviesService.GetMovie(id);
+
             return MapToResource(movie);
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Round 3 of Radarr upstream cherry-picks

<Details><Summary>Click to expand</Summary>

radarr/radarr@f3d6a1f99 Fixed: Release source for release/push (no change)
radarr/radarr@0e7874aac Fix Missing HelpText Translation Keys (no change)
radarr/radarr@2c3ad380e Remove unsupported pagination for Nyaa (not applicable)
radarr/radarr@1d8cf6a7f Fixed: Persist release source for pending releases (no change)
radarr/radarr@58b726a29 Fixed: Improve torrent blocklist matching (no change)
radarr/radarr@a652ce50a Fixed: Latvian and Russian language parsing (no change)
radarr/radarr@f7816aa5c Fixed: Filter history by multiple event types in PG (already coevred)
radarr/radarr@f5914da2f Remove double filtering in entity history repository (no change)
radarr/radarr@1ae98d618 Fixed: Movie posters flickering when width changes repeatedly (no change)
radarr/radarr@cc03651af Don't use TestCase for single test (no change)
radarr/radarr@907779b4c Fetch movie file entity from database to broadcast (no change)
radarr/radarr@cda40312e New: Optional directory setting for Aria2 (no change)
radarr/radarr@5a6482686 Add: New icon for deleted episodes with status missing from disk
radarr/radarr@d72f78d97 New: Custom import scripts can communicate information back (ours had more logic)
radarr/radarr@4c4073ce1 New: Support SABnzb's new format for sorters
radarr/radarr@c5992ed94 Bump Inno version to 6.2.2 (ours was newer)
radarr/radarr@60d9aacac Build report can get sent before installer finished (no change)
radarr/radarr@1bb404a91 Fixed: Only use frames for Primary video stream for analysis
radarr/radarr@ea470b4ee Sort Custom Filters (no change)
radarr/radarr@1932aec13 Improved http timeout handling (no change)

</Details>

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)