### PR TITLE
Fix: Progress bar shows downloading even when scene is imported already

### DIFF
--- a/frontend/src/Movie/Index/ProgressBar/MovieIndexProgressBar.tsx
+++ b/frontend/src/Movie/Index/ProgressBar/MovieIndexProgressBar.tsx
@@ -44,7 +44,7 @@ function MovieIndexProgressBar(props: MovieIndexProgressBarProps) {
 
   const progress = 100;
   const queueStatusText =
-    queueDetails.count > 0 ? translate('Downloading') : null;
+    queueDetails.count > 0 && !hasFile ? translate('Downloading') : null;
 
   let movieStatus = translate('NotAvailable');
   if (hasFile) {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
In some cases, like in the scene search results, the progress bar below the cover image was showing Downloading, even when there was a file on disk.  This fixes that by having a more explicit condition for displaying Downloading.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX