### PR TITLE
New: Additional release parser match

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
@@ -24,6 +24,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Studio.22.10.18.Title.XXX.720p.HEVC.x265.PRT[XvX]", true)]
         [TestCase("Studio - 2017-08-04 - Some Title. [WEBDL-480p]", true)]
         [TestCase("Pure Taboo - Sarah Arabic, Lily LaBeau - A Costly Divorce (June 24, 2025) [1080p HEVC x265]", true)]
+        [TestCase("[BellesaFilms] The Sister - Ashley Lane, Mannie Coco (2025-09-28) [2160p]", true)]
         [TestCase("something random 77f1b861-91c1-4e6f-b0b1-3b1c46733fb2 anything", true)] // StashId
         [TestCase("SGKI-011", true)]
         [TestCase("JUNY-018", true)]
@@ -55,6 +56,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Jesse Loads Monster Facials 2024-04-19 Frecklemonade.mkv", "Jesse Loads Monster Facials")]
         [TestCase("Lustery E1717 James And Six Sharp Cold Fear XXX 1080p MP4 FETiSH", "Lustery")]
         [TestCase("Pure Taboo - Sarah Arabic, Lily LaBeau - A Costly Divorce (June 24, 2025) [1080p HEVC x265]", "Pure Taboo")]
+        [TestCase("[BellesaFilms] The Sister - Ashley Lane, Mannie Coco (2025-09-28) [2160p]", "BellesaFilms")]
+
         public void should_correctly_parse_studio_names(string title, string result)
         {
             Parser.Parser.ParseMovieTitle(title).StudioTitle.Should().Be(result);
@@ -75,6 +78,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Studio - Performer Name - Some Title (10.01.2024)", "2024-01-10")]
         [TestCase("Step Siblings Caught 2024-02-07 Cash For Kisses On Valentines Day - S25E7", "2024-02-07")]
         [TestCase("Pure Taboo - Sarah Arabic, Lily LaBeau - A Costly Divorce (June 24, 2025) [1080p HEVC x265]", "2025-06-24")]
+        [TestCase("[BellesaFilms] The Sister - Ashley Lane, Mannie Coco (2025-09-28) [2160p]", "2025-09-28")]
         [TestCase("Jesse Loads Monster Facials 2024-04-19 Frecklemonade.mkv", "2024-04-19")]
         public void should_correctly_parse_release_date(string title, string result)
         {
@@ -99,6 +103,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Jesse Loads Monster Facials 2024-04-19 Frecklemonade.mkv", "frecklemonade")]
         [TestCase("Lustery E1717 James And Six Sharp Cold Fear XXX 1080p MP4 FETiSH", "james and six sharp cold fear")]
         [TestCase("Pure Taboo - Sarah Arabic, Lily LaBeau - A Costly Divorce (June 24, 2025) [1080p HEVC x265]", "sarah arabic lily labeau a costly divorce")]
+        [TestCase("[BellesaFilms] The Sister - Ashley Lane, Mannie Coco (2025-09-28) [2160p]", "the sister")]
         public void should_correctly_parse_normalize_release_token(string title, string result)
         {
             var releaseTokens = Parser.Parser.ParseMovieTitle(title).ReleaseTokens;

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -32,6 +32,11 @@ namespace NzbDrone.Core.Parser
             new Regex(@"^(?<studiotitle>[^-]+?)(?<releasetoken>\s*-\s*.+?)\s*\(\s*(?<airmonthname>January|February|March|April|May|June|July|August|September|October|November|December)\s+(?<airday>[0-3]?\d),?\s+(?<airyear>(19|20)\d{2})\s*\)",
                 RegexOptions.IgnoreCase | RegexOptions.Compiled),
 
+            // [Site] Title - Performers (yyyy-mm-dd) [Quality]
+            // [BellesaFilms] The Sister - Ashley Lane, Mannie Coco (2025-09-28) [2160p]
+            new Regex(@"^\[(?<studiotitle>[^\]]+)]\s+(?<releasetoken>.+?)\s*-\s*.*?\((?<airyear>\d{4})-(?<airmonth>\d{2})-(?<airday>\d{2})\)(?:\s+\[(?<quality>\d+p)])?$",
+                RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
             // (?P<site>.+?)?[\s\.\-](?P<date>\d{2}[\s\.\-]\d{2}[\s\.\-]\d{2})[\s\.\-](?P<performer>\w+.+?)?[\s\.\-](?P<title>.*?(?=(?:[\s\.\-]mp4)|$))
             // SCENE with airdate (18.04.28, 2018.04.28, 18-04-28, 18 04 28, 18_04_28) and performer
             new Regex(@"^(?<studiotitle>.+?)?[-_. ]+(?<airyear>\d{2}|\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])[-_. ]+(?<performer>\w+.+?)?[-_. ](?<title>.*?(?=(?:[-_. ]mp4)|$))",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Added a scene parser for this type of naming where studio is in brackets and date is toward the end.  I noticed a bunch of releases on HF that were named in a decent structure, but were coming up as Unknown Movie in interactive search.

`[BellesaFilms] The Sister - Ashley Lane, Mannie Coco (2025-09-27) [2160p]`

https://regex101.com/r/Eg6ipE/2

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX