### PR TITLE
Fix: Refresh Studios and Performers oldest to newest

### DIFF
--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -231,7 +231,7 @@ namespace NzbDrone.Core.Movies.Performers
             }
             else
             {
-                var allPerformers = _performerService.GetAllPerformers().OrderBy(c => c.SortName).ToList();
+                var allPerformers = _performerService.GetAllPerformers().OrderBy(c => c.LastInfoSync).ToList();
 
                 var updatePerformers = new HashSet<string>();
 

--- a/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
@@ -198,7 +198,7 @@ namespace NzbDrone.Core.Movies.Studios
             }
             else
             {
-                var allStudios = _studioService.GetAllStudios().OrderBy(c => c.SortTitle).ToList();
+                var allStudios = _studioService.GetAllStudios().OrderBy(c => c.LastInfoSync).ToList();
 
                 var updatedStudios = new HashSet<string>();
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Refresh the Studios and Performers based on last sync so older ones are synced first. The previous alpha order means that if a studio causes a fault then the end of the alphabet may never get a refresh. 

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX