### PR TITLE
Fix: Performer refresh not fully refreshing data

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetails.js
+++ b/frontend/src/Performer/Details/PerformerDetails.js
@@ -253,10 +253,9 @@ class PerformerDetails extends Component {
     }
 
     const statusDetails = getPerformerStatusDetails(status);
-    const runningYears =
-      statusDetails.title === translate('Inactive') ?
-        `${careerStart}-${careerEnd}` :
-        `${careerStart}-`;
+    const startYear = Number.isFinite(careerStart) ? careerStart : '';
+    const endYear = Number.isFinite(careerEnd) && careerEnd > 0 ? careerEnd : '';
+    const runningYears = `${startYear}-${endYear}`;
 
     const fanartUrl = getFanartUrl(images);
     const elementStyle = {
@@ -431,10 +430,11 @@ class PerformerDetails extends Component {
                     <Icon name={icons.PROFILE} size={17} />
 
                     <span className={styles.qualityProfileName}>
-                      {
+                      {qualityProfileId ?
                         <QualityProfileNameConnector
                           qualityProfileId={qualityProfileId}
-                        />
+                        /> :
+                        null
                       }
                     </span>
                   </Label>

--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -76,17 +76,18 @@ namespace NzbDrone.Core.Movies.Performers
                 performer.ForeignId = performerInfo.ForeignId;
             }
 
-            performer.Name = performerInfo.Name;
-            performer.HairColor = performerInfo.HairColor;
-            performer.Ethnicity = performerInfo.Ethnicity;
-            performer.Status = performerInfo.Status;
-            performer.Images = performerInfo.Images;
-            performer.CareerStart = performerInfo.CareerEnd;
-            performer.CareerStart = performerInfo.CareerStart;
-            performer.LastInfoSync = DateTime.UtcNow;
-            performer.CleanName = performerInfo.CleanName;
-            performer.SortName = performerInfo.SortName;
             performer.Age = performerInfo.Age;
+            performer.CareerEnd = performerInfo.CareerEnd;
+            performer.CareerStart = performerInfo.CareerStart;
+            performer.CleanName = performerInfo.CleanName;
+            performer.Ethnicity = performerInfo.Ethnicity;
+            performer.Gender = performerInfo.Gender;
+            performer.HairColor = performerInfo.HairColor;
+            performer.Images = performerInfo.Images;
+            performer.LastInfoSync = DateTime.UtcNow;
+            performer.Name = performerInfo.Name;
+            performer.SortName = performerInfo.SortName;
+            performer.Status = performerInfo.Status;
 
             _performerService.Update(performer);
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Career End and Gender were not properly refreshed.  Also fixed Performer Details page to render career span properly even if they are marked inactive but career end isn't set yet.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX