### PR TITLE
Chore: Disable Sentry to avoid build-time deps and logging

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -127,7 +127,9 @@
 
     <!-- Upload PDBs to Sentry, enabling stack traces with line numbers and file paths
       without the need to deploy the application with PDBs -->
-    <SentryUploadSymbols>true</SentryUploadSymbols>
+    <!-- Disabled by default to avoid automatic Sentry connection attempts; can be
+         enabled per-build with: msbuild -p:SentryUploadSymbols=true -->
+    <SentryUploadSymbols>false</SentryUploadSymbols>
 
     <!-- Source Link settings -->
     <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#publishrepositoryurl -->


### PR DESCRIPTION
#### Database Migration
NO

#### Description
This snuck in via Radarr upstream commits.  We don't have access to it, and it's not actually working for us, so I'm disabling it.
#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #683