### PR TITLE
Fix: change the quality source so it defaults to Web when unknown.

### DIFF
--- a/src/NzbDrone.Core.Test/Qualities/QualityFinderFixture.cs
+++ b/src/NzbDrone.Core.Test/Qualities/QualityFinderFixture.cs
@@ -7,6 +7,12 @@ namespace NzbDrone.Core.Test.Qualities
     [TestFixture]
     public class QualityFinderFixture
     {
+        [TestCase(QualitySource.Unknown, 480)]
+        public void should_return_WebDL_480(QualitySource source, int resolution)
+        {
+            QualityFinder.FindBySourceAndResolution(source, resolution).Should().Be(Quality.WEBDL480p);
+        }
+
         [TestCase(QualitySource.DVDRaw, 480)]
         public void should_return_DVD_Remux(QualitySource source, int resolution)
         {
@@ -26,15 +32,25 @@ namespace NzbDrone.Core.Test.Qualities
             QualityFinder.FindBySourceAndResolution(source, resolution).Should().Be(Quality.SDTV);
         }
 
-        [TestCase(QualitySource.Television, 720)]
         [TestCase(QualitySource.Unknown, 720)]
+        public void should_return_WebDL_720p(QualitySource source, int resolution)
+        {
+            QualityFinder.FindBySourceAndResolution(source, resolution).Should().Be(Quality.WEBDL720p);
+        }
+
+        [TestCase(QualitySource.Television, 720)]
         public void should_return_HDTV_720p(QualitySource source, int resolution)
         {
             QualityFinder.FindBySourceAndResolution(source, resolution).Should().Be(Quality.HDTV720p);
         }
 
-        [TestCase(QualitySource.Television, 1080)]
         [TestCase(QualitySource.Unknown, 1080)]
+        public void should_return_WebDL_1080p(QualitySource source, int resolution)
+        {
+            QualityFinder.FindBySourceAndResolution(source, resolution).Should().Be(Quality.WEBDL1080p);
+        }
+
+        [TestCase(QualitySource.Television, 1080)]
         public void should_return_HDTV_1080p(QualitySource source, int resolution)
         {
             QualityFinder.FindBySourceAndResolution(source, resolution).Should().Be(Quality.HDTV1080p);

--- a/src/NzbDrone.Core/Qualities/QualitySource.cs
+++ b/src/NzbDrone.Core/Qualities/QualitySource.cs
@@ -3,12 +3,12 @@ namespace NzbDrone.Core.Qualities
     public enum QualitySource
     {
         Unknown,
+        Web,
+        WebRip,
         DVD,
         DVDRaw,
         Television,
         TelevisionRaw,
-        Web,
-        WebRip,
         Bluray,
         BlurayRaw,
         BlurayDisk,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Change the order of sources, so that a WebDL is selected first over DVD, or HDTV as it is more likely that a scene is WebDL.


#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX