### PR TITLE
Chore: Fix Azure pipeline warning related to report generation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1200,7 +1200,7 @@ stages:
           ./build.sh --backend -f net6.0 -r win-x64
           TEST_DIR=_tests/net6.0/win-x64/publish/ ./test.sh Windows Unit Coverage
         displayName: Coverage Unit Tests
-      - task: reportgenerator@5.3.11
+      - task: reportgenerator@5.4.9
         displayName: Generate Coverage Report
         inputs:
           reports: '$(Build.SourcesDirectory)/CoverageResults/**/coverage.opencover.xml'


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This pipeline action is creating a warning in the output.  The action's dev has released a newer version of it, as of July, which is intended to negate the deprecation warning.

https://github.com/danielpalme/ReportGenerator/issues/744

I'm not sure if Azure is pulling the pipeline YAML from the commit branch, or repo default branch, so I can re-play this PR on `develop` is Azure is only looking at the default branch.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX