### PR TITLE
Chore: Suppress CA1825 on REST controllers (Roslyn false positive)

### DIFF
--- a/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
+++ b/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Suppress CA1825 for the the API project -->
+    <NoWarn>$(NoWarn);CA1825</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Ical.Net" Version="4.2.0" />

--- a/src/Whisparr.Http/Whisparr.Http.csproj
+++ b/src/Whisparr.Http/Whisparr.Http.csproj
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Suppress CA1825 for this project -->
+    <NoWarn>$(NoWarn);CA1825</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.5.4" />
 	<PackageReference Include="ImpromptuInterface" Version="7.0.1" />


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Recent API hardening led to some IDE false positives.  Rather than suppressing these in-class, it makes more sense to do it for the REST-related controllers as a whole.

The `[Consumes("application/json")]` pattern trips this Roslyn analyzer rule, which is a false positive in this case.  In this case, the pattern is forcing expected input/output mimetypes.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX