### PR TITLE
New: Corrupt File Detection

### DIFF
--- a/frontend/src/Settings/General/WhisparrSettings.js
+++ b/frontend/src/Settings/General/WhisparrSettings.js
@@ -24,6 +24,7 @@ function WhisparrSettings(props) {
     whisparrCacheMovieAPI,
     whisparrCachePerformerAPI,
     whisparrCacheStudioAPI,
+    whisparrCorruptFileDetection,
     whisparrValidateRuntime,
     whisparrValidateRuntimeLimit
   } = settings;
@@ -106,6 +107,21 @@ function WhisparrSettings(props) {
           helpText={translate('WhisparrAutoMatchOnDateHelpText')}
           onChange={onInputChange}
           {...whisparrAutoMatchOnDate}
+        />
+      </FormGroup>
+
+      <FormGroup
+        advancedSettings={advancedSettings}
+        isAdvanced={true}
+      >
+        <FormLabel>{translate('WhisparrCorruptFileDetection')}</FormLabel>
+
+        <FormInputGroup
+          type={inputTypes.CHECK}
+          name="whisparrCorruptFileDetection"
+          helpText={translate('WhisparrCorruptFileDetectionHelpText')}
+          onChange={onInputChange}
+          {...whisparrCorruptFileDetection}
         />
       </FormGroup>
 

--- a/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxySearchFixture.cs
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
             ExceptionVerification.IgnoreWarns();
         }
 
-        [TestCase("blacked", "Blacked")]
+        [TestCase("brazzers exxtra", "Brazzers Exxtra")]
         [TestCase("https://stashdb.org/studios/39cee498-a9ac-4403-910a-1a0157ad22d8", "Brazzers Exxtra")]
         public void successful_studio_search(string title, string expected)
         {

--- a/src/NzbDrone.Core/Configuration/ConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigService.cs
@@ -529,6 +529,13 @@ namespace NzbDrone.Core.Configuration
             set { SetValue("WhisparrCacheStudioAPI", value); }
         }
 
+        public bool WhisparrCorruptFileDetection
+        {
+            get { return GetValueBoolean("WhisparrCorruptFileDetection", false); }
+
+            set { SetValue("WhisparrCorruptFileDetection", value); }
+        }
+
         public bool WhisparrValidateRuntime
         {
             get { return GetValueBoolean("WhisparrValidateRuntime", false); }

--- a/src/NzbDrone.Core/Configuration/IConfigService.cs
+++ b/src/NzbDrone.Core/Configuration/IConfigService.cs
@@ -117,6 +117,7 @@ namespace NzbDrone.Core.Configuration
         bool WhisparrCacheMovieAPI { get; }
         bool WhisparrCachePerformerAPI { get; }
         bool WhisparrCacheStudioAPI { get; }
+        bool WhisparrCorruptFileDetection { get; }
         bool WhisparrValidateRuntime { get; }
         int WhisparrValidateRuntimeLimit { get; }
         int WhisparrFolderLimit { get; set; }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -2031,6 +2031,8 @@
   "WhisparrCacheStudioAPI": "Cache Studio API",
   "WhisparrCacheStudioAPIHelpText": "Cache API calls to studios",
   "WhisparrCalendarFeed": "{appName} Calendar Feed",
+  "WhisparrCorruptFileDetection": "Corrupt File Detection",
+  "WhisparrCorruptFileDetectionHelpText": "The file will be checked and if it is not found to be valid it will fail to automatically import.",
   "WhisparrFolderLimit": "Import File Limit",
   "WhisparrFolderLimitHelpText": "Limit the manual import tp a number of files within a folder",
   "WhisparrSupportsAnyDownloadClient": "{appName} supports many popular torrent and usenet download clients.",

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/ImportDecisionMaker.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/ImportDecisionMaker.cs
@@ -284,14 +284,20 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
 
                     decision = GetDecision(localMovie, downloadClientItem);
 
-                    if (localMovie.MediaInfo?.RunTime != null && localMovie.MediaInfo.RunTime.TotalMinutes > 0 && localMovie.Movie.MovieMetadata.Value.Runtime > 0)
+                    if (localMovie.MediaInfo?.RunTime != null && localMovie.MediaInfo.RunTime.TotalMinutes != 0 && localMovie.Movie.MovieMetadata.Value.Runtime > 0)
                     {
                         var runtime = localMovie.MediaInfo.RunTime.TotalMinutes;
                         var limit = _configService.WhisparrValidateRuntimeLimit;
 
                         if (runtime < localMovie.Movie.MovieMetadata.Value.Runtime - limit || runtime > localMovie.Movie.MovieMetadata.Value.Runtime + limit)
                         {
-                            _logger.Warn($"Runtime of {localMovie.Movie.MovieMetadata.Value.Runtime} expected but {runtime} Found for {localMovie.Movie.ToString()}");
+                            var rejection = $"Runtime of {localMovie.Movie.MovieMetadata.Value.Runtime} expected but {runtime} Found";
+                            if (runtime == -1)
+                            {
+                                rejection = "Corrupt file detected as Media Information was not able to be extracted.";
+                            }
+
+                            _logger.Warn($"{rejection} for {localMovie.Movie.ToString()}");
                             if (_configService.WhisparrValidateRuntime)
                             {
                                 decision = new ImportDecision(localMovie, new Rejection($"Runtime of {localMovie.Movie.MovieMetadata.Value.Runtime} expected but {runtime} Found"));

--- a/src/Whisparr.Api.V3/Config/HostConfigResource.cs
+++ b/src/Whisparr.Api.V3/Config/HostConfigResource.cs
@@ -54,6 +54,7 @@ namespace Whisparr.Api.V3.Config
         public bool WhisparrCacheMovieAPI { get; set; }
         public bool WhisparrCachePerformerAPI { get; set; }
         public bool WhisparrCacheStudioAPI { get; set; }
+        public bool WhisparrCorruptFileDetection { get; set; }
         public bool WhisparrValidateRuntime { get; set; }
         public int WhisparrValidateRuntimeLimit { get; set; }
     }
@@ -110,6 +111,7 @@ namespace Whisparr.Api.V3.Config
                 WhisparrCacheMovieAPI = configService.WhisparrCacheMovieAPI,
                 WhisparrCachePerformerAPI = configService.WhisparrCachePerformerAPI,
                 WhisparrCacheStudioAPI = configService.WhisparrCacheStudioAPI,
+                WhisparrCorruptFileDetection = configService.WhisparrCorruptFileDetection,
                 WhisparrValidateRuntime = configService.WhisparrValidateRuntime,
                 WhisparrValidateRuntimeLimit = configService.WhisparrValidateRuntimeLimit
             };

--- a/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -195,10 +195,11 @@ namespace Whisparr.Api.V3.ImportLists
 
                 try
                 {
+                    _logger.Info($"Caching {missingIds.Count} exclusions with {_exclusionResourceCache.Lock.CurrentCount} available threads.");
+
                     // If there are a large number of missing IDs, acquire the lock to prevent cache stampede
                     if (missingIds.Count > 100)
                     {
-                        _logger.Info($"Caching {missingIds.Count} exclusions with {_exclusionResourceCache.Lock.CurrentCount} avalible threads");
                         _exclusionResourceCache.Lock.Wait();
                         releaseLock = true;
                         if (stopwatch.Elapsed.TotalSeconds > 2)

--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -452,7 +452,14 @@ namespace Whisparr.Api.V3.Movies
             _movieResourcesCache.Remove(message.MovieInfo.Movie.Id.ToString());
 
             var updatedMovie = _moviesService.GetMovie(message.MovieInfo.Movie.Id);
-            BroadcastResourceChange(ModelAction.Updated, MapToResource(updatedMovie));
+            if (updatedMovie != null)
+            {
+                BroadcastResourceChange(ModelAction.Updated, MapToResource(updatedMovie));
+            }
+            else
+            {
+                BroadcastResourceChange(ModelAction.Updated, message.MovieInfo.Movie.Id);
+            }
         }
 
         [NonAction]
@@ -466,7 +473,14 @@ namespace Whisparr.Api.V3.Movies
 
             _movieResourcesCache.Remove(message.MovieFile.MovieId.ToString());
             var updatedMovie = _moviesService.GetMovie(message.MovieFile.MovieId);
-            BroadcastResourceChange(ModelAction.Updated, MapToResource(updatedMovie));
+            if (updatedMovie != null)
+            {
+                BroadcastResourceChange(ModelAction.Updated, MapToResource(updatedMovie));
+            }
+            else
+            {
+                BroadcastResourceChange(ModelAction.Updated, message.MovieFile.MovieId);
+            }
         }
 
         [NonAction]
@@ -579,10 +593,11 @@ namespace Whisparr.Api.V3.Movies
 
                 try
                 {
+                    _logger.Info($"Caching {missingIds.Count} movies with {_movieResourcesCache.Lock.CurrentCount} available threads.");
+
                     // If there are a large number of missing IDs, acquire the lock to prevent cache stampede
                     if (missingIds.Count > 100)
                     {
-                        _logger.Info($"Caching {missingIds.Count} movies with {_movieResourcesCache.Lock.CurrentCount} avalible threads");
                         _movieResourcesCache.Lock.Wait();
                         releaseLock = true;
                         if (stopwatch.Elapsed.TotalSeconds > 2)

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -245,10 +245,11 @@ namespace Whisparr.Api.V3.Performers
 
                 try
                 {
+                    _logger.Info($"Caching {missingIds.Count} performers with {_performerResourceCache.Lock.CurrentCount} available threads.");
+
                     // If there are a large number of missing IDs, acquire the lock to prevent cache stampede
                     if (missingIds.Count > 100)
                     {
-                        _logger.Info($"Caching {missingIds.Count} performers with {_performerResourceCache.Lock.CurrentCount} avalible threads");
                         _performerResourceCache.Lock.Wait();
                         releaseLock = true;
                         if (stopwatch.Elapsed.TotalSeconds > 2)

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -242,10 +242,11 @@ namespace Whisparr.Api.V3.Studios
 
                 try
                 {
+                    _logger.Info($"Caching {missingIds.Count} studios with {_studioResourceCache.Lock.CurrentCount} available threads.");
+
                     // If there are a large number of missing IDs, acquire the lock to prevent cache stampede
                     if (missingIds.Count > 100)
                     {
-                        _logger.Info($"Caching {missingIds.Count} studios with {_studioResourceCache.Lock.CurrentCount} avalible threads");
                         _studioResourceCache.Lock.Wait();
                         releaseLock = true;
                         if (stopwatch.Elapsed.TotalSeconds > 2)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Use the media information to see if the file could be corrupted.
Remove the sample check if the runtime is validated, for short scenes in h265 or AV1 codes. The rule is really only valid for movies.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX