### PR TITLE
Fix: use the source quality from the file if it exists so it is not changed

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateQuality.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateQuality.cs
@@ -23,6 +23,19 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators
         public LocalMovie Aggregate(LocalMovie localMovie, DownloadClientItem downloadClientItem)
         {
             var source = QualitySource.Unknown;
+
+            // Downloaded from the Web, so should be Web unless the file indicates something different
+            if (downloadClientItem != null && source == QualitySource.Unknown)
+            {
+                source = QualitySource.Web;
+            }
+
+            // Use the quality from the file if found so that the source is not changed.
+            if (localMovie?.Quality?.Quality?.Source != null)
+            {
+                source = localMovie.Quality.Quality.Source;
+            }
+
             var sourceConfidence = Confidence.Default;
             var resolution = 0;
             var resolutionConfidence = Confidence.Default;


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
Lower resolution may change when the quality is calculated, so use the source if extracted.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX