### PR TITLE
Fix: Update Season Search

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -232,7 +232,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public async Task scene_seasonsearch()
+        public async Task scene_seasonsearch_should_search_each_episode_individually()
         {
             WithEpisodes();
 
@@ -240,14 +240,14 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             await Subject.SeasonSearch(_xemSeries.Id, 1, false, false, true, false);
 
-            var criteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
+            // Season 1 has 2 episodes, each searched individually
+            var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
 
-            criteria.Count.Should().Be(1);
-            criteria[0].Year.Should().Be(1);
+            criteria.Count.Should().Be(2);
         }
 
         [Test]
-        public async Task scene_seasonsearch_should_search_multiple_seasons()
+        public async Task scene_seasonsearch_should_search_all_episodes_in_season()
         {
             WithEpisodes();
 
@@ -255,14 +255,14 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             await Subject.SeasonSearch(_xemSeries.Id, 2, false, false, true, false);
 
-            var criteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
+            // Season 2 has 4 episodes, each searched individually
+            var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
 
-            criteria.Count.Should().Be(1);
-            criteria[0].Year.Should().Be(2);
+            criteria.Count.Should().Be(4);
         }
 
         [Test]
-        public async Task scene_seasonsearch_should_use_seasonnumber_if_no_scene_number_is_available()
+        public async Task scene_seasonsearch_should_search_episodes_without_scene_numbers()
         {
             WithEpisodes();
 
@@ -270,10 +270,10 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             await Subject.SeasonSearch(_xemSeries.Id, 7, false, false, true, false);
 
-            var criteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
+            // Season 7 has 2 episodes, each searched individually
+            var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
 
-            criteria.Count.Should().Be(1);
-            criteria[0].Year.Should().Be(7);
+            criteria.Count.Should().Be(2);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -71,27 +71,12 @@ namespace NzbDrone.Core.IndexerSearch
         public async Task<List<DownloadDecision>> SeasonSearch(int seriesId, int seasonNumber, List<Episode> episodes, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch)
         {
             var series = _seriesService.GetSeries(seriesId);
-
             var downloadDecisions = new List<DownloadDecision>();
 
-            if (episodes.Count == 1)
+            // Search each episode individually - XXX content doesn't have traditional seasons
+            foreach (var episode in episodes)
             {
-                var searchSpec = Get<SingleEpisodeSearchCriteria>(series, episodes, monitoredOnly, userInvokedSearch, interactiveSearch);
-                var episode = episodes.First();
-                searchSpec.ReleaseDate = DateOnly.Parse(episode.AirDate);
-                searchSpec.Performer = episode.Actors.Select(p => p.Name).FirstOrDefault();
-                searchSpec.EpisodeTitle = episode.Title;
-                searchSpec.ExternalId = episode.ExternalId;
-
-                var decisions = await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
-                downloadDecisions.AddRange(decisions);
-            }
-            else
-            {
-                var searchSpec = Get<SeasonSearchCriteria>(series, episodes, monitoredOnly, userInvokedSearch, interactiveSearch);
-                searchSpec.Year = seasonNumber;
-
-                var decisions = await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
+                var decisions = await SearchSingle(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch);
                 downloadDecisions.AddRange(decisions);
             }
 


### PR DESCRIPTION
With "Seasons" or "Packs" not really being supported this will modify the season automatic search button to do individual searches on missing episodes. This means users don't need to click each episode manually if they only want that season or modify monitored status to use the search monitored task.