### PR TITLE
Fix: Correct disk scan media check only to run on filesize change

### DIFF
--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -191,7 +191,7 @@ namespace NzbDrone.Core.Movies.Performers
 
             try
             {
-                _diskScanService.Scan(movie);
+                _diskScanService.Scan(movie, trigger == CommandTrigger.Manual);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Revert a change in Disk Service so that it only reads the files metadata if the file size changes, but allow manual to force a redetection.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX