### PR TITLE
Fix: External Id Import 

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/AggregationService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/AggregationService.cs
@@ -41,22 +41,8 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation
         {
             var isMediaFile = MediaFileExtensions.Extensions.Contains(Path.GetExtension(localEpisode.Path));
 
-            if (localEpisode.DownloadClientEpisodeInfo == null &&
-                localEpisode.FolderEpisodeInfo == null &&
-                localEpisode.FileEpisodeInfo == null)
-            {
-                if (isMediaFile)
-                {
-                    if (downloadClientItem != null)
-                    {
-                        // Skip validation for downloads - will be handled by aggregators
-                    }
-                    else
-                    {
-                        throw new AugmentingFailedException("Unable to parse episode info from path: {0}", localEpisode.Path);
-                    }
-                }
-            }
+            // Don't throw early if parsing fails - let aggregators try external ID matching
+            // This allows library files to be matched by external ID from the database
 
             localEpisode.Size = _diskProvider.GetFileSize(localEpisode.Path);
             localEpisode.SceneName = localEpisode.SceneSource ? SceneNameCalculator.GetSceneName(localEpisode) : null;

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateEpisodes.cs
@@ -164,8 +164,11 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
                 // Verify the episode belongs to the series we're importing to
                 if (localEpisode.Series != null && episode.SeriesId != localEpisode.Series.Id)
                 {
-                    _logger.Debug("External ID {0} matched episode in different series (expected: {1}, found: {2}). Skipping.",
-                        filenameExternalId, localEpisode.Series.Id, episode.SeriesId);
+                    _logger.Debug(
+                        "External ID {0} matched episode in different series (expected: {1}, found: {2}). Skipping.",
+                        filenameExternalId,
+                        localEpisode.Series.Id,
+                        episode.SeriesId);
                     return null;
                 }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateEpisodes.cs
@@ -15,12 +15,14 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
     public class AggregateEpisodes : IAggregateLocalEpisode
     {
         private readonly IParsingService _parsingService;
+        private readonly IEpisodeService _episodeService;
         private readonly ITrackedDownloadService _trackedDownloadService;
         private readonly Logger _logger;
 
-        public AggregateEpisodes(IParsingService parsingService, ITrackedDownloadService trackedDownloadService, Logger logger)
+        public AggregateEpisodes(IParsingService parsingService, IEpisodeService episodeService, ITrackedDownloadService trackedDownloadService, Logger logger)
         {
             _parsingService = parsingService;
+            _episodeService = episodeService;
             _trackedDownloadService = trackedDownloadService;
             _logger = logger;
         }
@@ -151,6 +153,36 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
                         return trackedDownload.RemoteEpisode.Episodes;
                     }
                 }
+            }
+
+            // Fallback: Query database for episode with matching external ID
+            // This handles cases like manual imports or files from another instance
+            var episode = _episodeService.FindByExternalId(filenameExternalId);
+
+            if (episode != null)
+            {
+                // Verify the episode belongs to the series we're importing to
+                if (localEpisode.Series != null && episode.SeriesId != localEpisode.Series.Id)
+                {
+                    _logger.Debug("External ID {0} matched episode in different series (expected: {1}, found: {2}). Skipping.",
+                        filenameExternalId, localEpisode.Series.Id, episode.SeriesId);
+                    return null;
+                }
+
+                _logger.Debug("Matched file to episode via external ID from database: {0}", filenameExternalId);
+
+                // Update FileEpisodeInfo for other aggregators
+                if (localEpisode.FileEpisodeInfo == null)
+                {
+                    localEpisode.FileEpisodeInfo = new ParsedEpisodeInfo
+                    {
+                        Quality = QualityParser.ParseQuality(filename),
+                        Languages = LanguageParser.ParseLanguages(filename),
+                        ExternalId = filenameExternalId
+                    };
+                }
+
+                return new List<Episode> { episode };
             }
 
             return null;

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -84,6 +84,16 @@ namespace NzbDrone.Core.Parser
             new ExternalIdPattern(
                 @"^(?<prefix>[A-Z]{2,10})\.(?<number>\d{3,10})(?:\.|$)",
                 match => $"{match.Groups["prefix"].Value}-{match.Groups["number"].Value}"),
+
+            // External ID with single letter suffix (subtitle/version marker): DVAJ-702-C.mp4, ABC-123_A.mkv
+            new ExternalIdPattern(
+                $@"^(?<externalid>{ExternalIdBasePattern})[-_][A-Z](?:\.[a-z0-9]{{2,4}})?$",
+                match => match.Groups["externalid"].Value),
+
+            // External ID with bracketed quality/tag suffix: SNOS-002_[4K].mkv, ABC-123[UC].mp4
+            new ExternalIdPattern(
+                $@"^(?<externalid>{ExternalIdBasePattern})[-_]?\[[^\]]+\](?:\.[a-z0-9]{{2,4}})?$",
+                match => match.Groups["externalid"].Value),
         };
 
         private static readonly Regex[] ReportTitleRegex = new[]


### PR DESCRIPTION
A user brought up that, between 2 instances, their scenes weren't updating. Scenes we visible in the manage episodes tab but they were not automatically matching on the second instance. The reason was that I had it setup to used `trackedDownload?.RemoteEpisode?.Episodes` flag. `TryMatchByExternalID` doesn't do a direct DB query, it only check tracked downloads which wont exist on the second instance. This adds in a DB query as a fallback to the tracked downlods flags. Most users wont run into this issue so adding it as a fallback keeps speed up and most users unaffected.