### PR TITLE
New: Allow Search By External ID

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/Definitions/SingleEpisodeSearchCriteria.cs
+++ b/src/NzbDrone.Core/IndexerSearch/Definitions/SingleEpisodeSearchCriteria.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.IndexerSearch.Definitions
         public string EpisodeTitle { get; set; }
         public DateOnly? ReleaseDate { get; set; }
         public string Performer { get; set; }
+        public string ExternalId { get; set; }
 
         public override string ToString()
         {

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -77,6 +77,11 @@ namespace NzbDrone.Core.IndexerSearch
             if (episodes.Count == 1)
             {
                 var searchSpec = Get<SingleEpisodeSearchCriteria>(series, episodes, monitoredOnly, userInvokedSearch, interactiveSearch);
+                var episode = episodes.First();
+                searchSpec.ReleaseDate = DateOnly.Parse(episode.AirDate);
+                searchSpec.Performer = episode.Actors.Select(p => p.Name).FirstOrDefault();
+                searchSpec.EpisodeTitle = episode.Title;
+                searchSpec.ExternalId = episode.ExternalId;
 
                 var decisions = await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
                 downloadDecisions.AddRange(decisions);
@@ -101,6 +106,7 @@ namespace NzbDrone.Core.IndexerSearch
             searchSpec.ReleaseDate = DateOnly.Parse(episode.AirDate);
             searchSpec.Performer = episode.Actors.Select(p => p.Name).FirstOrDefault();
             searchSpec.EpisodeTitle = episode.Title;
+            searchSpec.ExternalId = episode.ExternalId;
 
             var decisions = await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
             downloadDecisions.AddRange(decisions);

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
@@ -122,6 +122,17 @@ namespace NzbDrone.Core.Indexers.Newznab
                             "search",
                             searchQuery));
                     }
+
+                    // Add External ID search if selected and available
+                    if (Settings.SearchExternalIdOnly && !string.IsNullOrWhiteSpace(searchCriteria.ExternalId))
+                    {
+                        var externalId = NewsnabifyTitle(searchCriteria.ExternalId);
+                        var searchQuery = $"&q={externalId}";
+                        pageableRequests.Add(GetPagedRequests(MaxPages,
+                            Settings.Categories,
+                            "search",
+                            searchQuery));
+                    }
                 }
             }
 

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
@@ -93,13 +93,17 @@ namespace NzbDrone.Core.Indexers.Newznab
         [FieldDefinition(8, Label = "Search Site + Title", Type = FieldType.Checkbox, HelpText = "Search using site name + title (without date/year).", Advanced = true)]
         public bool SearchSiteTitleOnly { get; set; }
 
-        [FieldDefinition(9, Label = "Date Format", Type = FieldType.Select, SelectOptions = typeof(DateSearchFormat), HelpText = "Date format to use in searches: YY.MM.DD, DD.MM.YY, or Both", Advanced = true)]
+        [FieldDefinition(9, Label = "Search External ID Only", Type = FieldType.Checkbox, HelpText = "Search using external ID only (without date/year/title).", Advanced = true)]
+        public bool SearchExternalIdOnly { get; set; }
+
+        [FieldDefinition(10, Label = "Date Format", Type = FieldType.Select, SelectOptions = typeof(DateSearchFormat), HelpText = "Date format to use in searches: YY.MM.DD, DD.MM.YY, or Both", Advanced = true)]
         public DateSearchFormat DateSearchFormat { get; set; }
 
-        [FieldDefinition(10, Label = "Network or Site", Type = FieldType.Select, SelectOptions = typeof(SeriesNameSource), HelpText = "Choose between Site Name, Network Name, or both for series searches", Advanced = true)]
+        [FieldDefinition(11, Label = "Network or Site", Type = FieldType.Select, SelectOptions = typeof(SeriesNameSource), HelpText = "Choose between Site Name, Network Name, or both for series searches", Advanced = true)]
         public SeriesNameSource SeriesNameSource { get; set; }
 
-        // Field 11 is used by TorznabSettings MinimumSeeders
+        // Field 12 is used by TorznabSettings MinimumSeeders
+        // Field 13 is used by TorznabSettings SeedCriteria
         // If you need to add another field here, update TorznabSettings as well and this comment
 
         public virtual NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
@@ -49,10 +49,10 @@ namespace NzbDrone.Core.Indexers.Torznab
             MinimumSeeders = IndexerDefaults.MINIMUM_SEEDERS;
         }
 
-        [FieldDefinition(11, Type = FieldType.Number, Label = "Minimum Seeders", HelpText = "Minimum number of seeders required.", Advanced = true)]
+        [FieldDefinition(12, Type = FieldType.Number, Label = "Minimum Seeders", HelpText = "Minimum number of seeders required.", Advanced = true)]
         public int MinimumSeeders { get; set; }
 
-        [FieldDefinition(12)]
+        [FieldDefinition(13)]
         public SeedCriteriaSettings SeedCriteria { get; set; } = new SeedCriteriaSettings();
 
         public override NzbDroneValidationResult Validate()


### PR DESCRIPTION
This allows users to search by the `externalId` that is stored in the DB for a given episode. It adds another option inside of the indexers settings similar to Site + Title only. 

Please note this is only the SEARCH it will still fail to automatically download and import. Users will need to manually download and import (Unless using the force download option) until I updated the parsing to accept External id. That will be next on the to do list.