### PR TITLE
New: Search for Performer Studio

### DIFF
--- a/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
@@ -45,6 +45,34 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
             ExceptionVerification.IgnoreWarns();
         }
 
+        [TestCase("whitney wright", "Whitney Wright")]
+        [TestCase("stash:155f2559-d1f1-42b1-8cbe-9008542df5ce", "Angela White")]
+        [TestCase("stashid:155f2559-d1f1-42b1-8cbe-9008542df5ce", "Angela White")]
+        [TestCase("https://stashdb.org/performers/155f2559-d1f1-42b1-8cbe-9008542df5ce", "Angela White")]
+        public void successful_performer_search(string title, string expected)
+        {
+            var result = Subject.SearchForNewPerformer(title);
+
+            result.Should().NotBeEmpty();
+
+            result[0].Name.Should().Be(expected);
+
+            ExceptionVerification.IgnoreWarns();
+        }
+
+        [TestCase("blacked", "Blacked")]
+        [TestCase("https://stashdb.org/studios/39cee498-a9ac-4403-910a-1a0157ad22d8", "Brazzers Exxtra")]
+        public void successful_studio_search(string title, string expected)
+        {
+            var result = Subject.SearchForNewStudio(title);
+
+            result.Should().NotBeEmpty();
+
+            result[0].Title.Should().Be(expected);
+
+            ExceptionVerification.IgnoreWarns();
+        }
+
         [TestCase("tmdbid:")]
         [TestCase("tmdbid: 99999999999999999999")]
         [TestCase("tmdbid: 0")]

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -830,6 +830,178 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             }
         }
 
+        public List<Performer> SearchForNewPerformer(string title)
+        {
+            try
+            {
+                var lowerTitle = title.ToLower();
+
+                lowerTitle = lowerTitle.Replace(".", "");
+
+                // Allow search to accept a full StashDB URL
+                var regex = new Regex(@"^https://stashdb\.org/performers/(?<stashid>[A-Za-z0-9\-]+).*$", RegexOptions.Compiled);
+                var match = regex.Match(title);
+
+                if (match.Success)
+                {
+                    lowerTitle = "stash:" + match.Groups["stashid"].Value;
+                    _logger.Debug($"Search based on StashDB URL.  Re-writing as {lowerTitle}");
+                }
+
+                if (lowerTitle.StartsWith("stash:") || lowerTitle.StartsWith("stashid:"))
+                {
+                    var slug = lowerTitle.Split(':')[1].Trim();
+
+                    var stashId = slug;
+
+                    if (slug.IsNullOrWhiteSpace() || slug.Any(char.IsWhiteSpace))
+                    {
+                        return new List<Performer>();
+                    }
+
+                    try
+                    {
+                        var performerLookup = GetPerformerInfo(stashId);
+                        return performerLookup == null ? new List<Performer>() : new List<Performer>() { performerLookup };
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Debug(ex, $"Perfromer not found");
+                        return new List<Performer>();
+                    }
+                }
+
+                var searchTerm = lowerTitle.Replace("_", " ").Replace(".", " ");
+
+                var firstChar = searchTerm.First();
+
+                var request = _whisparrMetadata.Create()
+                    .SetSegment("route", "performer/search")
+                    .AddQueryParam("q", searchTerm)
+                    .Build();
+
+                request.AllowAutoRedirect = true;
+                request.SuppressHttpError = true;
+
+                var httpResponse = _httpClient.Get<List<PerformerResource>>(request);
+
+                return httpResponse.Resource.SelectList(MapPerformer);
+            }
+            catch (UnexpectedHtmlContentException ex)
+            {
+                _logger.Warn(ex);
+                _logger.Warn("Search for '{0}' failed. StashDb returned a HTML Response.", ex, title, ex.Message);
+                return new List<Performer>();
+            }
+            catch (HttpException ex)
+            {
+                _logger.Warn(ex);
+                throw new SkyHookException("Search for '{0}' failed. Unable to communicate with StashDb.", ex, title);
+            }
+            catch (WebException ex)
+            {
+                _logger.Warn(ex);
+                throw new SkyHookException("Search for '{0}' failed. Unable to communicate with StashDb.", ex, title, ex.Message);
+            }
+            catch (JsonException ex)
+            {
+                _logger.Warn(ex);
+                _logger.Warn("Search for '{0}' failed. StashDb returned a JSON response.", ex, title, ex.Message);
+                return new List<Performer>();
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex);
+                throw new SkyHookException("Search for '{0}' failed. Invalid response received from StashDb.", ex, title);
+            }
+        }
+
+        public List<Studio> SearchForNewStudio(string title)
+        {
+            try
+            {
+                var lowerTitle = title.ToLower();
+
+                lowerTitle = lowerTitle.Replace(".", "");
+
+                // Allow search to accept a full StashDB URL
+                var regex = new Regex(@"^https://stashdb\.org/studios/(?<stashid>[A-Za-z0-9\-]+).*$", RegexOptions.Compiled);
+                var match = regex.Match(title);
+
+                if (match.Success)
+                {
+                    lowerTitle = "stash:" + match.Groups["stashid"].Value;
+                    _logger.Debug($"Search based on StashDB URL.  Re-writing as {lowerTitle}");
+                }
+
+                if (lowerTitle.StartsWith("stash:") || lowerTitle.StartsWith("stashid:"))
+                {
+                    var slug = lowerTitle.Split(':')[1].Trim();
+
+                    var stashId = slug;
+
+                    if (slug.IsNullOrWhiteSpace() || slug.Any(char.IsWhiteSpace))
+                    {
+                        return new List<Studio>();
+                    }
+
+                    try
+                    {
+                        var studioLookup = GetStudioInfo(stashId);
+                        return studioLookup == null ? new List<Studio>() : new List<Studio>() { studioLookup };
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Debug(ex, $"Studio not found");
+                        return new List<Studio>();
+                    }
+                }
+
+                var searchTerm = lowerTitle.Replace("_", " ").Replace(".", " ");
+
+                var firstChar = searchTerm.First();
+
+                var request = _whisparrMetadata.Create()
+                    .SetSegment("route", "site/search")
+                    .AddQueryParam("q", searchTerm)
+                    .Build();
+
+                request.AllowAutoRedirect = true;
+                request.SuppressHttpError = true;
+
+                var httpResponse = _httpClient.Get<List<StudioResource>>(request);
+
+                return httpResponse.Resource.SelectList(MapStudio);
+            }
+            catch (UnexpectedHtmlContentException ex)
+            {
+                _logger.Warn(ex);
+                _logger.Warn("Search for '{0}' failed. StashDb returned a HTML Response.", ex, title, ex.Message);
+                return new List<Studio>();
+            }
+            catch (HttpException ex)
+            {
+                _logger.Warn(ex);
+                throw new SkyHookException("Search for '{0}' failed. Unable to communicate with StashDb.", ex, title);
+            }
+            catch (WebException ex)
+            {
+                _logger.Warn(ex);
+                throw new SkyHookException("Search for '{0}' failed. Unable to communicate with StashDb.", ex, title, ex.Message);
+            }
+            catch (JsonException ex)
+            {
+                _logger.Warn(ex);
+                _logger.Warn("Search for '{0}' failed. StashDb returned a JSON response.", ex, title, ex.Message);
+                return new List<Studio>();
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex);
+                throw new SkyHookException("Search for '{0}' failed. Invalid response received from StashDb.", ex, title);
+            }
+        }
+
         private Movie MapSearchResult(MovieResource result)
         {
             var movie = _movieService.FindByForeignId(result.ItemType == ItemType.Movie ? result.ForeignIds.TmdbId.ToString() : result.ForeignIds.StashId);
@@ -973,7 +1145,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
         private Studio MapStudio(StudioResource studio)
         {
-            var newPerformer = new Studio
+            var newStudio = new Studio
             {
                 Title = studio.Title,
                 CleanTitle = studio.Title.CleanStudioTitle(),
@@ -985,7 +1157,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 Images = studio.Images?.Select(MapImage).ToList() ?? new List<MediaCover.MediaCover>()
             };
 
-            return newPerformer;
+            return newStudio;
         }
 
         private static Credit MapSceneCast(CastResource arg, string sceneForeignId)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Initial change to add search for performer and studio to the SkyHook endpoint. The client could be altered to search on each type Movie, Scene, Performer and Studio.

https://api.whisparr.com/v4/performer/search?q=angela%20white
https://api.whisparr.com/v4/site/search?q=blacked

Note; skyhook needs to be deployed with latest code as the site/search did not have the data structured correctly as a movieResource. 

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX