### PR TITLE
New: Add relative path to import movie select modal

### DIFF
--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
@@ -332,6 +332,7 @@ function InteractiveImportRow(props: InteractiveImportRowProps) {
       <SelectMovieModal
         isOpen={selectModalOpen === 'movie'}
         modalTitle={modalTitle}
+        relativePath={relativePath}
         onMovieSelect={onMovieSelect}
         onModalClose={onSelectModalClose}
       />

--- a/frontend/src/InteractiveImport/Movie/SelectMovieModal.tsx
+++ b/frontend/src/InteractiveImport/Movie/SelectMovieModal.tsx
@@ -6,17 +6,20 @@ import SelectMovieModalContent from './SelectMovieModalContent';
 interface SelectMovieModalProps {
   isOpen: boolean;
   modalTitle: string;
+  relativePath?: string;
   onMovieSelect(movie: Movie): void;
   onModalClose(): void;
 }
 
 function SelectMovieModal(props: SelectMovieModalProps) {
-  const { isOpen, modalTitle, onMovieSelect, onModalClose } = props;
+  const { isOpen, modalTitle, relativePath, onMovieSelect, onModalClose } =
+    props;
 
   return (
     <Modal isOpen={isOpen} onModalClose={onModalClose}>
       <SelectMovieModalContent
         modalTitle={modalTitle}
+        relativePath={relativePath || ''}
         onMovieSelect={onMovieSelect}
         onModalClose={onModalClose}
       />

--- a/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
+++ b/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
@@ -53,6 +53,7 @@ const bodyPadding = parseInt(dimensions.pageContentBodyPadding);
 
 interface SelectMovieModalContentProps {
   modalTitle: string;
+  relativePath: string;
   onMovieSelect(movie: Movie): void;
   onModalClose(): void;
 }
@@ -103,7 +104,7 @@ const Row: React.FC<ListChildComponentProps<RowItemData>> = ({
 };
 
 function SelectMovieModalContent(props: SelectMovieModalContentProps) {
-  const { modalTitle, onMovieSelect, onModalClose } = props;
+  const { modalTitle, relativePath, onMovieSelect, onModalClose } = props;
 
   const listRef = useRef<List<RowItemData>>(null);
   const scrollerRef = useRef<HTMLDivElement>(null);
@@ -234,7 +235,8 @@ function SelectMovieModalContent(props: SelectMovieModalContentProps) {
         </Scroller>
       </ModalBody>
 
-      <ModalFooter>
+      <ModalFooter className={styles.footer}>
+        <div className={styles.path}>{relativePath}</div>
         <Button onPress={onModalClose}>Cancel</Button>
       </ModalFooter>
     </ModalContent>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added the relative path when selecting a movie/scene to map to a manual file import.

#### Screenshot (if UI related)
<details><summary>Click to view</summary>
Note: data in screenshot is sample data, the only change is the relative path in light grey in the footer.
<img width="1060" height="568" alt="image" src="https://github.com/user-attachments/assets/e8e5d498-583e-47d6-b4e6-c50537c7374a" />
</details>

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #624 