### PR TITLE
Fix: Move from inconsistent SolutionDir to MSBuildThisFileDirectory

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -132,7 +132,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <AdditionalFiles Include="$(SolutionDir)stylecop.json" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I'd noticed StyleCop was not reliably working in both edit-time evaluation as well as build time when running tests in Visual Studio Code.  Microsoft documents the env `MSBuildThisFileDirectory` instead of SOlutionDir, in newer versions of the .NET SDK.  Thie was resulting in erroneous SA1200 validation errors which cause build to fail.

https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-reserved-and-well-known-properties?view=vs-2022

In this case, the VSC test runner was failing because `SolutionDir` would evaluate to `Undefined`, because it builds each child project individually rather than building the whole solution every time.

This change only applies to StyleCop, as I couldn't repro any build or test errors. outside of that.

#### Screenshot (if UI related)

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)