### PR TITLE
Fix: Allow empty year on new import list exclusion entry

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusion.js
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/ImportListExclusion.js
@@ -99,7 +99,7 @@ ImportListExclusion.propTypes = {
   movieTitle: PropTypes.string.isRequired,
   foreignId: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  movieYear: PropTypes.number.isRequired,
+  movieYear: PropTypes.number,
   onConfirmDeleteImportExclusion: PropTypes.func.isRequired
 };
 

--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusion.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportExclusion.cs
@@ -7,7 +7,7 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
         public string ForeignId { get; set; }
         public string MovieTitle { get; set; }
         public ImportExclusionType Type { get; set; }
-        public int MovieYear { get; set; }
+        public int? MovieYear { get; set; }
 
         public new string ToString()
         {

--- a/src/Whisparr.Api.V3/ImportLists/ImportExclusionsResource.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportExclusionsResource.cs
@@ -10,7 +10,7 @@ namespace Whisparr.Api.V3.ImportLists
         public string ForeignId { get; set; }
         public string MovieTitle { get; set; }
         public ImportExclusionType Type { get; set; }
-        public int MovieYear { get; set; }
+        public int? MovieYear { get; set; }
     }
 
     public static class ImportExclusionsResourceMapper
@@ -45,7 +45,7 @@ namespace Whisparr.Api.V3.ImportLists
                 ForeignId = resource.ForeignId,
                 MovieTitle = resource.MovieTitle,
                 Type = resource.Type,
-                MovieYear = resource.MovieYear
+                MovieYear = resource.MovieYear ?? 0
             };
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Allow empty year when manually adding an import list exclusion.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #512 