### PR TITLE
Fix: Throw health check error when upgraded to V3

### DIFF
--- a/src/NzbDrone.Core/HealthCheck/Checks/MetadataUrlCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/MetadataUrlCheck.cs
@@ -1,0 +1,29 @@
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Configuration.Events;
+using NzbDrone.Core.Localization;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    [CheckOn(typeof(ConfigSavedEvent))]
+    public class MetadataUrlCheck : HealthCheckBase
+    {
+        private readonly IConfigFileProvider _configFileService;
+
+        public MetadataUrlCheck(IConfigFileProvider configFileService, ILocalizationService localizationService)
+            : base(localizationService)
+        {
+            _configFileService = configFileService;
+        }
+
+        public override HealthCheck Check()
+        {
+            var whisparrMetadata = _configFileService.WhisparrMetadata;
+            if (whisparrMetadata == "https://api.whisparr.com/v3/{route}")
+            {
+                return new HealthCheck(GetType(), HealthCheckResult.Error, string.Format(_localizationService.GetLocalizedString("MetadataIncorrectUrlWarning"), _configFileService.Branch), "#config-metadata-url-mismatch");
+            }
+
+            return new HealthCheck(GetType());
+        }
+    }
+}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -899,6 +899,7 @@
   "Menu": "Menu",
   "Message": "Message",
   "Metadata": "Metadata",
+  "MetadataIncorrectUrlWarning": "The metadata URL is set for Whisparr version 2.x, but you are running version 3.x.  This happens if you do an unsupported in-place upgrade.  Please downgrade back to version 2.",
   "MetadataLoadError": "Unable to load Metadata",
   "MetadataSettings": "Metadata Settings",
   "MetadataSettingsSummary": "Create metadata files when movies are imported or refreshed",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
In Discord, we had some users coming in asking why StashDB searches were failing.  It was due to them upgrading directly from V2 to V3, which share common naming for config.xml.  Since this is an unsupported upgrade path, I added a health check to V3 to explicitly call this out.

#### Screenshot (if UI related)

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #578 