### PR TITLE
Fix: Existing Only Monitor

### DIFF
--- a/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
@@ -112,6 +112,12 @@ namespace NzbDrone.Core.Tv
                 return false;
             }
 
+            // If the series was set to monitor "Existing" only, don't monitor new episodes without files
+            if (series.AddOptions != null && series.AddOptions.Monitor == MonitorTypes.Existing && !episode.HasFile)
+            {
+                return false;
+            }
+
             var season = seasons.SingleOrDefault(c => c.SeasonNumber == episode.SeasonNumber);
             return season == null || season.Monitored;
         }

--- a/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
@@ -113,7 +113,7 @@ namespace NzbDrone.Core.Tv
             }
 
             // If the series was set to monitor "Existing" only, don't monitor new episodes without files
-            if (series.AddOptions != null && series.AddOptions.Monitor == MonitorTypes.Existing && !episode.HasFile)
+            if (series.AddOptions?.Monitor == MonitorTypes.Existing && episode?.HasFile != true)
             {
                 return false;
             }


### PR DESCRIPTION
When "Monitor Existing" was selected, it would only monitor episodes with files initially. However, when new episodes were added to the system later (via episode refresh), they were automatically monitored regardless of whether they had files, because the logic only checked `MonitorNewItems` and season monitoring status.

@plz12345 This is kind of a YOLO I don't have a good way to test this. I don't really feel like waiting for a week or so for a release to hit and test. 

* Fixes #64 