### PR TITLE
Fix: CSS updates

### DIFF
--- a/frontend/src/Episode/EpisodeTitleLink.css
+++ b/frontend/src/Episode/EpisodeTitleLink.css
@@ -1,5 +1,19 @@
 .link {
   composes: link from '~Components/Link/Link.css';
+  
+  max-width: 800px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-block;
+  
+   @media (min-width: 1440px) {
+    max-width: 1200x;
+  }
+
+  @media (min-width: 2160px) {
+    max-width: 2000px;
+  }
 
   &:hover {
     color: var(--linkHoverColor);

--- a/frontend/src/Episode/EpisodeTitleLink.css
+++ b/frontend/src/Episode/EpisodeTitleLink.css
@@ -1,22 +1,21 @@
 .link {
   composes: link from '~Components/Link/Link.css';
+
+  display: inline-block;
+  overflow: hidden;
   
   max-width: 800px;
-  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  display: inline-block;
-  
-   @media (min-width: 1440px) {
-    max-width: 1200x;
-  }
-
-  @media (min-width: 2160px) {
-    max-width: 2000px;
-  }
 
   &:hover {
     color: var(--linkHoverColor);
     text-decoration: underline;
+  }
+   @media (min-width: 2560px) {
+    max-width: 1200px;
+  }
+  @media (min-width: 3840px) {
+    max-width: 2000px;
   }
 }

--- a/frontend/src/Episode/EpisodeTitleLink.js
+++ b/frontend/src/Episode/EpisodeTitleLink.js
@@ -41,6 +41,7 @@ class EpisodeTitleLink extends Component {
       <div>
         <Link
           className={styles.link}
+          title={episodeTitle}
           onPress={this.onLinkPress}
         >
           {episodeTitle}


### PR DESCRIPTION
With JAV on the horizon, during testing I noticed an issue with very long titles. I changed the CSS around to do various levels of trunc at various resolutions.

Tested at various resolutions and  these numbers seemed close. Didn't do a while lot of testing but it is better than what it was. 

Also added the full title on hover so that you can read it if needed.

<img width="1664" height="511" alt="current 1080p" src="https://github.com/user-attachments/assets/487b1c7e-3847-4fc9-b674-325a32bb19e6" />
<img width="1654" height="616" alt="after 1080p" src="https://github.com/user-attachments/assets/81238dc5-ce24-4006-aa1c-4afb3d1584a9" />
