### PR TITLE
Fixed: Image loading to use native lazy load

### DIFF
--- a/frontend/src/Movie/Details/Credits/Cast/MovieCastPoster.js
+++ b/frontend/src/Movie/Details/Credits/Cast/MovieCastPoster.js
@@ -93,7 +93,7 @@ class MovieCastPoster extends Component {
                 style={elementStyle}
                 images={performer.images}
                 size={250}
-                lazy={true}
+                lazy={false}
                 overflow={true}
                 onError={this.onPosterLoadError}
                 onLoad={this.onPosterLoad}

--- a/frontend/src/Movie/Details/MovieDetails.js
+++ b/frontend/src/Movie/Details/MovieDetails.js
@@ -336,7 +336,7 @@ class MovieDetails extends Component {
                 coverType={itemType === 'movie' ? 'poster' : 'screenshot'}
                 images={images}
                 size={500}
-                lazy={true}
+                lazy={false}
                 placeholder={posterPlaceholder}
               />
 

--- a/frontend/src/Movie/MovieImage.tsx
+++ b/frontend/src/Movie/MovieImage.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import LazyLoad from 'react-lazyload';
 import { CoverType, Image } from './Movie';
 import styles from './MovieImage.css';
 
@@ -40,26 +39,22 @@ function MovieImage({
   safeForWorkMode,
   size = 250,
   lazy = true,
-  overflow = false,
   onError,
   onLoad,
 }: MovieImageProps) {
   const [url, setUrl] = useState<string | null>(null);
   const [hasError, setHasError] = useState(false);
-  const [isLoaded, setIsLoaded] = useState(false);
   const image = useRef<Image | null>(null);
 
   const handleLoad = useCallback(() => {
     setHasError(false);
-    setIsLoaded(true);
     onLoad?.();
-  }, [setHasError, setIsLoaded, onLoad]);
+  }, [setHasError, onLoad]);
 
   const handleError = useCallback(() => {
     setHasError(true);
-    setIsLoaded(false);
     onError?.();
-  }, [setHasError, setIsLoaded, onError]);
+  }, [setHasError, onError]);
 
   useEffect(() => {
     const nextImage = findImage(images, coverType);
@@ -95,38 +90,13 @@ function MovieImage({
     return <img className={className} style={style} src={placeholder} />;
   }
 
-  if (lazy) {
-    const blurClass = safeForWorkMode ? styles.blur : 'blur';
-    return (
-      <LazyLoad
-        height={size}
-        offset={100}
-        overflow={overflow}
-        placeholder={
-          <img
-            className={`${className ?? ''} ${blurClass}`}
-            style={style}
-            src={placeholder}
-          />
-        }
-      >
-        <img
-          className={`${className ?? ''} ${blurClass}`}
-          style={style}
-          src={url}
-          rel="noreferrer"
-          onError={handleError}
-          onLoad={handleLoad}
-        />
-      </LazyLoad>
-    );
-  }
-
+  const blurClass = safeForWorkMode ? styles.blur : 'blur';
   return (
     <img
-      className={className}
+      className={`${className ?? ''} ${blurClass}`}
       style={style}
-      src={isLoaded ? url : placeholder}
+      src={url ?? placeholder}
+      loading={lazy ? 'lazy' : undefined} // native lazy loading
       onError={handleError}
       onLoad={handleLoad}
     />

--- a/frontend/src/Performer/Details/PerformerDetails.js
+++ b/frontend/src/Performer/Details/PerformerDetails.js
@@ -326,7 +326,7 @@ class PerformerDetails extends Component {
                 style={elementStyle}
                 images={images}
                 size={250}
-                lazy={true}
+                lazy={false}
               />
 
               <div className={styles.info}>

--- a/frontend/src/Studio/Details/StudioDetails.js
+++ b/frontend/src/Studio/Details/StudioDetails.js
@@ -312,7 +312,7 @@ class StudioDetails extends Component {
                 style={elementStyle}
                 images={images}
                 size={250}
-                lazy={true}
+                lazy={false}
               />
 
               <div className={styles.info}>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
My recent re-work for SFW mode broke some image loading due to how React's lazy loader works.  This isn't even needed in modern browsers, so I removed it and went with the native browser lazy load.  Larger views use it, whereas detail views eager load.

Internet Explorer users can join us in modern times...

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #683