### PR TITLE
New: Monitor studio scenes from Performer detail

### DIFF
--- a/frontend/src/Performer/Details/PerformerDetailsStudio.js
+++ b/frontend/src/Performer/Details/PerformerDetailsStudio.js
@@ -186,9 +186,8 @@ class PerformerDetailsStudio extends Component {
         <div className={styles.header}>
           <div className={styles.left}>
             <MonitorToggleButton
-              monitored={monitored}
-              isDisabled={true}
-              tooltip={translate('PerformerStudioLinkTooltip')}
+              monitored={monitoredMovieCount === totalMovieCount}
+              tooltip={translate('PerformerStudioMonitorTooltip')}
               isSaving={isSaving}
               size={24}
               onPress={onMonitorStudioPress}

--- a/frontend/src/Performer/Details/PerformerDetailsStudioConnector.js
+++ b/frontend/src/Performer/Details/PerformerDetailsStudioConnector.js
@@ -6,7 +6,7 @@ import { createSelector } from 'reselect';
 import * as commandNames from 'Commands/commandNames';
 import { sortDirections } from 'Helpers/Props';
 import { executeCommand } from 'Store/Actions/commandActions';
-import { toggleMovieMonitored } from 'Store/Actions/movieActions';
+import { bulkMonitorMovie, toggleMovieMonitored } from 'Store/Actions/movieActions';
 import { setPerformerScenesSort, setPerformerScenesTableOption } from 'Store/Actions/performerScenesActions';
 import { toggleStudioMonitored } from 'Store/Actions/studioActions';
 import createDimensionsSelector from 'Store/Selectors/createDimensionsSelector';
@@ -99,6 +99,7 @@ const mapDispatchToProps = {
   setPerformerScenesTableOption,
   toggleStudioMonitored,
   toggleMovieMonitored,
+  bulkMonitorMovie,
   executeCommand
 };
 
@@ -109,14 +110,14 @@ class PerformerDetailsStudioConnector extends Component {
   };
 
   onMonitorStudioPress = (monitored) => {
-    const {
-      id
-    } = this.props;
+    // Use the bulk monitor API to toggle monitoring for all items in this studio
+    const { items } = this.props;
 
-    this.props.toggleStudioMonitored({
-      studioId: id,
-      monitored
-    });
+    const allMonitored = items.every((movie) => movie.monitored);
+    const newMonitoredState = !allMonitored;
+    const ids = items.map((item) => item.id);
+
+    this.props.bulkMonitorMovie({ ids, monitored: newMonitoredState });
   };
 
   onMonitorMoviePress = (movieId, monitored) => {
@@ -166,6 +167,7 @@ PerformerDetailsStudioConnector.propTypes = {
   setPerformerScenesSort: PropTypes.func.isRequired,
   toggleStudioMonitored: PropTypes.func.isRequired,
   toggleMovieMonitored: PropTypes.func.isRequired,
+  bulkMonitorMovie: PropTypes.func.isRequired,
   executeCommand: PropTypes.func.isRequired
 };
 

--- a/frontend/src/Studio/Details/StudioDetailsYear.js
+++ b/frontend/src/Studio/Details/StudioDetailsYear.js
@@ -149,7 +149,7 @@ class StudioDetailsYear extends Component {
     const newMonitoredState = !allMonitored;
     const ids = items.map((item) => item.id);
 
-    bulkMonitorMovie({ ids, monitored: newMonitoredState });
+    this.props.bulkMonitorMovie({ ids, monitored: newMonitoredState });
   };
 
   onMonitorMoviePress = (movieId, monitored, { shiftKey }) => {

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1406,7 +1406,7 @@
   "PerformerName": "Name",
   "PerformerQualityProfileHelpText": "Quality for newly added scenes.  Does not update existing scenes.",
   "PerformersSelectedInterp": "{count} Performer(s) Selected",
-  "PerformerStudioLinkTooltip": "Click Studio name to toggle from Details view",
+  "PerformerStudioMonitorTooltip": "Toggle monitoring on these scenes",
   "Period": "Period",
   "Permissions": "Permissions",
   "PhysicalRelease": "Physical Release",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This is a similar implementation to #733.  Previously, we disabled this toggle as it was tied to toggling monitoring for the whole studio, not just the visible performer scenes.  This PR moves to align with having the toggle monitor what you can see in the grouping.  Localized tooltip created, and fixed a minor bug with the Studio page implementation found after testing further.
#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX