### PR TITLE
new: increase cache ingestion performance

### DIFF
--- a/src/NzbDrone.Common/Cache/Cached.cs
+++ b/src/NzbDrone.Common/Cache/Cached.cs
@@ -39,7 +39,7 @@ namespace NzbDrone.Common.Cache
             _store = new ConcurrentDictionary<string, CacheItem>();
             _defaultLifeTime = defaultLifeTime;
             _rollingExpiry = rollingExpiry;
-            _lock = new SemaphoreSlim(1, 1);
+            _lock = new SemaphoreSlim(2, 2);
         }
 
         public void Set(string key, T value, TimeSpan? lifeTime = null)

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -553,22 +553,35 @@ namespace Whisparr.Api.V3.Movies
 
             if (missingIds.Count > 0)
             {
+                var releaseLock = false;
                 try
                 {
-                    _movieResourcesCache.Lock.Wait();
-
                     var getIds = new List<int>();
-                    foreach (var id in missingIds)
+
+                    // If there are a large number of missing IDs, acquire the lock to prevent cache stampede
+                    if (missingIds.Count > 100)
                     {
-                        var movieResource = _movieResourcesCache.Find(id.ToString());
-                        if (movieResource == null)
+                        _logger.Info($"Caching {missingIds.Count} movies with {_movieResourcesCache.Lock.CurrentCount} avalible threads");
+                        _movieResourcesCache.Lock.Wait();
+                        releaseLock = true;
+
+                        // recheck after acquiring the lock
+                        foreach (var id in missingIds)
                         {
-                            getIds.Add(id);
+                            var movieResource = _movieResourcesCache.Find(id.ToString());
+                            if (movieResource == null)
+                            {
+                                getIds.Add(id);
+                            }
+                            else
+                            {
+                                moviesResources.AddIfNotNull(movieResource);
+                            }
                         }
-                        else
-                        {
-                            moviesResources.AddIfNotNull(movieResource);
-                        }
+                    }
+                    else
+                    {
+                        getIds = missingIds;
                     }
 
                     if (getIds.Count > 0)
@@ -612,7 +625,10 @@ namespace Whisparr.Api.V3.Movies
                 }
                 finally
                 {
-                    _movieResourcesCache.Lock.Release();
+                    if (releaseLock)
+                    {
+                        _movieResourcesCache.Lock.Release();
+                    }
                 }
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Log information about the ingestion of the cache data, Number of items, current available locks (threads).
Allow smaller number of items to process without any locking.
Allow two threads to process at the same time. The locking is there to try and attempt to threads requesting the same items so that the server is not duplicating any work.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX