### PR TITLE
New: Add External ID Support

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/015_add_episode_external_id.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/015_add_episode_external_id.cs
@@ -1,0 +1,14 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(015)]
+    public class AddEpisodeExternalId : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Episodes").AddColumn("ExternalId").AsString().Nullable();
+        }
+    }
+}

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/EpisodeResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/EpisodeResource.cs
@@ -5,6 +5,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
     public class EpisodeResource
     {
         public int ForeignId { get; set; }
+        public string ExternalId { get; set; }
         public int Year { get; set; }
         public int EpisodeNumber { get; set; }
         public int? AbsoluteEpisodeNumber { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -242,6 +242,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
         {
             var episode = new Episode();
             episode.TvdbId = oracleEpisode.ForeignId;
+            episode.ExternalId = oracleEpisode.ExternalId;
             episode.Overview = oracleEpisode.Overview;
             episode.SeasonNumber = oracleEpisode.Year;
             episode.AbsoluteEpisodeNumber = oracleEpisode.AbsoluteEpisodeNumber;

--- a/src/NzbDrone.Core/Tv/Episode.cs
+++ b/src/NzbDrone.Core/Tv/Episode.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Tv
 
         public int SeriesId { get; set; }
         public int TvdbId { get; set; }
+        public string ExternalId { get; set; }
         public int EpisodeFileId { get; set; }
         public int SeasonNumber { get; set; }
         public string Title { get; set; }

--- a/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshEpisodeService.cs
@@ -60,6 +60,7 @@ namespace NzbDrone.Core.Tv
 
                     episodeToUpdate.SeriesId = series.Id;
                     episodeToUpdate.TvdbId = episode.TvdbId;
+                    episodeToUpdate.ExternalId = episode.ExternalId;
                     episodeToUpdate.SeasonNumber = episode.SeasonNumber;
                     episodeToUpdate.Runtime = episode.Runtime;
                     episodeToUpdate.AbsoluteEpisodeNumber = episode.AbsoluteEpisodeNumber;


### PR DESCRIPTION
This will allow Whisparr to pull down and store the `ExternalId` of all episodes. 

Added: 
- DB migration for the new ExternalId column
- Store External ID on refresh of series.

Will be used for JAV in future PR's