### PR TITLE
Fix: Stash Rename Integration

### DIFF
--- a/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
@@ -30,6 +30,6 @@ namespace NzbDrone.Core.Notifications
         public bool SupportsOnApplicationUpdate { get; set; }
         public bool SupportsOnManualInteractionRequired { get; set; }
 
-        public override bool Enable => OnGrab || OnDownload || (OnDownload && OnUpgrade) || OnSeriesAdd || OnSeriesDelete || OnEpisodeFileDelete || (OnEpisodeFileDelete && OnEpisodeFileDeleteForUpgrade) || OnHealthIssue || OnHealthRestored || OnApplicationUpdate || OnManualInteractionRequired;
+        public override bool Enable => OnGrab || OnDownload || (OnDownload && OnUpgrade) || OnRename || OnSeriesAdd || OnSeriesDelete || OnEpisodeFileDelete || (OnEpisodeFileDelete && OnEpisodeFileDeleteForUpgrade) || OnHealthIssue || OnHealthRestored || OnApplicationUpdate || OnManualInteractionRequired;
     }
 }


### PR DESCRIPTION
The Enable property determines if a notification is active. `OnRename` was missing from this expression, so notifications with only "On Rename" enabled were considered inactive and never triggered.

This is untested as I don't have a stash connection with something that I can rename.

Fixes: https://github.com/Whisparr/Whisparr/issues/670