### PR TITLE
Fix: Manual Import

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateMovie.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateMovie.cs
@@ -17,7 +17,10 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators
 
         public LocalMovie Aggregate(LocalMovie localMovie, DownloadClientItem downloadClientItem)
         {
-            localMovie.Movie = _movieService.GetMovie(localMovie.Movie.Id);
+            if (localMovie.Movie?.Id != null)
+            {
+                localMovie.Movie = _movieService.GetMovie(localMovie.Movie.Id);
+            }
 
             return localMovie;
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Need to do a null check on the movie object as it can be null when doing a manual import.

AggregationService is causing an error, when Called from the ManualImportService as the movie object can be null if it does not match.

our manual import is different from radarr as it calls the following.
// Augment movie file so imported files have all additional information an automatic import would
localMovie = _aggregationService.Augment(localMovie, null);

The process works, but errors are logged when the import file does not match a movie

[v3.0.2.1859] System.NullReferenceException: Object reference not set to an instance of an object.

   at NzbDrone.Core.MediaFiles.MovieImport.Aggregation.Aggregators.AggregateMovie.Aggregate(LocalMovie localMovie, DownloadClientItem downloadClientItem) in ./Whisparr.Core/MediaFiles/MovieImport/Aggregation/Aggregators/AggregateMovie.cs:line 22

   at NzbDrone.Core.MediaFiles.MovieImport.Aggregation.AggregationService.Augment(LocalMovie localMovie, DownloadClientItem downloadClientItem) in ./Whisparr.Core/MediaFiles/MovieImport/Aggregation/AggregationService.cs:line 73

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX