### PR TITLE
Fix: Parse quality info during scan/refresh

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/UpdateMediaInfoService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/UpdateMediaInfoService.cs
@@ -8,6 +8,7 @@ using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies;
+using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 
 namespace NzbDrone.Core.MediaFiles.MediaInfo
@@ -82,6 +83,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 return false;
             }
 
+            _logger.Trace("GetMediaInfo path='{0}', movieFile.Path='{1}', movieFile.RelativePath='{2}'", path, movieFile.Path, movieFile.RelativePath);
             var updatedMediaInfo = _videoFileInfoReader.GetMediaInfo(path);
 
             if (updatedMediaInfo == null)
@@ -94,7 +96,9 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             var localMovie = new LocalMovie();
             localMovie.Path = movieFile.Path;
             localMovie.Movie = movie;
-            localMovie.Quality = movieFile.Quality;
+
+            // Try re-check for Quality rather than defaulting to null/Unknown
+            localMovie.Quality = QualityParser.ParseQuality(movieFile.RelativePath);
             localMovie.MediaInfo = updatedMediaInfo;
 
             localMovie = _augmentQuality.Aggregate(localMovie, null);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
When doing a scan/refresh, quality info was being defaulted to Unknown in some cases (still), which in turn woulud default it to HDTV.  Extends #710 with use of existing filename-based quality parsing logic.

Let me know if I should revise.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX