### PR TITLE
Fix: Movie Import search resets index movie list

### DIFF
--- a/frontend/src/App/State/AppState.ts
+++ b/frontend/src/App/State/AppState.ts
@@ -6,6 +6,7 @@ import HistoryAppState from './HistoryAppState';
 import MovieCollectionAppState from './MovieCollectionAppState';
 import MovieFilesAppState from './MovieFilesAppState';
 import MoviesAppState, { MovieIndexAppState } from './MoviesAppState';
+import MovieSearchAppState from './MovieSearchAppState';
 import ParseAppState from './ParseAppState';
 import PerformersAppState from './PerformersAppState';
 import QueueAppState from './QueueAppState';
@@ -69,6 +70,7 @@ interface AppState {
   movieCollections: MovieCollectionAppState;
   movieFiles: MovieFilesAppState;
   movieIndex: MovieIndexAppState;
+  movieSearch: MovieSearchAppState;
   sceneIndex: MovieIndexAppState;
   performers: PerformersAppState;
   studios: StudiosAppState;

--- a/frontend/src/App/State/MovieSearchAppState.ts
+++ b/frontend/src/App/State/MovieSearchAppState.ts
@@ -1,0 +1,7 @@
+import Movie from 'Movie/Movie';
+
+export default interface MovieSearchAppState {
+  isFetching: boolean;
+  isPopulated: boolean;
+  items: Movie[];
+}

--- a/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
+++ b/frontend/src/InteractiveImport/Movie/SelectMovieModalContent.tsx
@@ -20,7 +20,7 @@ import Column from 'Components/Table/Column';
 import VirtualTableRowButton from 'Components/Table/VirtualTableRowButton';
 import { scrollDirections } from 'Helpers/Props';
 import Movie from 'Movie/Movie';
-import { searchMovies } from 'Store/Actions/movieActions';
+import { searchMoviesModal } from 'Store/Actions/movieSearchActions';
 import dimensions from 'Styles/Variables/dimensions';
 import translate from 'Utilities/String/translate';
 import SelectMovieModalTableHeader from './SelectMovieModalTableHeader';
@@ -97,7 +97,7 @@ function SelectMovieModalContent(props: SelectMovieModalContentProps) {
 
   const debouncedDispatchSearch = useMemo(
     // only fire API call once every 300ms, for those fast typers
-    () => debounce((val: string) => dispatch(searchMovies(val)), 300),
+    () => debounce((val: string) => dispatch(searchMoviesModal(val)), 300),
     [dispatch]
   );
 
@@ -109,7 +109,9 @@ function SelectMovieModalContent(props: SelectMovieModalContentProps) {
   const windowHeight = window.innerHeight;
 
   // movies come straight from Redux after searchMovies thunk runs
-  const items: Movie[] = useSelector((state: AppState) => state.movies.items);
+  const items: Movie[] = useSelector(
+    (state: AppState) => state.movieSearch.items
+  );
 
   // measure scroller size
   useEffect(() => {

--- a/frontend/src/Store/Actions/index.js
+++ b/frontend/src/Store/Actions/index.js
@@ -14,6 +14,7 @@ import * as movieBlocklist from './movieBlocklistActions';
 import * as movieFiles from './movieFileActions';
 import * as movieHistory from './movieHistoryActions';
 import * as movieIndex from './movieIndexActions';
+import * as movieSearch from './movieSearchActions';
 import * as oAuth from './oAuthActions';
 import * as organizePreview from './organizePreviewActions';
 import * as parse from './parseActions';
@@ -56,6 +57,7 @@ export default [
   releases,
   rootFolders,
   movies,
+  movieSearch,
   movieBlocklist,
   movieHistory,
   movieIndex,

--- a/frontend/src/Store/Actions/movieSearchActions.js
+++ b/frontend/src/Store/Actions/movieSearchActions.js
@@ -1,0 +1,45 @@
+import { createThunk, handleThunks } from 'Store/thunks';
+import createAjaxRequest from 'Utilities/createAjaxRequest';
+import { set, update } from './baseActions';
+import createHandleActions from './Creators/createHandleActions';
+
+export const section = 'movieSearch';
+
+export const defaultState = {
+  isFetching: false,
+  isPopulated: false,
+  error: null,
+  items: []
+};
+
+export const SEARCH_MOVIES_MODAL = 'movieSearch/searchMovies';
+export const searchMoviesModal = createThunk(SEARCH_MOVIES_MODAL);
+
+export const actionHandlers = handleThunks({
+  [SEARCH_MOVIES_MODAL]: (getState, payload, dispatch) => {
+    if (getState().movieSearch.isFetching) {
+      return;
+    }
+
+    dispatch(set({ section, isFetching: true }));
+
+    const { request, abortRequest } = createAjaxRequest({
+      url: '/movie/search',
+      data: { query: payload },
+      traditional: true
+    });
+
+    request
+      .done((data) => {
+        dispatch(update({ section, data }));
+        dispatch(set({ section, isFetching: false, isPopulated: true, error: null }));
+      })
+      .fail((xhr) => {
+        dispatch(set({ section, isFetching: false, isPopulated: false, error: xhr }));
+      });
+
+    return abortRequest;
+  }
+});
+
+export const reducers = createHandleActions({}, defaultState, section);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
I introduced a bug where searching in the modal would update app state for movies outside that modal, like the index.  I split the new search logic into its own actions, so that it uses a separate React/Redux app state container and leaves the main one for movies alone.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes a bug introduced in #719