### PR TITLE
Fix: Filter modals throwing error for performer, studio

### DIFF
--- a/frontend/src/Performer/Index/PerformerIndexFilterModal.tsx
+++ b/frontend/src/Performer/Index/PerformerIndexFilterModal.tsx
@@ -9,7 +9,12 @@ function createPerformerSelector() {
   return createSelector(
     (state: AppState) => state.performers.items,
     (performers) => {
-      return performers;
+      // Ensure we always return an array: if items is an object map, convert to values,
+      // if it's already an array return it, otherwise return an empty array.
+      if (Array.isArray(performers)) return performers;
+      if (performers && typeof performers === 'object')
+        return Object.values(performers);
+      return [];
     }
   );
 }

--- a/frontend/src/Store/Actions/performerActions.js
+++ b/frontend/src/Store/Actions/performerActions.js
@@ -220,7 +220,7 @@ export const defaultState = {
           };
         });
 
-        return tags.sort(sortByProp('status'));
+        return tags.sort(sortByProp('name'));
       }
     },
     {
@@ -249,7 +249,7 @@ export const defaultState = {
           };
         });
 
-        return tags.sort(name);
+        return tags.sort(sortByProp('name'));
       }
     },
     {
@@ -279,7 +279,7 @@ export const defaultState = {
           };
         });
 
-        return tags.sort(name);
+        return tags.sort(sortByProp('name'));
       }
     },
     {
@@ -305,7 +305,7 @@ export const defaultState = {
           };
         });
 
-        return tags.sort(name);
+        return tags.sort(sortByProp('name'));
       }
     },
     {
@@ -330,7 +330,7 @@ export const defaultState = {
           };
         });
 
-        return tags.sort(name);
+        return tags.sort(sortByProp('name'));
       }
     },
     {

--- a/frontend/src/Store/Actions/sceneIndexActions.js
+++ b/frontend/src/Store/Actions/sceneIndexActions.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { createAction } from 'redux-actions';
 import { filterBuilderTypes, filterBuilderValueTypes, sortDirections } from 'Helpers/Props';
 import sortByProp from 'Utilities/Array/sortByProp';
@@ -196,8 +197,8 @@ export const defaultState = {
       label: () => translate('Studio'),
       type: filterBuilderTypes.EXACT,
       optionsSelector: function(items) {
-        const tagList = items.reduce((acc, scene) => {
-          if (scene.studioTitle) {
+        const tagList = (items || []).reduce((acc, scene) => {
+          if (scene && scene.studioTitle) {
             acc.push({
               id: scene.studioTitle,
               name: scene.studioTitle
@@ -207,7 +208,9 @@ export const defaultState = {
           return acc;
         }, []);
 
-        return tagList.sort(sortByProp('name'));
+        const tags = _.uniqBy(tagList, 'id');
+
+        return tags.sort(sortByProp('name'));
       }
     },
     {
@@ -254,18 +257,22 @@ export const defaultState = {
       label: () => translate('Genres'),
       type: filterBuilderTypes.ARRAY,
       optionsSelector: function(items) {
-        const genreList = items.reduce((acc, scene) => {
-          scene.genres.forEach((genre) => {
-            acc.push({
-              id: genre,
-              name: genre
+        const genreList = (items || []).reduce((acc, scene) => {
+          if (scene && Array.isArray(scene.genres)) {
+            scene.genres.forEach((genre) => {
+              acc.push({
+                id: genre,
+                name: genre
+              });
             });
-          });
+          }
 
           return acc;
         }, []);
 
-        return genreList.sort(sortByProp('name'));
+        const genres = _.uniqBy(genreList, 'id');
+
+        return genres.sort(sortByProp('name'));
       }
     },
     {

--- a/frontend/src/Store/Actions/studioActions.js
+++ b/frontend/src/Store/Actions/studioActions.js
@@ -165,8 +165,8 @@ export const defaultState = {
       label: () => translate('Network'),
       type: filterBuilderTypes.EXACT,
       optionsSelector: function(items) {
-        const tagList = items.reduce((acc, studio) => {
-          if (studio.network) {
+        const tagList = (items || []).reduce((acc, studio) => {
+          if (studio && studio.network) {
             acc.push({
               id: studio.network,
               name: studio.network
@@ -176,7 +176,9 @@ export const defaultState = {
           return acc;
         }, []);
 
-        return tagList.sort(sortByProp);
+        const tags = _.uniqBy(tagList, 'id');
+
+        return tags.sort(sortByProp('name'));
       }
     },
     {

--- a/frontend/src/Utilities/Array/sortByProp.ts
+++ b/frontend/src/Utilities/Array/sortByProp.ts
@@ -1,12 +1,12 @@
-import { StringKey } from 'typings/Helpers/KeysMatching';
+export function sortByProp<T, K extends keyof T & string>(sortKey: K) {
+  return (a: T, b: T): number => {
+    const va = a[sortKey];
+    const vb = b[sortKey];
 
-export function sortByProp<
-  // eslint-disable-next-line no-use-before-define
-  T extends Record<K, string>,
-  K extends StringKey<T>
->(sortKey: K) {
-  return (a: T, b: T) => {
-    return a[sortKey].localeCompare(b[sortKey], undefined, { numeric: true });
+    const sa = va === undefined || va === null ? '' : String(va);
+    const sb = vb === undefined || vb === null ? '' : String(vb);
+
+    return sa.localeCompare(sb, undefined, { numeric: true });
   };
 }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Discord user reported errors when trying to use custom filters on performer.  Used Copilot to trace down ares of opportunity to harden the sortByProp function as well as usage of it, to guard against undefined (hydration) issues and such.

This was a regression when the items in #683 were merged, as I'd already fixed this, but lost those changes when merging in the conversions to TypeScript.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #683