### PR TITLE
Chore: Add Continue extension files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ src/**/[Oo]bj/
 *.sln.docstates
 .vs/
 .vscode/
+.continue/
 
 # Build results
 *_i.c


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This extension is used for integration custom LLM's to the dev experience.  It uses project root config in .continue, and these configs aren't ready for shared usage yet.

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX