### PR TITLE
Fix: Movie/Scene update performance

### DIFF
--- a/src/Whisparr.Api.V3/Movies/MovieController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieController.cs
@@ -411,9 +411,6 @@ namespace Whisparr.Api.V3.Movies
 
             var updatedMovie = _moviesService.UpdateMovie(model);
 
-            _movieResourcesCache.Remove(updatedMovie.Id.ToString());
-            BroadcastResourceChange(ModelAction.Updated, MapToResource(updatedMovie));
-
             return Accepted(moviesResource.Id);
         }
 


### PR DESCRIPTION
Recent changes to caching and resource mapping caused the PUT by ID API to slow down.  This was due to processing overhead in MapToResource, which was being called synchronously in this API.  This presented as taking 3+ seconds to monitor/unmonitor or save an edit to a single movie.

MovieService.UpdateMovie is already triggering all the work asynchronously by triggering a MovieEditedEvent, so these calls inside MovieConroller were duplicates and expensive (MapToResource is heavy, so better in async).

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX