### PR TITLE
Fix: Allow Blank Title for External ID Match

### DIFF
--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -441,6 +441,11 @@ namespace NzbDrone.Core.Parser
 
         public static string NormalizeEpisodeTitle(string title)
         {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
             var match = SpecialEpisodeTitleRegex
                         .Select(v => v.Match(title))
                         .FirstOrDefault(v => v.Success);


### PR DESCRIPTION
With the recent JAV changes it allows episodes to be matched purely on ExternalID

```[v2.0.0.1686] System.ArgumentNullException: Value cannot be null. (Parameter 'input')
   at System.Text.RegularExpressions.ThrowHelper.ThrowArgumentNullException(ExceptionArgument arg)
   at System.Text.RegularExpressions.Regex.Match(String input)
   at System.Linq.Enumerable.SelectArrayIterator`2.MoveNext()
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at NzbDrone.Core.Parser.Parser.NormalizeEpisodeTitle(String title)
   at NzbDrone.Core.Download.Aggregation.Aggregators.AggregateLanguages.Aggregate(RemoteEpisode remoteEpisode) in ./Whisparr.Core/Download/Aggregation/Aggregators/AggregateLanguages.cs:line 27
   at NzbDrone.Core.Download.Aggregation.RemoteEpisodeAggregationService.Augment(RemoteEpisode remoteEpisode) in ./Whisparr.Core/Download/Aggregation/RemoteEpisodeAggregationService.cs:line 32
```

This error was causing NormalizeEpisodeTitle to spazz out and then DDM couldn't do it's job