### PR TITLE
Fix: Remove Scene Import from sidebar (regression)

### DIFF
--- a/frontend/src/Components/Page/Sidebar/PageSidebar.js
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.js
@@ -26,10 +26,6 @@ const links = [
     alias: '/scenes',
     children: [
       {
-        title: () => translate('ImportLibrary'),
-        to: '/add/import/scenes'
-      },
-      {
         title: () => translate('AddNew'),
         to: '/add/new/scene'
       },


### PR DESCRIPTION
#### Database Migration
NO

#### Description
At some point we had a regression that added this back.  This shouldn't be used for scene library imports, so removing it again.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)