### PR TITLE
Fix: Truncate Long Filenames

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedEpisodeTitlesFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/TruncatedEpisodeTitlesFixture.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using FizzWare.NBuilder;
 using FluentAssertions;
@@ -183,6 +184,123 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             result.GetByteCount().Should().BeLessOrEqualTo(255);
 
             result.Should().Be("Lorem ipsum dolor sit amet, consectetur adipiscing elit Maecenas et magna sem Morbi vitae volutpat quam, id porta arcu Orci varius natoque penatibus et magnis dis parturient montes nascetur ridiculus musu Cras vestibulum - 2016 05 06 - Episod... HDTV-720p");
+        }
+
+        [Test]
+        public void should_smartly_truncate_only_episode_title_component()
+        {
+            _series.Title = "Short Series Title";
+            _namingConfig.StandardEpisodeFormat = "{Site Title} - {Release Date} - {Episode Title} - {Quality Full}";
+
+            _episodes.First().Title = "This is an extremely long episode title that definitely needs to be truncated because it makes the filename exceed the 255 character limit when combined with all other components including series title release date and quality information which should all be preserved completely while only the episode title gets truncated smartly";
+
+            var result = Subject.BuildFileName(new List<Episode> { _episodes.First() }, _series, _episodeFile);
+            result.GetByteCount().Should().BeLessOrEqualTo(255);
+
+            // Should contain ellipsis indicating truncation occurred
+            result.Should().Contain("...");
+
+            // Should start with series title and date (preserved components)
+            result.Should().StartWith("Short Series Title - 2016 05 06 -");
+
+            // Should end with quality info and ellipsis since episode title was truncated
+            result.Should().EndWith("... - HDTV-720p");
+
+            // Verify key components are preserved
+            result.Should().Contain("Short Series Title");
+            result.Should().Contain("2016 05 06");
+            result.Should().Contain("HDTV-720p");
+        }
+
+        [Test]
+        public void should_smartly_truncate_longest_component_when_episode_title_identified()
+        {
+            _series.Title = "Series";
+            _namingConfig.StandardEpisodeFormat = "{Site Title}/{Release Date}/{Episode Title}/{Quality Full}";
+
+            _episodes.First().Title = "A Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Really Long Episode Title That Should Be Truncated";
+
+            var result = Subject.BuildFileName(new List<Episode> { _episodes.First() }, _series, _episodeFile);
+            result.GetByteCount().Should().BeLessOrEqualTo(255);
+
+            // Should contain truncated episode title with ellipsis
+            result.Should().Contain("...");
+            result.Should().EndWith($"{Path.DirectorySeparatorChar}HDTV-720p");
+
+            // Other components should remain intact
+            result.Should().StartWith($"Series{Path.DirectorySeparatorChar}2016 05 06{Path.DirectorySeparatorChar}");
+        }
+
+        [Test]
+        public void should_fallback_to_simple_truncation_when_no_episode_title_component_found()
+        {
+            _series.Title = "A Very Long Series Title That Takes Up Most Of The Filename Space And Definitely Exceeds The Character Limit For Filenames When Combined With Other Components Like Release Date And Quality Information Making The Entire Filename Too Long For The Filesystem";
+            _namingConfig.StandardEpisodeFormat = "{Site Title} - {Release Date} - {Quality Full}";
+
+            // No episode title in format, so should fallback to simple truncation
+            var result = Subject.BuildFileName(new List<Episode> { _episodes.First() }, _series, _episodeFile);
+            result.GetByteCount().Should().BeLessOrEqualTo(255);
+
+            // Should contain ellipsis indicating truncation occurred
+            result.Should().Contain("...");
+
+            // With simple truncation, the entire string is truncated and may not end with the expected format
+            result.Should().StartWith("A Very Long Series Title That Takes Up Most Of The Filename Space And Definitely Exceeds The Character Limit For Filenames When Combi");
+        }
+
+        [Test]
+        public void should_fallback_to_simple_truncation_when_non_title_components_too_long()
+        {
+            // Create a series title that is so long that even without episode title, it exceeds the limit
+            _series.Title = "An Extremely Long Series Title That Takes Up So Much Space That Even Without Episode Title The Filename Would Be Too Long For The Filesystem Limit And Needs Much More Characters To Actually Trigger The Truncation Logic Because The Current Length Is Still Under The 255 Character Limit So We Need To Add Even More Text Here To Make Sure It Goes Over The Limit When Combined With Date And Quality Information Which Should Push It Past 255 Characters Total";
+            _namingConfig.StandardEpisodeFormat = "{Site Title} - {Release Date} - {Episode Title} - {Quality Full}";
+
+            _episodes.First().Title = "Short";
+
+            var result = Subject.BuildFileName(new List<Episode> { _episodes.First() }, _series, _episodeFile);
+            result.GetByteCount().Should().BeLessOrEqualTo(255);
+
+            // Should contain ellipsis indicating truncation occurred
+            result.Should().Contain("...");
+
+            // With fallback to simple truncation, the entire string gets truncated
+            result.Should().StartWith("An Extremely Long Series Title That Takes Up So Much Space That Even Without Episode Title The Filename Would Be Too Long For The Filesy");
+        }
+
+        [Test]
+        public void should_preserve_file_extension_in_smart_truncation()
+        {
+            _series.Title = "Series";
+            _namingConfig.StandardEpisodeFormat = "{Site Title} - {Episode Title} - {Quality Full}";
+
+            _episodes.First().Title = "A Very Long Episode Title That Should Be Truncated While Preserving The File Extension And Other Components That Make The Filename Way Too Long For The Filesystem To Handle Properly When Combined With The Extension And All The Other Components Which Need To Be Much Longer To Actually Trigger The Smart Truncation Logic Because Currently The Generated Filename Is Still Under The 255 Character Limit And We Need More Text To Push It Over";
+
+            var result = Subject.BuildFileName(new List<Episode> { _episodes.First() }, _series, _episodeFile, ".mkv");
+            result.GetByteCount().Should().BeLessOrEqualTo(255);
+
+            result.Should().EndWith(".mkv");
+            result.Should().Contain("...");
+            result.Should().StartWith("Series -");
+            result.Should().Contain("- HDTV-720p");
+        }
+
+        [Test]
+        public void should_truncate_episode_title_at_word_boundary_when_possible()
+        {
+            _series.Title = "Series";
+            _namingConfig.StandardEpisodeFormat = "{Site Title} - {Episode Title} - {Quality Full}";
+
+            _episodes.First().Title = "This is a very long episode title with multiple words that should be truncated smartly at word boundaries when the filename becomes too long for filesystem limits and needs to have much more text to actually trigger the truncation logic in the smart filename builder because the current length is still under the required limit to activate the truncation functionality and we need even more words here to make it really really really really really really really really really really really really really really really really really really really really really really really long so that it definitely exceeds the character limit";
+
+            var result = Subject.BuildFileName(new List<Episode> { _episodes.First() }, _series, _episodeFile);
+            result.GetByteCount().Should().BeLessOrEqualTo(255);
+
+            result.Should().Contain("...");
+            result.Should().EndWith("- HDTV-720p");
+
+            // The truncated part should not end mid-word (though this is more of an implementation detail)
+            var truncatedPart = result.Substring(result.IndexOf(" - ") + 3, result.LastIndexOf("...") - result.IndexOf(" - ") - 3);
+            truncatedPart.Should().NotEndWith(" ");
         }
     }
 }

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -119,6 +119,62 @@ namespace NzbDrone.Core.Organizer
             _logger = logger;
         }
 
+        private string TruncateFileNameSmartly(List<string> components, string extension, NamingConfig namingConfig)
+        {
+            // Find which component contains the episode title by looking for episode title tokens
+            var episodeTitleComponentIndex = -1;
+
+            for (var i = 0; i < components.Count; i++)
+            {
+                // This is a simplified approach - in practice we'd need to track which component has the title
+                // For now, we'll assume the longest component is likely the episode title
+                if (episodeTitleComponentIndex == -1 || components[i].Length > components[episodeTitleComponentIndex].Length)
+                {
+                    episodeTitleComponentIndex = i;
+                }
+            }
+
+            if (episodeTitleComponentIndex == -1)
+            {
+                // No episode title found, fallback to simple truncation
+                var maxLength = LongPathSupport.MaxFileNameLength - extension.GetByteCount() - 3;
+                var fileNameWithoutExtension = string.Join(Path.DirectorySeparatorChar.ToString(), components);
+                return fileNameWithoutExtension.Truncate(maxLength).TrimEnd(' ', '.') + "..." + extension;
+            }
+
+            // Calculate space needed for all components except the episode title
+            var nonTitleComponents = new List<string>();
+            for (var i = 0; i < components.Count; i++)
+            {
+                if (i != episodeTitleComponentIndex)
+                {
+                    nonTitleComponents.Add(components[i]);
+                }
+            }
+
+            var nonTitleLength = string.Join(Path.DirectorySeparatorChar.ToString(), nonTitleComponents).GetByteCount();
+            var separatorLength = Path.DirectorySeparatorChar.ToString().GetByteCount(); // Space for one more separator
+            var extensionLength = extension.GetByteCount();
+            var ellipsisLength = 3; // "..." in bytes
+
+            // Calculate maximum length available for episode title
+            var maxTitleLength = LongPathSupport.MaxFileNameLength - nonTitleLength - separatorLength - extensionLength - ellipsisLength;
+
+            if (maxTitleLength <= 0)
+            {
+                // Even without episode title, we're too long - fallback to simple truncation
+                var maxLength = LongPathSupport.MaxFileNameLength - extension.GetByteCount() - 3;
+                var fileNameWithoutExtension = string.Join(Path.DirectorySeparatorChar.ToString(), components);
+                return fileNameWithoutExtension.Truncate(maxLength).TrimEnd(' ', '.') + "..." + extension;
+            }
+
+            // Truncate just the episode title
+            var truncatedTitle = components[episodeTitleComponentIndex].Truncate(maxTitleLength).TrimEnd(' ', '.') + "...";
+            components[episodeTitleComponentIndex] = truncatedTitle;
+
+            return string.Join(Path.DirectorySeparatorChar.ToString(), components) + extension;
+        }
+
         private string BuildFileName(List<Episode> episodes, Series series, EpisodeFile episodeFile, string extension, int maxPath, NamingConfig namingConfig = null, List<CustomFormat> customFormats = null)
         {
             if (namingConfig == null)
@@ -185,7 +241,15 @@ namespace NzbDrone.Core.Organizer
                 }
             }
 
-            return string.Join(Path.DirectorySeparatorChar.ToString(), components) + extension;
+            var fileName = string.Join(Path.DirectorySeparatorChar.ToString(), components) + extension;
+
+            // Smart truncation: if filename exceeds limit, truncate only the episode title
+            if (fileName.GetByteCount() > LongPathSupport.MaxFileNameLength)
+            {
+                fileName = TruncateFileNameSmartly(components, extension, namingConfig);
+            }
+
+            return fileName;
         }
 
         public string BuildFileName(List<Episode> episodes, Series series, EpisodeFile episodeFile, string extension = "", NamingConfig namingConfig = null, List<CustomFormat> customFormats = null)


### PR DESCRIPTION
Whisparr only truncated release tokens individually and not the entire filename causing errors. If the total filename was > 255 but the title, or any other token, was < 255 it would attempt to rename and then error out as the OS would not allow it. 

This new feature checks the total length of the filename, not just individual tokens, and if > 255 starts to truc the title (Assuming titles will always be the longest) till the overall filename drops below 255.