### PR TITLE
Fix: Broken performer image causes bad layout

### DIFF
--- a/frontend/src/Movie/Details/Credits/Cast/MovieCastPoster.js
+++ b/frontend/src/Movie/Details/Credits/Cast/MovieCastPoster.js
@@ -54,8 +54,7 @@ class MovieCastPoster extends Component {
     const elementStyle = {
       width: `${posterWidth}px`,
       height: `${posterHeight}px`,
-      borderRadius: '5px',
-      'object-fit': 'cover'
+      borderRadius: '5px'
     };
 
     const contentStyle = {

--- a/frontend/src/Movie/Details/Credits/MovieCreditPoster.css
+++ b/frontend/src/Movie/Details/Credits/MovieCreditPoster.css
@@ -19,6 +19,7 @@ $hoverScale: 1.05;
   position: relative;
   display: block;
   background-color: var(--defaultColor);
+  object-fit: cover;
 }
 
 .overlayTitle {
@@ -34,6 +35,13 @@ $hoverScale: 1.05;
   color: var(--offWhite);
   text-align: center;
   font-size: 20px;
+}
+
+.link {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .title {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If Whisparr failed to properly download a performer image, it is corrupt, or otherwise unloadable, the card could improperly render the overlay title off-center.  The user can fix the image by refreshing the performer, but the platform won't do this on-demand.  In my testing logging was showing 404's for the images, so my repro was likely a missing/corrupted headshot.

#### Screenshot (if UI related)
<img width="359" height="333" alt="image" src="https://github.com/user-attachments/assets/0e392bee-dca9-4dcd-9255-764b79313731" />
<img width="359" height="333" alt="image" src="https://github.com/user-attachments/assets/9e2a2748-549b-4a6e-9ac7-47339944bc7a" />

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX