### PR TITLE
Fix: Handle error using import folder

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileService.cs
@@ -4,6 +4,7 @@ using System.IO;
 // using System.IO.Abstractions;
 using System.Linq;
 using NzbDrone.Common;
+using NzbDrone.Core.Datastore;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Movies;
@@ -136,8 +137,16 @@ namespace NzbDrone.Core.MediaFiles
             {
                 if (file.MovieId > 0)
                 {
-                    var movie = _movieRepository.Get(file.MovieId);
-                    movieFiles.Add(Path.Combine(movie.Path, movie.MovieFile.RelativePath));
+                    try
+                    {
+                        var movie = _movieRepository.Get(file.MovieId);
+                        movieFiles.Add(Path.Combine(movie.Path, movie.MovieFile.RelativePath));
+                    }
+                    catch (ModelNotFoundException)
+                    {
+                        // Movie File record exists but not movie record
+                        _movieRepository.Delete(file.MovieId);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
#### Database Migration
 NO

#### Description
Correct an error when using the import /unmapped, when the movie Id does not return correctly. Change the code to handle the error.

The error is caused as there is a MovieFiles record that has a movieId that does not exist in the movies table. The correction will remove the bad data.

[Error] CommandExecutor: Error occurred while executing task RescanScenes 

[v3.0.2.1628] NzbDrone.Core.Datastore.ModelNotFoundException: Movie with ID 289716 does not exist

   at NzbDrone.Core.Datastore.BasicRepository`1.Get(Int32 id) in ./Whisparr.Core/Datastore/BasicRepository.cs:line 97

   at NzbDrone.Core.MediaFiles.MediaFileService.FilterExistingFiles(List`1 files) in ./Whisparr.Core/MediaFiles/MediaFileService.cs:line 139

   at NzbDrone.Core.MediaFiles.MovieImport.ImportDecisionMaker.GetSceneImportDecisions(List`1 videoFiles, DownloadClientItem downloadClientItem, ParsedMovieInfo folderInfo, Boolean sceneSource, Boolean filterExistingFiles) in ./Whisparr.Core/MediaFiles/MovieImport/ImportDecisionMaker.cs:line 131

   at NzbDrone.Core.MediaFiles.MovieImport.ImportDecisionMaker.GetSceneImportDecisions(List`1 videoFiles) in ./Whisparr.Core/MediaFiles/MovieImport/ImportDecisionMaker.cs:line 79

   at NzbDrone.Core.MediaFiles.SceneDiskScanService.Scan(List`1 folders) in ./Whisparr.Core/MediaFiles/SceneDiskScanService.cs:line 160

   at NzbDrone.Core.MediaFiles.SceneDiskScanService.Execute(RescanScenesCommand message) in ./Whisparr.Core/MediaFiles/SceneDiskScanService.cs:line 276

   at NzbDrone.Core.Messaging.Commands.CommandExecutor.ExecuteCommand[TCommand](TCommand command, CommandModel commandModel) in ./Whisparr.Core/Messaging/Commands/CommandExecutor.cs:line 81

   at System.Dynamic.UpdateDelegates.UpdateAndExecuteVoid3[T0,T1,T2](CallSite site, T0 arg0, T1 arg1, T2 arg2)

   at NzbDrone.Core.Messaging.Commands.CommandExecutor.ExecuteCommands() in ./Whisparr.Core/Messaging/Commands/CommandExecutor.cs:line 44


#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX