### PR TITLE
New: Mark merged or deleted performer with the deleted status

### DIFF
--- a/frontend/src/Store/Actions/movieActions.js
+++ b/frontend/src/Store/Actions/movieActions.js
@@ -105,6 +105,17 @@ export const filters = [
         type: filterTypes.EQUAL
       }
     ]
+  },
+  {
+    key: 'deleted',
+    label: () => translate('Deleted'),
+    filters: [
+      {
+        key: 'status',
+        value: 'deleted',
+        type: filterTypes.EQUAL
+      }
+    ]
   }
 ];
 

--- a/frontend/src/Store/Actions/performerActions.js
+++ b/frontend/src/Store/Actions/performerActions.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { createAction } from 'redux-actions';
 import { batchActions } from 'redux-batched-actions';
-import { filterBuilderTypes, filterBuilderValueTypes, sortDirections } from 'Helpers/Props';
+import { filterBuilderTypes, filterBuilderValueTypes, filterTypes, sortDirections } from 'Helpers/Props';
 import { createThunk, handleThunks } from 'Store/thunks';
 import sortByProp from 'Utilities/Array/sortByProp';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
@@ -166,6 +166,39 @@ export const defaultState = {
       key: 'all',
       label: () => translate('All'),
       filters: []
+    },
+    {
+      key: 'monitored',
+      label: () => translate('MonitoredOnly'),
+      filters: [
+        {
+          key: 'monitored',
+          value: true,
+          type: filterTypes.EQUAL
+        }
+      ]
+    },
+    {
+      key: 'unmonitored',
+      label: () => translate('Unmonitored'),
+      filters: [
+        {
+          key: 'monitored',
+          value: false,
+          type: filterTypes.EQUAL
+        }
+      ]
+    },
+    {
+      key: 'deleted',
+      label: () => translate('Deleted'),
+      filters: [
+        {
+          key: 'status',
+          value: 'deleted',
+          type: filterTypes.EQUAL
+        }
+      ]
     }
   ],
 
@@ -211,7 +244,7 @@ export const defaultState = {
       label: () => translate('Status'),
       type: filterBuilderTypes.EXACT,
       optionsSelector: function(items) {
-        const tagList = ['active', 'inactive', 'unknown'];
+        const tagList = ['active', 'inactive', 'unknown', 'deleted'];
 
         const tags = tagList.map((tag) => {
           return {

--- a/frontend/src/Store/Actions/studioActions.js
+++ b/frontend/src/Store/Actions/studioActions.js
@@ -1,10 +1,11 @@
 import _ from 'lodash';
 import { createAction } from 'redux-actions';
 import { batchActions } from 'redux-batched-actions';
-import { filterBuilderTypes, filterBuilderValueTypes, sortDirections } from 'Helpers/Props';
+import { filterBuilderTypes, filterBuilderValueTypes, filterTypes, sortDirections } from 'Helpers/Props';
 import { createThunk, handleThunks } from 'Store/thunks';
 import sortByProp from 'Utilities/Array/sortByProp';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
+import camelCaseToString from 'Utilities/String/camelCaseToString';
 import translate from 'Utilities/String/translate';
 import { set, updateItem } from './baseActions';
 import createFetchHandler from './Creators/createFetchHandler';
@@ -126,6 +127,39 @@ export const defaultState = {
       key: 'all',
       label: () => translate('All'),
       filters: []
+    },
+    {
+      key: 'monitored',
+      label: () => translate('MonitoredOnly'),
+      filters: [
+        {
+          key: 'monitored',
+          value: true,
+          type: filterTypes.EQUAL
+        }
+      ]
+    },
+    {
+      key: 'unmonitored',
+      label: () => translate('Unmonitored'),
+      filters: [
+        {
+          key: 'monitored',
+          value: false,
+          type: filterTypes.EQUAL
+        }
+      ]
+    },
+    {
+      key: 'deleted',
+      label: () => translate('Deleted'),
+      filters: [
+        {
+          key: 'status',
+          value: 'deleted',
+          type: filterTypes.EQUAL
+        }
+      ]
     }
   ],
 
@@ -147,6 +181,23 @@ export const defaultState = {
       label: () => translate('Title'),
       type: filterBuilderTypes.EXACT,
       valueType: filterBuilderValueTypes.DEFAULT
+    },
+    {
+      name: 'status',
+      label: () => translate('Status'),
+      type: filterBuilderTypes.EXACT,
+      optionsSelector: function(items) {
+        const tagList = ['active', 'deleted'];
+
+        const tags = tagList.map((tag) => {
+          return {
+            id: tag,
+            name: camelCaseToString(tag)
+          };
+        });
+
+        return tags.sort(sortByProp('name'));
+      }
     },
     {
       name: 'sceneCount',

--- a/src/NzbDrone.Core/Datastore/Migration/012_studio_status.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/012_studio_status.cs
@@ -1,0 +1,15 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(012)]
+    public class tudio_status : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            Alter.Table("Studios")
+                .AddColumn("Status").AsInt32().WithDefaultValue(0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Datastore/TableMapping.cs
+++ b/src/NzbDrone.Core/Datastore/TableMapping.cs
@@ -174,7 +174,9 @@ namespace NzbDrone.Core.Datastore
 
                   Mapper.Entity<MovieMetadata>("MovieMetadata").RegisterModel();
 
-                  Mapper.Entity<Performer>("Performers").RegisterModel();
+                  Mapper.Entity<Performer>("Performers").RegisterModel()
+                        .Ignore(e => e.MergedIntoId);
+
                   Mapper.Entity<Studio>("Studios").RegisterModel();
 
                   Mapper.Entity<AutoTagging.AutoTag>("AutoTagging").RegisterModel();

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/PerformerResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/PerformerResource.cs
@@ -11,6 +11,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public string Gender { get; set; }
         public string Ethnicity { get; set; }
         public PerformerStatus Status { get; set; }
+        public string MergedIntoId { get; set; }
         public int? Age { get; set; }
         public int? CareerStart { get; set; }
         public int? CareerEnd { get; set; }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/StudioResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/StudioResource.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using NzbDrone.Core.Movies.Studios;
 
 namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
 {
@@ -8,6 +9,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public List<string> Aliases { get; set; }
         public string Homepage { get; set; }
         public string Network { get; set; }
+        public StudioStatus Status { get; set; }
         public List<ImageResource> Images { get; set; }
         public ExternalIdResource ForeignIds { get; set; }
     }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -995,6 +995,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 SortName = Parser.Parser.NormalizeTitle(performer.Name),
                 Gender = MapGender(performer.Gender),
                 Status = performer.Status,
+                MergedIntoId = performer.MergedIntoId,
                 Age = performer.Age,
                 CareerStart = performer.CareerStart,
                 CareerEnd = performer.CareerEnd,
@@ -1098,7 +1099,8 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 Website = studio.Homepage,
                 ForeignId = studio.ForeignIds.StashId,
                 Network = studio.Network,
-                Images = studio.Images?.Select(MapImage).ToList() ?? new List<MediaCover.MediaCover>()
+                Images = studio.Images?.Select(MapImage).ToList() ?? new List<MediaCover.MediaCover>(),
+                Status = studio.Status
             };
 
             return newStudio;

--- a/src/NzbDrone.Core/Movies/Performers/Performer.cs
+++ b/src/NzbDrone.Core/Movies/Performers/Performer.cs
@@ -14,6 +14,7 @@ namespace NzbDrone.Core.Movies.Performers
         }
 
         public string ForeignId { get; set; }
+        public string MergedIntoId { get; set; }
         public string Name { get; set; }
         public string SortName { get; set; }
         public string CleanName { get; set; }
@@ -53,7 +54,8 @@ namespace NzbDrone.Core.Movies.Performers
     {
         Active,
         Inactive,
-        Unknown
+        Unknown,
+        Deleted
     }
 
     public enum Ethnicity

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -103,7 +103,7 @@ namespace NzbDrone.Core.Movies
                 {
                     movieMetadata.Status = MovieStatusType.Deleted;
                     _movieMetadataService.Upsert(movieMetadata);
-                    _logger.Debug("Movie marked as deleted on TMDb for {0}", movie.Title);
+                    _logger.Debug("Movie metadata source has marked it as deleted: {0}", movie);
                     _eventAggregator.PublishEvent(new MovieUpdatedEvent(movie));
                 }
 

--- a/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
@@ -83,6 +83,7 @@ namespace NzbDrone.Core.Movies.Studios
             studio.CleanTitle = studioInfo.CleanTitle;
             studio.SortTitle = studioInfo.SortTitle;
             studio.Aliases = studioInfo.Aliases;
+            studio.Status = studioInfo.Status;
 
             _studioService.Update(studio);
 

--- a/src/NzbDrone.Core/Movies/Studios/Studio.cs
+++ b/src/NzbDrone.Core/Movies/Studios/Studio.cs
@@ -27,6 +27,7 @@ namespace NzbDrone.Core.Movies.Studios
         public string Network { get; set; }
         public DateTime Added { get; set; }
         public bool Monitored { get; set; }
+        public StudioStatus Status { get; set; }
         public DateTime? AfterDate { get; set; }
         public int QualityProfileId { get; set; }
         public bool SearchOnAdd { get; set; }
@@ -40,8 +41,8 @@ namespace NzbDrone.Core.Movies.Studios
             QualityProfileId = otherStudio.QualityProfileId;
             SearchOnAdd = otherStudio.SearchOnAdd;
             Monitored = otherStudio.Monitored;
+            Status = otherStudio.Status;
             AfterDate = otherStudio.AfterDate;
-
             RootFolderPath = otherStudio.RootFolderPath;
             Tags = otherStudio.Tags;
         }
@@ -50,5 +51,13 @@ namespace NzbDrone.Core.Movies.Studios
         {
             return string.Format("[{0}]", Title.NullSafe());
         }
+    }
+
+    public enum StudioStatus
+    {
+        Active,
+        Inactive,
+        Unknown,
+        Deleted
     }
 }

--- a/src/Whisparr.Api.V3/Studios/StudioResource.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioResource.cs
@@ -18,6 +18,7 @@ namespace Whisparr.Api.V3.Studios
         public string Network { get; set; }
         public List<MediaCover> Images { get; set; }
         public bool Monitored { get; set; }
+        public StudioStatus Status { get; set; }
         public string AfterDate { get; set; }
         public string RootFolderPath { get; set; }
         public int QualityProfileId { get; set; }
@@ -52,6 +53,7 @@ namespace Whisparr.Api.V3.Studios
                 Website = model.Website,
                 Network = model.Network,
                 Monitored = model.Monitored,
+                Status = model.Status,
                 AfterDate = model.AfterDate?.ToLocalTime().ToString("yyyy-MM-dd"),
                 Images = model.Images,
                 QualityProfileId = model.QualityProfileId,
@@ -85,6 +87,7 @@ namespace Whisparr.Api.V3.Studios
                 Website = resource.Website,
                 Network = resource.Network,
                 Monitored = resource.Monitored,
+                Status = resource.Status,
                 AfterDate = string.IsNullOrWhiteSpace(resource.AfterDate) ? null : DateTime.Parse(resource.AfterDate),
                 QualityProfileId = resource.QualityProfileId,
                 RootFolderPath = resource.RootFolderPath,


### PR DESCRIPTION
#### Database Migration
YES - 12

#### Description
Set the status to deleted for performers that are no longer on StashDB. This is the same logic for Movies.

Studios will need a database change to store a status.

Works with https://github.com/Whisparr/WhisparrAPI.Metadata/pull/24 as additional data is extracted to show the an item is deleted or merged.

Sample data can be found at StashDB 
https://stashdb.org/edits?operation=merge&status=accepted
https://stashdb.org/edits?operation=destroy&status=accepted

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX