### PR TITLE
Fix: Stasharr Scene Exclusion Endpoint

### DIFF
--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportListExclusionRepository.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportListExclusionRepository.cs
@@ -29,7 +29,13 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
 
         public ImportListExclusion GetByForeignId(string foreignId)
         {
-            return Query(x => x.ForeignId == foreignId).First();
+            var exclusions = Query(x => x.ForeignId == foreignId).ToList();
+            if (exclusions.Count == 0)
+            {
+                return null;
+            }
+
+            return exclusions.First();
         }
 
         public List<ImportListExclusion> AllByType(ImportExclusionType type)

--- a/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -44,9 +44,10 @@ namespace Whisparr.Api.V3.ImportLists
             SharedValidator.RuleFor(c => c.MovieYear).GreaterThan(0);
         }
 
+        // Endpoint only used by stasharr to show excluded scenes
         [HttpGet]
         [Produces("application/json")]
-        public List<ImportListExclusionResource> GetImportListExclusions(string stashId)
+        public List<ImportListExclusionResource> GetImportListExclusions(string stashId, ImportExclusionType type = ImportExclusionType.Scene)
         {
             var importListExclusionResources = new List<ImportListExclusionResource>();
 
@@ -64,10 +65,11 @@ namespace Whisparr.Api.V3.ImportLists
                 if (_useCache)
                 {
                     importListExclusionResources = GetExclusionResources();
+                    importListExclusionResources = importListExclusionResources.Where(x => x.Type == type).ToList();
                 }
                 else
                 {
-                    importListExclusionResources = _importListExclusionService.GetAllExclusions().ToResource();
+                    importListExclusionResources = _importListExclusionService.GetAllByType(type).ToResource();
                 }
             }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
API/exclusions is only used for stasharr, and stasharr is expecting just scene exclusion, so the default behaviour is to return just the scene exclusions.

Other integrations can get a different type, or check a single single StashId if it is excluded

The single StashId will no longer error if it is not excluded.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX