### PR TITLE
New: Update Season Search to be More Like Single Search

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -73,9 +73,16 @@ namespace NzbDrone.Core.IndexerSearch
             var series = _seriesService.GetSeries(seriesId);
             var downloadDecisions = new List<DownloadDecision>();
 
+            _logger.ProgressInfo("Searching for {0} episodes in {1}", episodes.Count, series.Title);
+
             // Search each episode individually - XXX content doesn't have traditional seasons
+            var searchedCount = 0;
+
             foreach (var episode in episodes)
             {
+                searchedCount++;
+                _logger.ProgressInfo("Searching for {0} - {1} [{2}/{3}]", series.Title, episode.Title, searchedCount, episodes.Count);
+
                 var decisions = await SearchSingle(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch);
                 downloadDecisions.AddRange(decisions);
             }

--- a/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
@@ -1,7 +1,9 @@
+using System.Linq;
 using NLog;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Messaging.Commands;
+using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.IndexerSearch
 {
@@ -9,23 +11,46 @@ namespace NzbDrone.Core.IndexerSearch
     {
         private readonly ISearchForReleases _releaseSearchService;
         private readonly IProcessDownloadDecisions _processDownloadDecisions;
+        private readonly IEpisodeService _episodeService;
+        private readonly ISeriesService _seriesService;
         private readonly Logger _logger;
 
         public SeasonSearchService(ISearchForReleases releaseSearchService,
                                    IProcessDownloadDecisions processDownloadDecisions,
+                                   IEpisodeService episodeService,
+                                   ISeriesService seriesService,
                                    Logger logger)
         {
             _releaseSearchService = releaseSearchService;
             _processDownloadDecisions = processDownloadDecisions;
+            _episodeService = episodeService;
+            _seriesService = seriesService;
             _logger = logger;
         }
 
         public void Execute(SeasonSearchCommand message)
         {
-            var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, message.SeasonNumber, false, true, message.Trigger == CommandTrigger.Manual, false).GetAwaiter().GetResult();
-            var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
+            var series = _seriesService.GetSeries(message.SeriesId);
+            var episodes = _episodeService.GetEpisodesBySeason(message.SeriesId, message.SeasonNumber);
+            var userInvokedSearch = message.Trigger == CommandTrigger.Manual;
+            var downloadedCount = 0;
 
-            _logger.ProgressInfo("Season search completed. {0} reports downloaded.", processed.Grabbed.Count);
+            _logger.ProgressInfo("Searching for {0} episodes in {1}", episodes.Count, series.Title);
+
+            var searchedCount = 0;
+
+            foreach (var episode in episodes)
+            {
+                searchedCount++;
+                _logger.ProgressInfo("Searching for {0} - {1} [{2}/{3}]", series.Title, episode.Title, searchedCount, episodes.Count);
+
+                var decisions = _releaseSearchService.EpisodeSearch(episode, userInvokedSearch, false).GetAwaiter().GetResult();
+                var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
+
+                downloadedCount += processed.Grabbed.Count;
+            }
+
+            _logger.ProgressInfo("Season search completed. {0} reports downloaded.", downloadedCount);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using NLog;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.Download;


### PR DESCRIPTION
With the changes I made to season search it acts more like individual search.

Problem: 

When you activate the new season search the logging and decision making was based off of 1 decision and download. This meant when you did it on a season for Whisparr the UI would only display that it is searching for the first episode then just seem to hang. UX means they have no idea if it actually crashed or is just taking a long time. 

Fix:
Update the logging to reflect what it is doing similar to individual scenes so that users can see progress. The UI should display when a decision has been made and the client moves onto the next search. I also updated the flow from: 

Search -> Make decision -> Search -> Make decision -> Download 2x

To :

Search -> Make decision -> Download -> Search -> Make decision -> Download

This way users can actually see the files populate in their clients as another way of seeing that it is not hanging.