### PR TITLE
New: Add parser button to scenes index

### DIFF
--- a/frontend/src/Scene/Index/SceneIndex.tsx
+++ b/frontend/src/Scene/Index/SceneIndex.tsx
@@ -28,6 +28,7 @@ import MovieIndexSelectAllButton from 'Movie/Index/Select/MovieIndexSelectAllBut
 import MovieIndexSelectAllMenuItem from 'Movie/Index/Select/MovieIndexSelectAllMenuItem';
 import MovieIndexSelectModeButton from 'Movie/Index/Select/MovieIndexSelectModeButton';
 import MovieIndexSelectModeMenuItem from 'Movie/Index/Select/MovieIndexSelectModeMenuItem';
+import ParseToolbarButton from 'Parse/ParseToolbarButton';
 import NoScene from 'Scene/NoScene';
 import { executeCommand } from 'Store/Actions/commandActions';
 import { fetchQueueDetails } from 'Store/Actions/queueActions';
@@ -237,7 +238,7 @@ const SceneIndex = withScrollPosition((props: SceneIndexProps) => {
             />
 
             <PageToolbarButton
-              label={translate('RSSSync')}
+              label={translate('RssSync')}
               iconName={icons.RSS}
               isSpinning={isRssSyncExecuting}
               isDisabled={hasNoScene}
@@ -258,6 +259,8 @@ const SceneIndex = withScrollPosition((props: SceneIndexProps) => {
               onPress={onInteractiveImportPress}
             />
 
+            <PageToolbarSeparator />
+            <ParseToolbarButton />
             <PageToolbarSeparator />
 
             <MovieIndexSelectModeButton


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Adds the Parser Test button to Scenes index.  A lot of users have "why didn't this match" questions on releases.  While this button is in Settings > Custom Formats, it isn't really useful or (IMO) relevant there.  This is also in line with Sonarr, which also has it more prominent on the main page.  I also fixed a bad localization on the RSS Sync button.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #628 