### PR TITLE
Fix: Pass V2 JAV Tests

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParseMovieTitleFixture.cs
@@ -110,5 +110,24 @@ namespace NzbDrone.Core.Test.ParserTests
             var cleanReleaseToken = Parser.Parser.NormalizeEpisodeTitle(releaseTokens);
             cleanReleaseToken.Should().Be(result);
         }
+
+        [TestCase("[SKMJ-649] Amateur female college students found at hot springs all over Japan. Would you like to try entering the men's bath with just a towel on? 15 ordinary tourists who were traveling normally until just now. All of them have raw creampie sin this luxurious 3-hour special.", "SKMJ-649")]
+        [TestCase("[ABC-123] Test Title", "ABC-123")]
+        [TestCase("(XYZ-456) Another Test", "XYZ-456")]
+        [TestCase("{DEF-789} Curly Brackets", "DEF-789")]
+        [TestCase("GHI-012 Starting Title", "GHI-012")]
+        [TestCase("[JKL_345] Underscore Separator", "JKL_345")]
+        [TestCase("[MNO.678] Dot Separator", "MNO.678")]
+        [TestCase("[ABCD 123] Space Separator", "ABCD 123")]
+        [TestCase("WXYZ-999 Title Without Brackets", "WXYZ-999")]
+        [TestCase("No External ID Here", null)]
+        [TestCase("", null)]
+        [TestCase("Random [Text] Without ID Pattern", null)]
+        [TestCase("[123] Number Only", null)]
+        [TestCase("[ABC] Letters Only", null)]
+        public void should_correctly_parse_code(string title, string result)
+        {
+            Parser.Parser.ParseMovieTitle(title)?.Code.Should().Be(result);
+        }
     }
 }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -129,6 +129,9 @@ namespace NzbDrone.Core.Parser
 
             // JAV-FC2
             new Regex(@"(?<code>FC2.*(?:PPV).*[0-9]{4,7})", RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+            // Pattern for IDs in brackets like [SKMJ-649], (ABC-123), {XYZ-456}, [SKMJ_649], [SKMJ.649]
+            new Regex(@"[\[\(\{](?<code>[A-Z]{2,5}[- ][0-9]{3,5})[\]\)\}]", RegexOptions.IgnoreCase | RegexOptions.Compiled),
         };
 
         private static readonly Regex[] ReportTitleFolderRegex = new[]
@@ -999,6 +1002,7 @@ namespace NzbDrone.Core.Parser
                     result.StashId = m.Groups["stashid"].Value;
                 }
 
+                result.Code = string.Empty;
                 if (matchCollection[0].Groups["code"].Success)
                 {
                     result.Code = matchCollection[0].Groups["code"].Value;


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Add the JAV Tests from v2 and alter the parser to pass the additional patterns.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX