### PR TITLE
Fix: Season Search Changes

### DIFF
--- a/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
@@ -1,7 +1,9 @@
+using System.Linq;
 using NLog;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Messaging.Commands;
+using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.IndexerSearch
 {
@@ -9,23 +11,48 @@ namespace NzbDrone.Core.IndexerSearch
     {
         private readonly ISearchForReleases _releaseSearchService;
         private readonly IProcessDownloadDecisions _processDownloadDecisions;
+        private readonly IEpisodeService _episodeService;
         private readonly Logger _logger;
 
         public SeasonSearchService(ISearchForReleases releaseSearchService,
                                    IProcessDownloadDecisions processDownloadDecisions,
+                                   IEpisodeService episodeService,
                                    Logger logger)
         {
             _releaseSearchService = releaseSearchService;
             _processDownloadDecisions = processDownloadDecisions;
+            _episodeService = episodeService;
             _logger = logger;
         }
 
         public void Execute(SeasonSearchCommand message)
         {
-            var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, message.SeasonNumber, true, true, message.Trigger == CommandTrigger.Manual, false).GetAwaiter().GetResult();
-            var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
+            var episodes = _episodeService.GetEpisodesBySeason(message.SeriesId, message.SeasonNumber);
 
-            _logger.ProgressInfo("Season search completed. {0} reports downloaded.", processed.Grabbed.Count);
+            // Filter to only missing (no file) and monitored episodes
+            episodes = episodes.Where(e => !e.HasFile && e.Monitored).ToList();
+
+            if (!episodes.Any())
+            {
+                _logger.ProgressInfo("No missing monitored episodes found for this season.");
+                return;
+            }
+
+            var totalGrabbed = 0;
+            var searchedCount = 0;
+
+            foreach (var episode in episodes)
+            {
+                searchedCount++;
+                _logger.ProgressInfo("Searching for {0} [{1}/{2}]", episode.Title, searchedCount, episodes.Count);
+
+                var decisions = _releaseSearchService.EpisodeSearch(episode, message.Trigger == CommandTrigger.Manual, false).GetAwaiter().GetResult();
+                var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
+
+                totalGrabbed += processed.Grabbed.Count;
+            }
+
+            _logger.ProgressInfo("Season search completed. {0} reports downloaded.", totalGrabbed);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
@@ -2,7 +2,6 @@ using NLog;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Messaging.Commands;
-using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.IndexerSearch
 {
@@ -10,46 +9,23 @@ namespace NzbDrone.Core.IndexerSearch
     {
         private readonly ISearchForReleases _releaseSearchService;
         private readonly IProcessDownloadDecisions _processDownloadDecisions;
-        private readonly IEpisodeService _episodeService;
-        private readonly ISeriesService _seriesService;
         private readonly Logger _logger;
 
         public SeasonSearchService(ISearchForReleases releaseSearchService,
                                    IProcessDownloadDecisions processDownloadDecisions,
-                                   IEpisodeService episodeService,
-                                   ISeriesService seriesService,
                                    Logger logger)
         {
             _releaseSearchService = releaseSearchService;
             _processDownloadDecisions = processDownloadDecisions;
-            _episodeService = episodeService;
-            _seriesService = seriesService;
             _logger = logger;
         }
 
         public void Execute(SeasonSearchCommand message)
         {
-            var series = _seriesService.GetSeries(message.SeriesId);
-            var episodes = _episodeService.GetEpisodesBySeason(message.SeriesId, message.SeasonNumber);
-            var userInvokedSearch = message.Trigger == CommandTrigger.Manual;
-            var downloadedCount = 0;
+            var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, message.SeasonNumber, true, true, message.Trigger == CommandTrigger.Manual, false).GetAwaiter().GetResult();
+            var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
 
-            _logger.ProgressInfo("Searching for {0} episodes in {1}", episodes.Count, series.Title);
-
-            var searchedCount = 0;
-
-            foreach (var episode in episodes)
-            {
-                searchedCount++;
-                _logger.ProgressInfo("Searching for {0} - {1} [{2}/{3}]", series.Title, episode.Title, searchedCount, episodes.Count);
-
-                var decisions = _releaseSearchService.EpisodeSearch(episode, userInvokedSearch, false).GetAwaiter().GetResult();
-                var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
-
-                downloadedCount += processed.Grabbed.Count;
-            }
-
-            _logger.ProgressInfo("Season search completed. {0} reports downloaded.", downloadedCount);
+            _logger.ProgressInfo("Season search completed. {0} reports downloaded.", processed.Grabbed.Count);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
@@ -39,13 +39,9 @@ namespace NzbDrone.Core.IndexerSearch
             }
 
             var totalGrabbed = 0;
-            var searchedCount = 0;
 
             foreach (var episode in episodes)
             {
-                searchedCount++;
-                _logger.ProgressInfo("Searching for {0} [{1}/{2}]", episode.Title, searchedCount, episodes.Count);
-
                 var decisions = _releaseSearchService.EpisodeSearch(episode, message.Trigger == CommandTrigger.Manual, false).GetAwaiter().GetResult();
                 var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
 


### PR DESCRIPTION
Season search was not respecting if a file already existed for a episode. Modified up the logic to check if the episode is monitored and does not have a file associated. I changed up some of the logging as well