### PR TITLE
Fix: Remove extra visible bracket from performer details

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetails.js
+++ b/frontend/src/Performer/Details/PerformerDetails.js
@@ -403,7 +403,7 @@ class PerformerDetails extends Component {
                         position={tooltipPositions.BOTTOM}
                       />
                     </span>
-                    }
+
                     {!!tags.length && (
                       <span>
                         <Tooltip


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Recent performer page edits had an extra bracket on the page, fixed.

#### Screenshot (if UI related)
<img width="636" height="255" alt="image" src="https://github.com/user-attachments/assets/7f8b43e0-9d02-4631-a9e0-2252b1be5f73" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX