### PR TITLE
Fix: Update to lastinfosync

### DIFF
--- a/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/RefreshSeriesService.cs
@@ -256,7 +256,9 @@ namespace NzbDrone.Core.Tv
             }
             else
             {
-                var allSeries = _seriesService.GetAllSeries().OrderBy(c => c.SortTitle).ToList();
+                // Order by LastInfoSync (oldest first) so that if the task times out,
+                // the most stale series get refreshed first rather than always alphabetically
+                var allSeries = _seriesService.GetAllSeries().OrderBy(c => c.LastInfoSync).ToList();
 
                 foreach (var series in allSeries)
                 {


### PR DESCRIPTION
Update the site refresh to do it by last sync rather than alphabetical.

This issue was causing people with larger DBs to essentially never get the trailing end of their site list to update. If the refresh timed out, there was an error, or cancelation of any kind then the task restarts at A and the latter sites can never be refreshed. This changes it to last sync time so that the refresh command will start at the oldest sync time and work to the newest. This means that if there is an issue it will pick up on the next oldest and keep moving.