### PR TITLE
Chore: Remove release branch warning from V3

### DIFF
--- a/src/NzbDrone.Core/HealthCheck/Checks/ReleaseBranchCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/ReleaseBranchCheck.cs
@@ -33,7 +33,8 @@ namespace NzbDrone.Core.HealthCheck.Checks
         {
             Master,
             Develop,
-            Nightly
+            Nightly,
+            Eros
         }
     }
 }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Prior to this edit, `Master` (unused), `Develop` (V2), and `Nightly` were considered "valid".  V2 and V3 are on par with each other w/r/t code stability, so I feel it's appropriate to remove this warning.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX