### PR TITLE
Fix: Omit stop words in manual import filter

### DIFF
--- a/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
+++ b/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
@@ -165,16 +165,25 @@ function SelectMovieModalContent(props: SelectMovieModalContentProps) {
     [allMovies, onMovieSelect]
   );
 
+  function normalize(input: string): string {
+    const stopWords = new Set(['a', 'an', 'the', 'and', 'or', 'of']);
+    return input
+      .toLowerCase()
+      .split(/[^a-z0-9]+/) // split on non-alphanumeric
+      .filter((word) => word && !stopWords.has(word))
+      .join('');
+  }
+
   const items = useMemo(() => {
     const sorted = [...allMovies].sort((a, b) =>
       a.sortTitle.localeCompare(b.sortTitle)
     );
 
+    const normalizedFilter = normalize(filter);
+
     return sorted.filter(
       (item) =>
-        item.cleanTitle.includes(
-          filter.toLowerCase().replace(/[^a-zA-Z0-9]/g, '')
-        ) ||
+        normalize(item.cleanTitle).includes(normalizedFilter) ||
         item.stashId === filter ||
         item.tmdbId.toString() === filter
     );


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Replace existing simple regex with a tokenized filter based on the .NET Clean Title regex (no JavaScript equivalent).

This approximates the .NET regex defined here
https://github.com/Whisparr/Whisparr/blob/1dc84cd55c3ceade35495fbd0a407b4aafe3f046/src/NzbDrone.Core/Parser/Parser.cs#L173
 
I tested this with a bunch of combinations, but will happily revise if anyone reports issues I didn't account for in my tests.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #613 