### PR TITLE
Fix: Run Media Info Service to extract the correct resolution on rescans

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -154,17 +154,12 @@ namespace NzbDrone.Core.MediaFiles
                 var path = Path.Combine(movie.Path, file.RelativePath);
                 var fileSize = _diskProvider.GetFileSize(path);
 
-                if (file.Size == fileSize)
-                {
-                    continue;
-                }
-
-                file.Size = fileSize;
-
-                if (!_updateMediaInfoService.Update(file, movie))
+                if (!_updateMediaInfoService.Update(file, movie) && file.Size != fileSize)
                 {
                     filesToUpdate.Add(file);
                 }
+
+                file.Size = fileSize;
             }
 
             // Update any files that had a file size change, but didn't get media info updated.


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Make sure that the MediaInfo is able to run if the EnableMediaInfo is checked on.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX