### PR TITLE
Chore: Add .continue folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ src/**/[Oo]bj/
 *.sln.docstates
 .vs/
 .vscode/
+.continue/
 
 # Build results
 *_i.c


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Continue is an IDE extension that integrates with various LLM's.  It defaults to storeing its files in `.continue`, in the project root.  Until I have tuned/tested it, I'll exclude its content from the repo.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)