### PR TITLE
Fix page load failure

### DIFF
--- a/frontend/src/Movie/Details/MovieDetails.css
+++ b/frontend/src/Movie/Details/MovieDetails.css
@@ -60,7 +60,7 @@
   margin-right: 35px;
   width: 368px;
   height: 207px;
-  object-fit: 'contain';
+  object-fit: contain;
 }
 
 .info {

--- a/src/Whisparr.Api.V3/MovieFiles/MediaInfoResource.cs
+++ b/src/Whisparr.Api.V3/MovieFiles/MediaInfoResource.cs
@@ -37,7 +37,7 @@ namespace Whisparr.Api.V3.MovieFiles
             {
                 AudioBitrate = model.AudioBitrate,
                 AudioChannels = MediaInfoFormatter.FormatAudioChannels(model),
-                AudioLanguages = model.AudioLanguages.ConcatToString("/"),
+                AudioLanguages = model.AudioLanguages?.ConcatToString("/") ?? string.Empty,
                 AudioStreamCount = model.AudioStreamCount,
                 AudioCodec = MediaInfoFormatter.FormatAudioCodec(model, sceneName),
                 VideoBitDepth = model.VideoBitDepth,
@@ -49,7 +49,7 @@ namespace Whisparr.Api.V3.MovieFiles
                 Resolution = $"{model.Width}x{model.Height}",
                 RunTime = FormatRuntime(model.RunTime),
                 ScanType = model.ScanType,
-                Subtitles = model.Subtitles.ConcatToString("/")
+                Subtitles = model.Subtitles?.ConcatToString("/") ?? string.Empty
             };
         }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
User reported failure to load scenes.  Stacktrace idicates either AudioLanguages or Subtitles was null in MediaInfoResource, and had no null safety.  Added that.  I couldn't repro, so hoping this fixes it.

Also, I snuck in a CSS fix for scene detail where the screenshot/cover was not properly contained, so it would stretch horizontally to fill the container.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #821