### PR TITLE
Fix: Update Monitor Logic

### DIFF
--- a/src/Whisparr.Api.V3/SeasonPass/SeasonPassController.cs
+++ b/src/Whisparr.Api.V3/SeasonPass/SeasonPassController.cs
@@ -45,9 +45,17 @@ namespace Whisparr.Api.V3.SeasonPass
                     }
                 }
 
-                if (resource.MonitoringOptions != null && resource.MonitoringOptions.Monitor == MonitorTypes.None)
+                if (resource.MonitoringOptions != null)
                 {
-                    series.Monitored = false;
+                    if (resource.MonitoringOptions.Monitor == MonitorTypes.None)
+                    {
+                        series.Monitored = false;
+                    }
+                    else
+                    {
+                        // Re-enable series monitoring when changing from None to another monitor type
+                        series.Monitored = true;
+                    }
                 }
 
                 _episodeMonitoredService.SetEpisodeMonitoredStatus(series, resource.MonitoringOptions);


### PR DESCRIPTION
Currently, if you add a site, set the monitor status to none, then change the monitor status back to something like `All Scenes` downloads are still disabled. You have to edit the site and reenable downloads even though the monitoring status is set to all. This PR changes up the logic so that if the site is set to monitor anything then downloads will be enabled. 