### PR TITLE
Fix: Existing scene shows as downloading

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovie/AddNewMovieSearchResult.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovie/AddNewMovieSearchResult.js
@@ -94,6 +94,7 @@ class AddNewMovieSearchResult extends Component {
       monitored,
       isAvailable,
       movieFile,
+      sizeOnDisk,
       queueItem,
       runtime,
       movieRuntimeFormat,
@@ -107,7 +108,7 @@ class AddNewMovieSearchResult extends Component {
       isNewAddMovieModalOpen
     } = this.state;
 
-    const hasMovieFile = !!movieFile;
+    const hasMovieFile = !!movieFile || sizeOnDisk > 0;
 
     const linkProps = isExistingMovie ? { to: `/movie/${titleSlug}` } : { onPress: this.onPress };
     const providerProps = itemType === 'movie' ? { tmdbId: foreignId } : { stashId: foreignId };
@@ -387,7 +388,8 @@ AddNewMovieSearchResult.propTypes = {
   showRelativeDates: PropTypes.bool,
   shortDateFormat: PropTypes.string,
   longDateFormat: PropTypes.string,
-  timeFormat: PropTypes.string
+  timeFormat: PropTypes.string,
+  sizeOnDisk: PropTypes.number
 };
 
 AddNewMovieSearchResult.defaultProps = {


### PR DESCRIPTION
The scene lookup API doesn't return movieFile data.  Since that is purely for search, I thought it would be easier to use sizeOnDisk, which the API does return, rather than clutter the search API JSON with movieFile data.  I tried fixing this in #744, but missed that, as my dev env doesn't have media on it.  I did function test it with media, this time.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX