### PR TITLE
Fixed: Filter scenes by Studio, Genre

### DIFF
--- a/frontend/src/Store/Actions/sceneIndexActions.js
+++ b/frontend/src/Store/Actions/sceneIndexActions.js
@@ -207,7 +207,7 @@ export const defaultState = {
           return acc;
         }, []);
 
-        return tagList.sort(sortByProp('studioTitle'));
+        return tagList.sort(sortByProp('name'));
       }
     },
     {
@@ -265,7 +265,7 @@ export const defaultState = {
           return acc;
         }, []);
 
-        return genreList.sort(sortByProp('genres'));
+        return genreList.sort(sortByProp('name'));
       }
     },
     {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The Radarr upstream picks caused an issue when I ported them to Scene Index.  This fixes that, so the app doesn't throw when attempting to biuld a scene index filter based on Studio or Genre.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #690