### PR TITLE
Fix: cache Movie Exclusions for stasharr

### DIFF
--- a/frontend/src/Settings/General/WhisparrSettings.js
+++ b/frontend/src/Settings/General/WhisparrSettings.js
@@ -16,6 +16,7 @@ function WhisparrSettings(props) {
 
   const {
     whisparrAutoMatchOnDate,
+    whisparrCacheExclusionAPI,
     whisparrCacheMovieAPI,
     whisparrCachePerformerAPI,
     whisparrCacheStudioAPI,
@@ -29,6 +30,22 @@ function WhisparrSettings(props) {
 
   return (
     <FieldSet legend={translate('Whisparr')}>
+      <FormGroup
+        advancedSettings={advancedSettings}
+        isAdvanced={true}
+      >
+
+        <FormLabel>{translate('WhisparrCacheExclusionAPI')}</FormLabel>
+
+        <FormInputGroup
+          type={inputTypes.CHECK}
+          name="whisparrCacheExclusionAPI"
+          helpText={translate('WhisparrCacheExclusionAPIHelpText')}
+          onChange={onInputChange}
+          {...whisparrCacheExclusionAPI}
+        />
+      </FormGroup>
+
       <FormGroup
         advancedSettings={advancedSettings}
         isAdvanced={true}

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -478,6 +478,12 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("WhisparrAutoMatchOnDate", value); }
         }
 
+        public bool WhisparrCacheExclusionAPI
+        {
+            get { return GetValueBoolean("WhisparrCacheExclusionAPI", false); }
+            set { SetValue("WhisparrCacheExclusionAPI", value); }
+        }
+
         public bool WhisparrCacheMovieAPI
         {
             get { return GetValueBoolean("WhisparrCacheMovieAPI", false); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -109,6 +109,7 @@ namespace NzbDrone.Core.Configuration
 
                 // Whisparr
                 bool WhisparrAutoMatchOnDate { get; }
+                bool WhisparrCacheExclusionAPI { get; }
                 bool WhisparrCacheMovieAPI { get; }
                 bool WhisparrCachePerformerAPI { get; }
                 bool WhisparrCacheStudioAPI { get; }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -2010,6 +2010,8 @@
   "Whisparr": "{appName}",
   "WhisparrAutoMatchOnDate": "Match scene on Date Only",
   "WhisparrAutoMatchOnDateHelpText": "If checked Whisparr will accept a scene on just studio and date. Can cause false positives",
+  "WhisparrCacheExclusionAPI": "Cache Exclusion API",
+  "WhisparrCacheExclusionAPIHelpText": "Cache API calls to exclusions",
   "WhisparrCacheMovieAPI": "Cache Movie API",
   "WhisparrCacheMovieAPIHelpText": "Cache API calls to movie/scene",
   "WhisparrCachePerformerAPI": "Cache Performer API",

--- a/src/Whisparr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Whisparr.Api.V3/Config/HostConfigResource.cs
@@ -46,6 +46,7 @@ namespace Whisparr.Api.V3.Config
         public int BackupInterval { get; set; }
         public int BackupRetention { get; set; }
         public bool WhisparrAutoMatchOnDate { get; set; }
+        public bool WhisparrCacheExclusionAPI { get; set; }
         public bool WhisparrCacheMovieAPI { get; set; }
         public bool WhisparrCachePerformerAPI { get; set; }
         public bool WhisparrCacheStudioAPI { get; set; }
@@ -97,6 +98,7 @@ namespace Whisparr.Api.V3.Config
                 BackupRetention = configService.BackupRetention,
                 ApplicationUrl = configService.ApplicationUrl,
                 WhisparrAutoMatchOnDate = configService.WhisparrAutoMatchOnDate,
+                WhisparrCacheExclusionAPI = configService.WhisparrCacheExclusionAPI,
                 WhisparrCacheMovieAPI = configService.WhisparrCacheMovieAPI,
                 WhisparrCachePerformerAPI = configService.WhisparrCachePerformerAPI,
                 WhisparrCacheStudioAPI = configService.WhisparrCacheStudioAPI,


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Cache the exclusion list for stasharr as the Development is MIA.

Stasharr is the only place using this legacy endpoint. 

Revet a change in Disk Service so that it only reads the files metadata if the file changes, but allow manual to force a redetection.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX