### PR TITLE
Fix: Parse 4k/5k/6k/8k resolutions

### DIFF
--- a/src/NzbDrone.Common.Test/CacheTests/CachedFixture.cs
+++ b/src/NzbDrone.Common.Test/CacheTests/CachedFixture.cs
@@ -80,7 +80,6 @@ namespace NzbDrone.Common.Test.CacheTests
         }
 
         [Test]
-        [Platform(Exclude = "MacOsX")]
         public void should_honor_ttl()
         {
             var hitCount = 0;

--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabCapabilitiesProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabCapabilitiesProviderFixture.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using NzbDrone.Common.Http;
 using NzbDrone.Core.Indexers.Newznab;
 using NzbDrone.Core.Test.Framework;
+using NzbDrone.Test.Common;
 
 namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
 {
@@ -93,6 +94,8 @@ namespace NzbDrone.Core.Test.IndexerTests.NewznabTests
             var result = Subject.GetCapabilities(_settings);
 
             result.Should().NotBeNull();
+
+            ExceptionVerification.ExpectedErrors(1);
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfoFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfoFixture.cs
@@ -54,6 +54,14 @@ namespace NzbDrone.Core.Test.MediaFiles.MovieImport.Aggregation.Aggregators.Augm
         [TestCase(720, 1, Resolution.R480p)] // SDTV
         [TestCase(600, 1, Resolution.R480p)]
         [TestCase(100, 1, Resolution.R480p)]
+
+        // 5K / 6K / 8K cases
+        [TestCase(5120, 2880, Resolution.R2880p)] // 5K true
+        [TestCase(5100, 2800, Resolution.R2880p)] // 5K boundary
+        [TestCase(6144, 3160, Resolution.R3160p)] // 6K RED
+        [TestCase(6016, 3384, Resolution.R3384p)] // 6K Blackmagic
+        [TestCase(7680, 4320, Resolution.R4320p)] // 8K true
+        [TestCase(7500, 1, Resolution.R4320p)] // 8K width boundary
         public void should_return_closest_resolution(int mediaInfoWidth, int mediaInfoHeight, Resolution expectedResolution)
         {
             var mediaInfo = Builder<MediaInfoModel>.CreateNew()

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -311,7 +311,6 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie.Name.2008.BDREMUX.1080p.Bluray.AVC.DTS-HR.MA.5.1-LEGi0N")]
         [TestCase("Movie.Title.M.2008.USA.BluRay.Remux.1080p.MPEG-2.DD.5.1-TDD")]
         [TestCase("Movie.Title.2018.1080p.BluRay.REMUX.MPEG-2.DTS-HD.MA.5.1-EPSiLON")]
-        [TestCase("Movie.Title.II.2003.4K.BluRay.Remux.1080p.AVC.DTS-HD.MA.5.1-BMF")]
         [TestCase("Movie Title 2022 (BDRemux 1080p HEVC FLAC) [Netaro]")]
         [TestCase("[Vodes] Movie Title - Other Title (2020) [BDRemux 1080p HEVC Dual-Audio]")]
         [TestCase("This.Wonderful.Movie.1991.German.ML.1080p.BluRay.AVC-GeRMaNSCeNEGRoUP")]

--- a/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/QualityParserFixture.cs
@@ -293,6 +293,42 @@ namespace NzbDrone.Core.Test.ParserTests
             ParseAndVerifyQuality(title, QualitySource.Bluray, proper, Resolution.R2160p);
         }
 
+        [Test]
+        [TestCase("Movie.Title.2025.5120x2880.x264", Resolution.R2880p, 33)]
+        [TestCase("Movie.Title.2025.5k.x264", Resolution.R2880p, 33)]
+        [TestCase("Movie.Title.2025.5k-UHD.x265", Resolution.R2880p, 33)]
+        [TestCase("Movie.Title.2025.6144x3160.x265", Resolution.R3160p, 34)]
+        [TestCase("Movie.Title.2025.6016x3384.x265", Resolution.R3384p, 36)]
+        [TestCase("Movie.Title.2025.6k-UHD.x265", Resolution.R3160p, 34)]
+        [TestCase("Movie.Title.2025.8k.7680x4320.x265", Resolution.R4320p, 35)]
+        [TestCase("Movie.Title.2025.8K-UHD.x265", Resolution.R4320p, 35)]
+        [TestCase("Movie.Title.2025.4k-UHD.x265", Resolution.R2160p, 18)]
+        [TestCase("Movie.Title.2025.2160p.x265", Resolution.R2160p, 18)]
+        [TestCase("Movie.Title.2025.UHD.x265", Resolution.R2160p, 18)]
+        public void should_parse_large_resolutions(string title, Resolution expectedResolution, int expectedQualityId)
+        {
+            var result = QualityParser.ParseQuality(title);
+
+            result.ResolutionDetectionSource.Should().Be(QualityDetectionSource.Name);
+            result.Quality.Resolution.Should().Be((int)expectedResolution);
+
+            var expectedQuality = Quality.FindById(expectedQualityId);
+            result.Quality.Should().Be(expectedQuality);
+        }
+
+        [Test]
+        [TestCase("Movie.Title.2025.Season5.EpisodeK")]
+        [TestCase("Movie.Title.2025.500k")]
+        [TestCase("Movie.Title.2025.5kgain")]
+        [TestCase("Movie.Title.2025.s5k")]
+        public void should_not_match_false_positive_large_resolutions(string title)
+        {
+            var result = QualityParser.ParseQuality(title);
+
+            result.Quality.Resolution.Should().Be((int)Resolution.Unknown);
+            result.Quality.Should().Be(Quality.Unknown);
+        }
+
         [TestCase("Movie.Name.2004.576p.BDRip.x264-HANDJOB")]
         [TestCase("Movie.Title.S01E05.576p.BluRay.DD5.1.x264-HiSD")]
         public void should_parse_bluray576p_quality(string title)

--- a/src/NzbDrone.Core/Datastore/Migration/241_6K3384_Quality.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/241_6K3384_Quality.cs
@@ -1,0 +1,25 @@
+using System.Data;
+using FluentMigrator;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(241)]
+    public class AddHighWebDlQualities3384 : AddHighWebDlQualities
+    {
+        protected override void MainDbUpgrade()
+        {
+            Execute.WithConnection(PerformHighWebDlQualityMigration);
+        }
+
+        private void PerformHighWebDlQualityMigration(IDbConnection conn, IDbTransaction tran)
+        {
+            var updater = new ProfileUpdater125(conn, tran);
+            updater.SplitQualityAppend(10, 33); // WEBDL-2880p
+            updater.SplitQualityAppend(33, 34); // WEBDL-3160p
+            updater.SplitQualityAppend(34, 36); // WEBDL-3384p
+            updater.SplitQualityAppend(36, 35); // WEBDL-4320p
+
+            updater.Commit();
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
@@ -9,6 +9,31 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenter
 {
     public class AugmentQualityFromMediaInfo : IAugmentQuality
     {
+        // Threshold constants for readability and easier adjustments
+        private const int Threshold8KWidth = 7500;
+        private const int Threshold8KHeight = 4300;
+
+        private const int Threshold6KRedWidth = 6100;   // RED 6144x3160 (loose lower-bound)
+        private const int Threshold6KRedHeight = 3100;
+
+        private const int Threshold6KBMWidth = 6000;    // Blackmagic 6016x3384 (loose lower-bound)
+        private const int Threshold6KBMHeight = 3300;
+
+        private const int Threshold5KWidth = 5100;      // 5120x2880
+        private const int Threshold5KHeight = 2800;
+
+        private const int Threshold4KWidth = 3200;      // loose 3840x2160 match
+        private const int Threshold4KHeight = 2100;
+
+        private const int Threshold1080pWidth = 1800;
+        private const int Threshold1080pHeight = 1000;
+
+        private const int Threshold720pWidth = 1200;
+        private const int Threshold720pHeight = 700;
+
+        private const int Threshold576pWidth = 1000;
+        private const int Threshold576pHeight = 560;
+
         private readonly Logger _logger;
 
         public int Order => 4;
@@ -45,65 +70,69 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenter
                 }
             }
 
-            // 8K
-            if (width >= 7500 || height >= 4300)
+            // If dimensions are not present, nothing to augment
+            if (width <= 0 || height <= 0)
             {
+                _logger.Trace("MediaInfo has no valid dimensions (width={0}, height={1})", width, height);
+                return null;
+            }
+
+            // 8K
+            if (width >= Threshold8KWidth || height >= Threshold8KHeight)
+            {
+                _logger.Trace("Resolution {0}x{1} considered 4320p (8K)", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R4320p, Confidence.MediaInfo);
             }
 
             // 6K RED (6144x3160)
-            if (width >= 6100 && height >= 3100)
+            if (width >= Threshold6KRedWidth && height >= Threshold6KRedHeight)
             {
+                _logger.Trace("Resolution {0}x{1} considered 3160p (6K - RED)", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R3160p, Confidence.MediaInfo);
             }
 
             // 6K Blackmagic (6016x3384)
-            if (width >= 6000 && height >= 3300)
+            if (width >= Threshold6KBMWidth && height >= Threshold6KBMHeight)
             {
+                _logger.Trace("Resolution {0}x{1} considered 3384p (6K - Blackmagic)", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R3384p, Confidence.MediaInfo);
             }
 
             // 5k (5120x2880)
-            if (width >= 5100 && height >= 2800)
+            if (width >= Threshold5KWidth && height >= Threshold5KHeight)
             {
+                _logger.Trace("Resolution {0}x{1} considered 2880p (5K)", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R2880p, Confidence.MediaInfo);
             }
 
             // 4K (UHD/2160p)
-            if (width >= 3200 || height >= 2100)
+            if (width >= Threshold4KWidth || height >= Threshold4KHeight)
             {
                 _logger.Trace("Resolution {0}x{1} considered 2160p (4K)", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R2160p, Confidence.MediaInfo);
             }
 
             // 1080p
-            if (width >= 1800 || height >= 1000)
+            if (width >= Threshold1080pWidth || height >= Threshold1080pHeight)
             {
                 _logger.Trace("Resolution {0}x{1} considered 1080p", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R1080p, Confidence.MediaInfo);
             }
 
-            if (width >= 1200 || height >= 700)
+            if (width >= Threshold720pWidth || height >= Threshold720pHeight)
             {
                 _logger.Trace("Resolution {0}x{1} considered 720p", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R720p, Confidence.MediaInfo);
             }
 
-            if (width >= 1000 || height >= 560)
+            if (width >= Threshold576pWidth || height >= Threshold576pHeight)
             {
                 _logger.Trace("Resolution {0}x{1} considered 576p", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R576p, Confidence.MediaInfo);
             }
 
-            if (width > 0 && height > 0)
-            {
-                _logger.Trace("Resolution {0}x{1} considered 480p", width, height);
-                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R480p, Confidence.MediaInfo);
-            }
-
-            _logger.Trace("Resolution {0}x{1}", width, height);
-
-            return null;
+            _logger.Trace("Resolution {0}x{1} considered 480p", width, height);
+            return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R480p, Confidence.MediaInfo);
         }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/Augmenters/Quality/AugmentQualityFromMediaInfo.cs
@@ -45,12 +45,38 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.Augmenter
                 }
             }
 
+            // 8K
+            if (width >= 7500 || height >= 4300)
+            {
+                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R4320p, Confidence.MediaInfo);
+            }
+
+            // 6K RED (6144x3160)
+            if (width >= 6100 && height >= 3100)
+            {
+                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R3160p, Confidence.MediaInfo);
+            }
+
+            // 6K Blackmagic (6016x3384)
+            if (width >= 6000 && height >= 3300)
+            {
+                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R3384p, Confidence.MediaInfo);
+            }
+
+            // 5k (5120x2880)
+            if (width >= 5100 && height >= 2800)
+            {
+                return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R2880p, Confidence.MediaInfo);
+            }
+
+            // 4K (UHD/2160p)
             if (width >= 3200 || height >= 2100)
             {
-                _logger.Trace("Resolution {0}x{1} considered 2160p", width, height);
+                _logger.Trace("Resolution {0}x{1} considered 2160p (4K)", width, height);
                 return AugmentQualityResult.SourceAndResolutionOnly(source, sourceConfidence, (int)Resolution.R2160p, Confidence.MediaInfo);
             }
 
+            // 1080p
             if (width >= 1800 || height >= 1000)
             {
                 _logger.Trace("Resolution {0}x{1} considered 1080p", width, height);

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -57,8 +57,22 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex RealRegex = new (@"\b(?<real>REAL)\b",
                                                             RegexOptions.Compiled);
 
-        private static readonly Regex ResolutionRegex = new (@"\b(?:(?<R360p>360p)|(?<R480p>480p|480i|640x480|848x480)|(?<R540p>540p)|(?<R576p>576p)|(?<R720p>720p|1280x720|960p)|(?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|(?<R2160p>2160p|3840x2160|4k[-_. ](?:UHD|HEVC|BD|H\.?265)|(?:UHD|HEVC|BD|H\.?265)[-_. ]4k))\b",
-                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ResolutionRegex = new
+        (
+            @"\b(?:
+                (?<R360p>360p)|
+                (?<R480p>480p|480i|640x480|848x480)|
+                (?<R540p>540p)|
+                (?<R576p>576p)|
+                (?<R720p>720p|1280x720|960p)|
+                (?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|
+                (?<R2160p>2160p|3840x2160|4096x2160|4k(?:[-_. ](?:UHD|HEVC|BD|H\.?265))?)|
+                (?<R2880p>2880p|5120x2880|5k(?:[-_. ](?:UHD|HEVC|BD|H\.?265))?)|
+                (?<R3160p>3160p|6144x3160|6k(?:[-_. ](?:UHD|HEVC|BD|H\.?265))?)|
+                (?<R3384p>3384p|6016x3384|6k(?:[-_. ](?:UHD|HEVC|BD|H\.?265))?)|
+                (?<R4320p>4320p|7680x4320|8k(?:[-_. ](?:UHD|HEVC|BD|H\.?265))?)
+            )\b",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
         // Handle cases where no resolution is in the release name; assume if UHD then 4k
         private static readonly Regex ImpliedResolutionRegex = new (@"\b(?<R2160p>UHD)\b",
@@ -93,6 +107,7 @@ namespace NzbDrone.Core.Parser
             // Based on extension
             if (result.Quality == Quality.Unknown && !name.ContainsInvalidPathChars())
             {
+                Logger.Debug("Quality unknown.  Attempting to parse quality from file extension for '{0}'", name);
                 try
                 {
                     result.Quality = MediaFileExtensions.GetQualityForExtension(Path.GetExtension(name));
@@ -488,6 +503,50 @@ namespace NzbDrone.Core.Parser
                     }
                 }
 
+                if (resolution == Resolution.R4320p)
+                {
+                    result.ResolutionDetectionSource = QualityDetectionSource.Name;
+
+                    result.Quality = source == QualitySource.Unknown
+                        ? Quality.WEBDL4320p
+                        : QualityFinder.FindBySourceAndResolution(source, 4320);
+
+                    return result;
+                }
+
+                if (resolution == Resolution.R3384p)
+                {
+                    result.ResolutionDetectionSource = QualityDetectionSource.Name;
+
+                    result.Quality = source == QualitySource.Unknown
+                        ? Quality.WEBDL3384p
+                        : QualityFinder.FindBySourceAndResolution(source, 3384);
+
+                    return result;
+                }
+
+                if (resolution == Resolution.R3160p)
+                {
+                    result.ResolutionDetectionSource = QualityDetectionSource.Name;
+
+                    result.Quality = source == QualitySource.Unknown
+                        ? Quality.WEBDL3160p
+                        : QualityFinder.FindBySourceAndResolution(source, 3160);
+
+                    return result;
+                }
+
+                if (resolution == Resolution.R2880p)
+                {
+                    result.ResolutionDetectionSource = QualityDetectionSource.Name;
+
+                    result.Quality = source == QualitySource.Unknown
+                        ? Quality.WEBDL2880p
+                        : QualityFinder.FindBySourceAndResolution(source, 2880);
+
+                    return result;
+                }
+
                 if (resolution == Resolution.R2160p)
                 {
                     result.ResolutionDetectionSource = QualityDetectionSource.Name;
@@ -637,11 +696,13 @@ namespace NzbDrone.Core.Parser
         private static Resolution ParseResolution(string name)
         {
             var match = ResolutionRegex.Match(name);
+            Logger.Debug("Resolution match for '{0}': {1}", name, match.Value);
 
             var matchimplied = ImpliedResolutionRegex.Match(name);
 
             if (!match.Success & !matchimplied.Success)
             {
+                Logger.Debug("No resolution match for 'match' or 'matchImplied', using Unknown: '{0}'", name);
                 return Resolution.Unknown;
             }
 
@@ -678,6 +739,26 @@ namespace NzbDrone.Core.Parser
             if (match.Groups["R2160p"].Success || matchimplied.Groups["R2160p"].Success)
             {
                 return Resolution.R2160p;
+            }
+
+            if (match.Groups["R2880p"].Success || matchimplied.Groups["R2880p"].Success)
+            {
+                return Resolution.R2880p;
+            }
+
+            if (match.Groups["R3160p"].Success || matchimplied.Groups["R3160p"].Success)
+            {
+                return Resolution.R3160p;
+            }
+
+            if (match.Groups["R3384p"].Success || matchimplied.Groups["R3384p"].Success)
+            {
+                return Resolution.R3384p;
+            }
+
+            if (match.Groups["R4320p"].Success || matchimplied.Groups["R4320p"].Success)
+            {
+                return Resolution.R4320p;
             }
 
             return Resolution.Unknown;
@@ -753,6 +834,10 @@ namespace NzbDrone.Core.Parser
         R576p = 576,
         R720p = 720,
         R1080p = 1080,
-        R2160p = 2160
+        R2160p = 2160,
+        R2880p = 2880,
+        R3160p = 3160,
+        R3384p = 3384,
+        R4320p = 4320
     }
 }

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -700,12 +700,13 @@ namespace NzbDrone.Core.Parser
 
             var matchimplied = ImpliedResolutionRegex.Match(name);
 
-            if (!match.Success & !matchimplied.Success)
+            if (!match.Success && !matchimplied.Success)
             {
                 Logger.Debug("No resolution match for 'match' or 'matchImplied', using Unknown: '{0}'", name);
                 return Resolution.Unknown;
             }
 
+            // Prefer explicit resolution regex groups first (precision over implied fallback)
             if (match.Groups["R360p"].Success)
             {
                 return Resolution.R360p;
@@ -736,27 +737,53 @@ namespace NzbDrone.Core.Parser
                 return Resolution.R1080p;
             }
 
-            if (match.Groups["R2160p"].Success || matchimplied.Groups["R2160p"].Success)
+            if (match.Groups["R2160p"].Success)
             {
                 return Resolution.R2160p;
             }
 
-            if (match.Groups["R2880p"].Success || matchimplied.Groups["R2880p"].Success)
+            if (match.Groups["R2880p"].Success)
             {
                 return Resolution.R2880p;
             }
 
-            if (match.Groups["R3160p"].Success || matchimplied.Groups["R3160p"].Success)
+            if (match.Groups["R3160p"].Success)
             {
                 return Resolution.R3160p;
             }
 
-            if (match.Groups["R3384p"].Success || matchimplied.Groups["R3384p"].Success)
+            if (match.Groups["R3384p"].Success)
             {
                 return Resolution.R3384p;
             }
 
-            if (match.Groups["R4320p"].Success || matchimplied.Groups["R4320p"].Success)
+            if (match.Groups["R4320p"].Success)
+            {
+                return Resolution.R4320p;
+            }
+
+            // No explicit match found; fall back to implied matches (e.g., 'UHD' => R2160p)
+            if (matchimplied.Groups["R2160p"].Success)
+            {
+                return Resolution.R2160p;
+            }
+
+            if (matchimplied.Groups["R2880p"].Success)
+            {
+                return Resolution.R2880p;
+            }
+
+            if (matchimplied.Groups["R3160p"].Success)
+            {
+                return Resolution.R3160p;
+            }
+
+            if (matchimplied.Groups["R3384p"].Success)
+            {
+                return Resolution.R3384p;
+            }
+
+            if (matchimplied.Groups["R4320p"].Success)
             {
                 return Resolution.R4320p;
             }

--- a/src/NzbDrone.Core/Qualities/Quality.cs
+++ b/src/NzbDrone.Core/Qualities/Quality.cs
@@ -94,6 +94,7 @@ namespace NzbDrone.Core.Qualities
         public static Quality WEBDL2160p => new Quality(18, "WEBDL-2160p", QualitySource.Web, 2160);
         public static Quality WEBDL2880p => new Quality(33, "WEBDL-2880p", QualitySource.Web, 2880);
         public static Quality WEBDL3160p => new Quality(34, "WEBDL-3160p", QualitySource.Web, 3160);
+        public static Quality WEBDL3384p => new Quality(36, "WEBDL-3384p", QualitySource.Web, 3384);
         public static Quality WEBDL4320p => new Quality(35, "WEBDL-4320p", QualitySource.Web, 4320);
 
         // Bluray
@@ -135,6 +136,7 @@ namespace NzbDrone.Core.Qualities
                 WEBDL2160p,
                 WEBDL2880p,
                 WEBDL3160p,
+                WEBDL3384p,
                 WEBDL4320p,
                 WEBRip480p,
                 WEBRip720p,
@@ -187,12 +189,13 @@ namespace NzbDrone.Core.Qualities
                 new QualityDefinition(Quality.Bluray2160p) { Weight = 23, MinSize = 0, MaxSize = null, PreferredSize = null },
                 new QualityDefinition(Quality.Remux2160p)  { Weight = 24, MinSize = 0, MaxSize = null, PreferredSize = null },
 
-                new QualityDefinition(Quality.BRDISK)      { Weight = 28, MinSize = 0, MaxSize = null, PreferredSize = null },
-                new QualityDefinition(Quality.RAWHD)       { Weight = 29, MinSize = 0, MaxSize = null, PreferredSize = null },
+                new QualityDefinition(Quality.BRDISK)      { Weight = 29, MinSize = 0, MaxSize = null, PreferredSize = null },
+                new QualityDefinition(Quality.RAWHD)       { Weight = 30, MinSize = 0, MaxSize = null, PreferredSize = null },
                 new QualityDefinition(Quality.WEBDL2880p)  { Weight = 25, MinSize = 0, MaxSize = null, PreferredSize = null },
                 new QualityDefinition(Quality.WEBDL3160p)  { Weight = 26, MinSize = 0, MaxSize = null, PreferredSize = null },
-                new QualityDefinition(Quality.WEBDL4320p)  { Weight = 27, MinSize = 0, MaxSize = null, PreferredSize = null },
-                new QualityDefinition(Quality.VR)          { Weight = 30, MinSize = 4, MaxSize = null, PreferredSize = null },
+                new QualityDefinition(Quality.WEBDL3384p)  { Weight = 27, MinSize = 0, MaxSize = null, PreferredSize = null },
+                new QualityDefinition(Quality.WEBDL4320p)  { Weight = 28, MinSize = 0, MaxSize = null, PreferredSize = null },
+                new QualityDefinition(Quality.VR)          { Weight = 31, MinSize = 4, MaxSize = null, PreferredSize = null },
             };
         }
 


### PR DESCRIPTION
#### Database Migration
YES

#### Description
- Add / Fix 4k/5k/6k/8k parsing by filename
- Add 4k/5k/6k/8k parsing based on resolution (if scanning media is enabled in settings)

#### Screenshot (if UI related)
<img width="400" height="540" alt="image" src="https://github.com/user-attachments/assets/e371a697-481e-47b8-8d9f-087a6fa3da97" />

#### Todos
- [X] Tests
- [X] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [X] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX