### PR TITLE
Fix: getRelativeDate should ignore timezone offset

### DIFF
--- a/frontend/src/Utilities/Date/getRelativeDate.ts
+++ b/frontend/src/Utilities/Date/getRelativeDate.ts
@@ -1,9 +1,4 @@
 import moment from 'moment';
-import formatTime from 'Utilities/Date/formatTime';
-import isInNextWeek from 'Utilities/Date/isInNextWeek';
-import isToday from 'Utilities/Date/isToday';
-import isTomorrow from 'Utilities/Date/isTomorrow';
-import isYesterday from 'Utilities/Date/isYesterday';
 import translate from 'Utilities/String/translate';
 import formatDateTime from './formatDateTime';
 
@@ -15,6 +10,7 @@ interface GetRelativeDateOptions {
   includeSeconds?: boolean;
   timeForToday?: boolean;
   includeTime?: boolean;
+  ignoreTimezone?: boolean;
 }
 
 function getRelativeDate({
@@ -25,34 +21,60 @@ function getRelativeDate({
   includeSeconds = false,
   timeForToday = false,
   includeTime = false,
+  ignoreTimezone = false,
 }: GetRelativeDateOptions) {
-  if (!date) {
+  if (date == null || date === '') {
     return '';
   }
 
-  if ((includeTime || timeForToday) && !timeFormat) {
+  if (
+    (includeTime || timeForToday) &&
+    (timeFormat == null || timeFormat === '')
+  ) {
     throw new Error(
       "getRelativeDate: 'timeFormat' is required when 'includeTime' or 'timeForToday' is true"
     );
   }
+  // Detect date-only strings (YYYY-MM-DD) or midnight-UTC timestamps
+  const isDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(date || '');
+  const isMidnightUtc = /T00:00:00(?:\.000)?Z$/.test(date || '');
 
-  const isTodayDate = isToday(date);
+  const useUtcCalendar = Boolean(ignoreTimezone || isDateOnly || isMidnightUtc);
+
+  // Parse date and reference 'now' in the same mode (UTC or local)
+  const m = useUtcCalendar ? moment.utc(date) : moment(date);
+  const now = useUtcCalendar ? moment.utc() : moment();
+
+  // Small local time formatter that mirrors Utilities/Date/formatTime behavior
   const time = timeFormat
-    ? formatTime(date, timeFormat, {
-        includeMinuteZero: true,
-        includeSeconds,
-      })
+    ? (() => {
+        let tf = timeFormat;
+        const t = m.clone();
+
+        if (includeSeconds) {
+          tf = tf.replace(/\(?:mm\)?/, ':mm:ss');
+        } else if (t.minute() === 0) {
+          tf = tf.replace('(:mm)', '');
+        } else {
+          tf = tf.replace('(:mm)', ':mm');
+        }
+
+        return t.format(tf);
+      })()
     : '';
+
+  const isTodayDate = m.isSame(now, 'day');
 
   if (isTodayDate && timeForToday) {
     return time;
   }
 
-  if (!showRelativeDates) {
-    return moment(date).format(shortDateFormat);
+  if (showRelativeDates === false) {
+    return m.format(shortDateFormat);
   }
 
-  if (isYesterday(date)) {
+  const isYesterdayDate = m.isSame(now.clone().subtract(1, 'day'), 'day');
+  if (isYesterdayDate) {
     return includeTime
       ? translate('YesterdayAt', { time })
       : translate('Yesterday');
@@ -62,21 +84,22 @@ function getRelativeDate({
     return includeTime ? translate('TodayAt', { time }) : translate('Today');
   }
 
-  if (isTomorrow(date)) {
+  const isTomorrowDate = m.isSame(now.clone().add(1, 'day'), 'day');
+  if (isTomorrowDate) {
     return includeTime
       ? translate('TomorrowAt', { time })
       : translate('Tomorrow');
   }
 
-  if (isInNextWeek(date)) {
-    const day = moment(date).format('dddd');
-
+  const diffDays = m.startOf('day').diff(now.startOf('day'), 'days');
+  if (diffDays > 0 && diffDays <= 7) {
+    const day = m.format('dddd');
     return includeTime ? translate('DayOfWeekAt', { day, time }) : day;
   }
 
   return includeTime
     ? formatDateTime(date, shortDateFormat, timeFormat, { includeSeconds })
-    : moment(date).format(shortDateFormat);
+    : m.format(shortDateFormat);
 }
 
 export default getRelativeDate;


### PR DESCRIPTION
This function assumes reliable metadata for timezone, but the fact is, neither StashDB or TMDB offer this precision reliably.  StashDB stores this as 00:00:00 UTC, so Whisparr will happily round that backwards to "yesterday" if the user's browser is set to anything less than UTC-00:00.  This change ignores that so that users will see the same dates in both StashDB and Whisparr.  If the datetime DOES include an offset, we'll use it.

Don't mind the name of the feature branch, just using this to also test the pipeline on deploying a UI-only change.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX