### PR TITLE
Fix: Stop duplicate scan processes running for the same movie at the same time

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
@@ -44,6 +46,9 @@ namespace NzbDrone.Core.MediaFiles
         private readonly IEventAggregator _eventAggregator;
         private readonly Logger _logger;
 
+        // Per-movie in-process locks to ensure Scan runs only one concurrent scan per movie.Id
+        private static readonly ConcurrentDictionary<int, SemaphoreSlim> ScanLocks = new ConcurrentDictionary<int, SemaphoreSlim>();
+
         public DiskScanService(IDiskProvider diskProvider,
                                IMakeImportDecision importDecisionMaker,
                                IImportApprovedMovie importApprovedMovies,
@@ -78,128 +83,160 @@ namespace NzbDrone.Core.MediaFiles
 
         public void Scan(Movie movie, bool manual = false)
         {
-            var rootFolder = _rootFolderService.GetBestRootFolderPath(movie.Path);
-
-            var movieFolderExists = _diskProvider.FolderExists(movie.Path);
-
-            if (!movieFolderExists)
+            if (movie == null)
             {
-                if (!_diskProvider.FolderExists(rootFolder))
-                {
-                    _logger.Warn("Movie's root folder ({0}) doesn't exist.", rootFolder);
-                    _eventAggregator.PublishEvent(new MovieScanSkippedEvent(movie, MovieScanSkippedReason.RootFolderDoesNotExist));
-                    return;
-                }
-
-                if (_diskProvider.FolderEmpty(rootFolder))
-                {
-                    _logger.Warn("Movie's root folder ({0}) is empty. Rescan will not update movies as a failsafe.", rootFolder);
-                    _eventAggregator.PublishEvent(new MovieScanSkippedEvent(movie, MovieScanSkippedReason.RootFolderIsEmpty));
-                    return;
-                }
-            }
-
-            _logger.Trace("Scanning disk for {0}", movie.Title);
-
-            if (!movieFolderExists)
-            {
-                if (_configService.CreateEmptyMovieFolders)
-                {
-                    if (_configService.DeleteEmptyFolders)
-                    {
-                        _logger.Debug("Not creating missing movie folder: {0} because delete empty movie folders is enabled", movie.Path);
-                    }
-                    else
-                    {
-                        _logger.Debug("Creating missing movie folder: {0}", movie.Path);
-
-                        _diskProvider.CreateFolder(movie.Path);
-                        SetPermissions(movie.Path);
-                    }
-                }
-                else
-                {
-                    _logger.Debug("Movie's folder doesn't exist: {0}", movie.Path);
-                }
-
-                CleanMediaFiles(movie, new List<string>());
-                CompletedScanning(movie, new List<string>());
-
                 return;
             }
 
-            var videoFilesStopwatch = Stopwatch.StartNew();
-            var mediaFileList = FilterPaths(movie.Path, GetVideoFiles(movie.Path)).ToList();
-            videoFilesStopwatch.Stop();
-            _logger.Trace("Finished getting movie files for: {0} [{1}]", movie, videoFilesStopwatch.Elapsed);
+            var sem = ScanLocks.GetOrAdd(movie.Id, _ => new SemaphoreSlim(1, 1));
 
-            CleanMediaFiles(movie, mediaFileList);
-
-            var movieFiles = _mediaFileService.GetFilesByMovie(movie.Id);
-            var unmappedFiles = MediaFileService.FilterExistingFiles(mediaFileList, movieFiles, movie);
-
-            var decisionsStopwatch = Stopwatch.StartNew();
-            var decisions = _importDecisionMaker.GetImportDecisions(unmappedFiles, movie, false);
-            decisionsStopwatch.Stop();
-            _logger.Trace("Import decisions complete for: {0} [{1}]", movie, decisionsStopwatch.Elapsed);
-            _importApprovedMovies.Import(decisions, false);
-
-            // Update existing files that have a different file size
-            var fileInfoStopwatch = Stopwatch.StartNew();
-            var filesToUpdate = new List<MovieFile>();
-
-            foreach (var file in movieFiles)
+            _logger.Trace("Acquiring scan lock for movie id {0} ({1})", movie.Id, movie.Title);
+            sem.Wait();
+            try
             {
-                var path = Path.Combine(movie.Path, file.RelativePath);
-                var fileSize = _diskProvider.GetFileSize(path);
+                var rootFolder = _rootFolderService.GetBestRootFolderPath(movie.Path);
 
-                if (!manual && file.Size == fileSize)
+                var movieFolderExists = _diskProvider.FolderExists(movie.Path);
+
+                if (!movieFolderExists)
                 {
-                    continue;
-                }
-
-                file.Size = fileSize;
-
-                if (!_updateMediaInfoService.Update(file, movie))
-                {
-                    filesToUpdate.Add(file);
-                }
-            }
-
-            // Update any files that had a file size change, but didn't get media info updated.
-            if (filesToUpdate.Any())
-            {
-                _mediaFileService.Update(filesToUpdate);
-            }
-
-            fileInfoStopwatch.Stop();
-            _logger.Trace("Reprocessing existing files complete for: {0} [{1}]", movie, decisionsStopwatch.Elapsed);
-
-            var filesOnDisk = GetNonVideoFiles(movie.Path);
-            var possibleExtraFiles = FilterPaths(movie.Path, filesOnDisk);
-
-            RemoveEmptyMovieFolder(movie.Path);
-
-            // Check if movie is a scene, then cleanup the unmapped scene
-            if (movie.MovieMetadata.Value.ItemType == ItemType.Scene)
-            {
-                var existingUnmappedFiles = _mediaFileRepository.GetUnmappedFiles();
-                if (existingUnmappedFiles != null)
-                {
-                    foreach (var unmappedFile in existingUnmappedFiles)
+                    if (!_diskProvider.FolderExists(rootFolder))
                     {
-                        if (unmappedFile.OriginalFilePath.Contains(movie.Path))
+                        _logger.Warn("Movie's root folder ({0}) doesn't exist.", rootFolder);
+                        _eventAggregator.PublishEvent(new MovieScanSkippedEvent(movie, MovieScanSkippedReason.RootFolderDoesNotExist));
+                        return;
+                    }
+
+                    if (_diskProvider.FolderEmpty(rootFolder))
+                    {
+                        _logger.Warn("Movie's root folder ({0}) is empty. Rescan will not update movies as a failsafe.", rootFolder);
+                        _eventAggregator.PublishEvent(new MovieScanSkippedEvent(movie, MovieScanSkippedReason.RootFolderIsEmpty));
+                        return;
+                    }
+                }
+
+                _logger.Trace("Scanning disk for {0}", movie.Title);
+
+                if (!movieFolderExists)
+                {
+                    if (_configService.CreateEmptyMovieFolders)
+                    {
+                        if (_configService.DeleteEmptyFolders)
                         {
-                            var reason = DeleteMediaFileReason.Manual;
-                            _mediaFileRepository.Delete(unmappedFile);
-                            _eventAggregator.PublishEvent(new MovieFileDeletedEvent(unmappedFile, reason));
-                            break;
+                            _logger.Debug("Not creating missing movie folder: {0} because delete empty movie folders is enabled", movie.Path);
+                        }
+                        else
+                        {
+                            _logger.Debug("Creating missing movie folder: {0}", movie.Path);
+
+                            _diskProvider.CreateFolder(movie.Path);
+                            SetPermissions(movie.Path);
+                        }
+                    }
+                    else
+                    {
+                        _logger.Debug("Movie's folder doesn't exist: {0}", movie.Path);
+                    }
+
+                    CleanMediaFiles(movie, new List<string>());
+                    CompletedScanning(movie, new List<string>());
+
+                    return;
+                }
+
+                var videoFilesStopwatch = Stopwatch.StartNew();
+                var mediaFileList = FilterPaths(movie.Path, GetVideoFiles(movie.Path)).ToList();
+                videoFilesStopwatch.Stop();
+                _logger.Trace("Finished getting movie files for: {0} [{1}]", movie, videoFilesStopwatch.Elapsed);
+
+                CleanMediaFiles(movie, mediaFileList);
+
+                var movieFiles = _mediaFileService.GetFilesByMovie(movie.Id);
+                var unmappedFiles = MediaFileService.FilterExistingFiles(mediaFileList, movieFiles, movie);
+
+                var decisionsStopwatch = Stopwatch.StartNew();
+                var decisions = _importDecisionMaker.GetImportDecisions(unmappedFiles, movie, false);
+                decisionsStopwatch.Stop();
+                _logger.Trace("Import decisions complete for: {0} [{1}]", movie, decisionsStopwatch.Elapsed);
+                _importApprovedMovies.Import(decisions, false);
+
+                // Update existing files that have a different file size
+                var fileInfoStopwatch = Stopwatch.StartNew();
+                var filesToUpdate = new List<MovieFile>();
+
+                foreach (var file in movieFiles)
+                {
+                    var path = Path.Combine(movie.Path, file.RelativePath);
+                    var fileSize = _diskProvider.GetFileSize(path);
+
+                    if (!manual && file.Size == fileSize)
+                    {
+                        continue;
+                    }
+
+                    file.Size = fileSize;
+
+                    if (!_updateMediaInfoService.Update(file, movie))
+                    {
+                        filesToUpdate.Add(file);
+                    }
+                }
+
+                // Update any files that had a file size change, but didn't get media info updated.
+                if (filesToUpdate.Any())
+                {
+                    _mediaFileService.Update(filesToUpdate);
+                }
+
+                fileInfoStopwatch.Stop();
+                _logger.Trace("Reprocessing existing files complete for: {0} [{1}]", movie, decisionsStopwatch.Elapsed);
+
+                var filesOnDisk = GetNonVideoFiles(movie.Path);
+                var possibleExtraFiles = FilterPaths(movie.Path, filesOnDisk);
+
+                RemoveEmptyMovieFolder(movie.Path);
+
+                // Check if movie is a scene, then cleanup the unmapped scene
+                if (movie.MovieMetadata.Value.ItemType == ItemType.Scene)
+                {
+                    var existingUnmappedFiles = _mediaFileRepository.GetUnmappedFiles();
+                    if (existingUnmappedFiles != null)
+                    {
+                        foreach (var unmappedFile in existingUnmappedFiles)
+                        {
+                            if (unmappedFile.OriginalFilePath.Contains(movie.Path))
+                            {
+                                var reason = DeleteMediaFileReason.Manual;
+                                _mediaFileRepository.Delete(unmappedFile);
+                                _eventAggregator.PublishEvent(new MovieFileDeletedEvent(unmappedFile, reason));
+                                break;
+                            }
                         }
                     }
                 }
-            }
 
-            CompletedScanning(movie, possibleExtraFiles);
+                CompletedScanning(movie, possibleExtraFiles);
+            }
+            finally
+            {
+                try
+                {
+                    sem.Release();
+                }
+                catch (SemaphoreFullException)
+                {
+                    // Shouldn't happen, but guard against releasing too many times.
+                }
+
+                // Attempt to remove the semaphore from the dictionary when it looks unused.
+                // This is best-effort and racing callers may re-create the entry; that's acceptable.
+                if (ScanLocks.TryGetValue(movie.Id, out var existing) && ReferenceEquals(existing, sem) && sem.CurrentCount == 1)
+                {
+                    ScanLocks.TryRemove(movie.Id, out _);
+                }
+
+                _logger.Trace("Released scan lock for movie id {0} ({1})", movie.Id, movie.Title);
+            }
         }
 
         private void CleanMediaFiles(Movie movie, List<string> mediaFileList)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
If multiple scan processes are triggered to run at the same time then multiple records can be created. Lock at the movie id level across the threads.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #828 