### PR TITLE
Fix  TMDb company import list empty results

### DIFF
--- a/src/NzbDrone.Core/ImportLists/TMDb/Company/TMDbCompanyImport.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/Company/TMDbCompanyImport.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.ImportLists.TMDb.Company
 
         public override IParseImportListResponse GetParser()
         {
-            return new TMDbCompanyParser();
+            return new TMDbCompanyParser(Settings);
         }
 
         public override IImportListRequestGenerator GetRequestGenerator()

--- a/src/NzbDrone.Core/ImportLists/TMDb/Company/TMDbCompanyParser.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/Company/TMDbCompanyParser.cs
@@ -7,6 +7,13 @@ namespace NzbDrone.Core.ImportLists.TMDb.Company
 {
     public class TMDbCompanyParser : TMDbParser
     {
+        private readonly TMDbCompanySettings _settings;
+
+        public TMDbCompanyParser(TMDbCompanySettings settings)
+        {
+            _settings = settings;
+        }
+
         public override IList<ImportListMovie> ParseResponse(ImportListResponse importResponse)
         {
             var movies = new List<ImportListMovie>();

--- a/src/NzbDrone.Core/ImportLists/TMDb/Company/TMDbCompanyRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/TMDb/Company/TMDbCompanyRequestGenerator.cs
@@ -11,13 +11,15 @@ namespace NzbDrone.Core.ImportLists.TMDb.Company
         public IHttpClient HttpClient { get; set; }
         public IHttpRequestBuilderFactory RequestBuilder { get; set; }
         public Logger Logger { get; set; }
-        public int MaxPages { get; set; }
 
         public virtual ImportListPageableRequestChain GetMovies()
         {
             var pageableRequests = new ImportListPageableRequestChain();
 
-            pageableRequests.Add(GetMoviesRequest());
+            foreach (var request in GetMoviesRequest())
+            {
+                pageableRequests.Add(new[] { request }); // Wrap each in its own enumerable (workaround)
+            }
 
             return pageableRequests;
         }
@@ -27,27 +29,37 @@ namespace NzbDrone.Core.ImportLists.TMDb.Company
             Logger.Info($"Importing TMDb movies from company: {Settings.CompanyId}");
 
             var requestBuilder = RequestBuilder.Create()
-                                               .SetSegment("api", "3")
-                                               .SetSegment("route", "discover")
-                                               .SetSegment("id", $"movie")
-                                               .SetSegment("secondaryRoute", "")
-                                               .AddQueryParam("include_adult", true);
+                .SetSegment("api", "3")
+                .SetSegment("route", "discover")
+                .SetSegment("id", $"movie")
+                .SetSegment("secondaryRoute", "")
+                .AddQueryParam("include_adult", "true")
+                .AddQueryParam("include_video", "false")
+                .AddQueryParam("language", "en-US")
+                .AddQueryParam("sort_by", "popularity.desc")
+                .AddQueryParam("with_companies", Settings.CompanyId);
 
-            requestBuilder.AddQueryParam("with_companies", Settings.CompanyId);
+            // Initial request to get total pages
+            var initialBuilder = requestBuilder.Clone().AddQueryParam("page", "1");
+            var initialRequest = new ImportListRequest(initialBuilder.Accept(HttpAccept.Json).Build());
+            var initialResponse = HttpClient.Get(initialRequest.HttpRequest);
 
-            var jsonResponse = JsonConvert.DeserializeObject<MovieSearchResource>(HttpClient.Execute(requestBuilder.Build()).Content);
-
-            MaxPages = jsonResponse.TotalPages;
-
-            for (var pageNumber = 1; pageNumber <= MaxPages; pageNumber++)
+            if (initialResponse.HasHttpError)
             {
-                requestBuilder.AddQueryParam("page", pageNumber, true);
+                Logger.Warn($"TMDb request failed on page 1: {initialResponse.StatusCode}");
+                yield break;
+            }
 
-                var request = requestBuilder.Build();
+            var json = JsonConvert.DeserializeObject<MovieSearchResource>(initialResponse.Content);
+            var totalPages = json.TotalPages;
+            Logger.Debug($"Total pages to fetch: {totalPages}");
 
-                Logger.Debug($"Importing TMDb movies from: {request.Url}");
+            for (var page = 1; page <= totalPages; page++)
+            {
+                Logger.Debug($"Building request for page [{page}]");
 
-                yield return new ImportListRequest(request);
+                var pageBuilder = requestBuilder.Clone().AddQueryParam("page", page.ToString());
+                yield return new ImportListRequest(pageBuilder.Accept(HttpAccept.Json).Build());
             }
         }
     }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This was broken for a couple reasons.
1. URL needed to be refactored.  `include_adult` is a case sensitive string, not a proper boolean, on TMDb's processing side.
2. Pagination wasn't working.  I put a workaround in place to force it rather than fixing the core processing code, since these lists are an edge case.

Note, I validated the Person import list, and it works as-is.  That API doesn't seem to require pagination.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #650 