### PR TITLE
Fix: Use Events to clear the cache

### DIFF
--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -131,6 +131,7 @@ namespace Whisparr.Api.V3.Performers
 
             var updatedPerformer = _performerService.Update(resource.ToModel(performer));
 
+            _performerResourceCache.Remove(updatedPerformer.ForeignId);
             BroadcastResourceChange(ModelAction.Updated, updatedPerformer.ToResource());
 
             return Accepted(updatedPerformer);
@@ -171,6 +172,7 @@ namespace Whisparr.Api.V3.Performers
             var resource = message.Performer.ToResource();
 
             FetchAndLinkMovies(resource);
+            _performerResourceCache.Remove(resource.ForeignId);
             BroadcastResourceChange(ModelAction.Updated, resource);
         }
 

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -127,6 +127,7 @@ namespace Whisparr.Api.V3.Studios
 
             var updatedStudio = _studioService.Update(resource.ToModel(studio));
 
+            _studioResourceCache.Remove(updatedStudio.ForeignId);
             BroadcastResourceChange(ModelAction.Updated, updatedStudio.ToResource());
 
             return Accepted(updatedStudio);
@@ -158,6 +159,7 @@ namespace Whisparr.Api.V3.Studios
             }
 
             // Remove the studio now that the associated scenes have been removed
+            _studioResourceCache.Remove(studio.ForeignId);
             _studioService.RemoveStudio(studio);
         }
 
@@ -166,6 +168,7 @@ namespace Whisparr.Api.V3.Studios
         {
             var resource = message.Studio.ToResource();
 
+            _studioResourceCache.Remove(resource.ForeignId);
             FetchAndLinkMovies(resource);
             BroadcastResourceChange(ModelAction.Updated, message.Studio.ToResource());
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Use the events to trigger the clearing of the cache,
Make sure all the events return a fully populated movieResource

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #740 