### PR TITLE
Fix: Windows disk service logging security

### DIFF
--- a/src/NzbDrone.Windows/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Windows/Disk/DiskProvider.cs
@@ -101,7 +101,7 @@ namespace NzbDrone.Windows.Disk
             }
             catch (Exception e)
             {
-                Logger.Warn(e, "Couldn't set permission for {0}. account:{1} rights:{2} accessControlType:{3}", filename, accountSid, rights, controlType);
+                Logger.Warn(e, "Couldn't set permission for {0}. rights:{1}, accessControlType:{2}", filename, rights, controlType);
                 throw;
             }
         }


### PR DESCRIPTION
CodeQL scanning picked up a bad practice of logging accountsid in clear text.  Low risk for now, but we wouldn't want users submitting logs with this info potentially in it.

This is only a change to logging.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX