### PR TITLE
New: NFO Creation Additions

### DIFF
--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -204,7 +204,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     xmlResult += Environment.NewLine;
                 }
 
-                xmlResult += "https://www.thetvdb.com/?tab=series&id=" + series.TvdbId;
+                xmlResult += "https://theporndb.net/sites/" + series.TvdbId;
             }
 
             return xmlResult.IsNullOrWhiteSpace() ? null : new MetadataFileResult("tvshow.nfo", xmlResult);
@@ -240,6 +240,12 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     details.Add(new XElement("aired", episode.AirDate));
                     details.Add(new XElement("plot", episode.Overview));
 
+                    // Add studio for Stash compatibility
+                    if (!string.IsNullOrWhiteSpace(series.Network))
+                    {
+                        details.Add(new XElement("studio", series.Network));
+                    }
+
                     var tvdbId = new XElement("uniqueid", episode.TvdbId);
                     tvdbId.SetAttributeValue("type", "tvdb");
                     tvdbId.SetAttributeValue("default", true);
@@ -248,6 +254,14 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     var whisparrId = new XElement("uniqueid", episode.Id);
                     whisparrId.SetAttributeValue("type", "whisparr");
                     details.Add(whisparrId);
+
+                    // Add TPDB ID for Stash compatibility
+                    if (!string.IsNullOrWhiteSpace(episode.ExternalId))
+                    {
+                        var tpdbId = new XElement("uniqueid", episode.ExternalId);
+                        tpdbId.SetAttributeValue("type", "tpdb");
+                        details.Add(tpdbId);
+                    }
 
                     if (image == null)
                     {
@@ -263,6 +277,20 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                     if (episode.Ratings != null && episode.Ratings.Votes > 0)
                     {
                         details.Add(new XElement("rating", episode.Ratings.Value));
+                    }
+
+                    // Add performers/actors for Stash compatibility
+                    if (episode.Actors != null && episode.Actors.Any())
+                    {
+                        var order = 1;
+                        foreach (var actor in episode.Actors)
+                        {
+                            var actorElement = new XElement("actor");
+                            actorElement.Add(new XElement("name", actor.Name));
+                            actorElement.Add(new XElement("order", order));
+                            details.Add(actorElement);
+                            order++;
+                        }
                     }
 
                     if (episodeFile.MediaInfo != null)

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataSettings.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadataSettings.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
         [FieldDefinition(0, Label = "Series Metadata", Type = FieldType.Checkbox, Section = MetadataSectionType.Metadata, HelpText = "tvshow.nfo with full series metadata")]
         public bool SeriesMetadata { get; set; }
 
-        [FieldDefinition(1, Label = "Series Metadata URL", Type = FieldType.Checkbox, Section = MetadataSectionType.Metadata, HelpText = "tvshow.nfo with TheTVDB show URL (can be combined with 'Series Metadata')", Advanced = true)]
+        [FieldDefinition(1, Label = "Series Metadata URL", Type = FieldType.Checkbox, Section = MetadataSectionType.Metadata, HelpText = "tvshow.nfo with ThePornDB URL (can be combined with 'Series Metadata')", Advanced = true)]
         public bool SeriesMetadataUrl { get; set; }
 
         [FieldDefinition(2, Label = "Episode Metadata", Type = FieldType.Checkbox, Section = MetadataSectionType.Metadata, HelpText = "<filename>.nfo")]


### PR DESCRIPTION
Various additions to NFO creation to assists Stash users.

- I added in performers with an order tag so that the Stash NFO plugin can order them correctly
- Decided to omit tags as 1) the data would be awful and 2) we don't have them anyway.
- Added TPDB ID Support for Site
- Added Studio/Site
- Updated various strinigs for better verbage


Completes the V2 section of https://github.com/Whisparr/Whisparr/issues/588