### PR TITLE
Fix: Select Input issues prevent modal rendering

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewPerformer/AddNewPerformerModalContent.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewPerformer/AddNewPerformerModalContent.js
@@ -96,7 +96,7 @@ class AddNewPerformerModalContent extends Component {
                   </FormLabel>
 
                   <FormInputGroup
-                    type={inputTypes.MOVIE_MONITORED_SELECT}
+                    type={inputTypes.MONITOR_MOVIES_SELECT}
                     name="monitor"
                     onChange={onInputChange}
                     {...monitor}

--- a/frontend/src/Components/Form/Select/RootFolderSelectInput.tsx
+++ b/frontend/src/Components/Form/Select/RootFolderSelectInput.tsx
@@ -99,6 +99,8 @@ function createRootFolderOptionsSelector(
         values,
         isSaving: rootFolders.isSaving,
         saveError: rootFolders.saveError,
+        isPopulated: rootFolders.isPopulated,
+        isFetching: rootFolders.isFetching,
       };
     }
   );
@@ -114,7 +116,7 @@ function RootFolderSelectInput({
   ...otherProps
 }: RootFolderSelectInputProps) {
   const dispatch = useDispatch();
-  const { values, isSaving, saveError } = useSelector(
+  const { values, isSaving, saveError, isPopulated, isFetching } = useSelector(
     createRootFolderOptionsSelector(
       value,
       includeMissingValue,
@@ -200,8 +202,10 @@ function RootFolderSelectInput({
   }, []);
 
   useEffect(() => {
-    dispatch(fetchRootFolders());
-  }, [dispatch]);
+    if (!isPopulated && !isFetching) {
+      dispatch(fetchRootFolders());
+    }
+  }, [dispatch, isPopulated, isFetching]);
 
   return (
     <>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Fixing two bugs related to input select components, both caused by recent upstream radarr commits incorporated into our code.  Root Folder Select was causing a modal flicker, noticed on Import List edit modal.   Add Performer was throwing a warning in the yarn console due to renaming the const for that.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX