### PR TITLE
Fix: Call the correct changed endpoint

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/IProvideMovieInfo.cs
+++ b/src/NzbDrone.Core/MetadataSource/IProvideMovieInfo.cs
@@ -20,6 +20,7 @@ namespace NzbDrone.Core.MetadataSource
         List<string> GetStudioScenes(string stashId);
         (List<string> Scenes, List<string> TpdbMovies) GetStudioWorks(string stashId);
         HashSet<int> GetChangedMovies(DateTime startTime);
+        HashSet<int> GetChangedTpdbMovies(DateTime startTime);
         HashSet<string> GetChangedScenes(DateTime startTime);
         HashSet<string> GetChangedStudios(DateTime startTime);
         HashSet<string> GetChangedPerformers(DateTime startTime);

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -77,6 +77,25 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             return new HashSet<int>(response.Resource);
         }
 
+        public HashSet<int> GetChangedTpdbMovies(DateTime startTime)
+        {
+            // Round down to the hour to ensure we cover gap and don't kill cache every call
+            var cacheAdjustedStart = startTime.AddMinutes(-15);
+            var startDate = cacheAdjustedStart.Date.AddHours(cacheAdjustedStart.Hour).ToString("s");
+
+            var request = _whisparrMetadata.Create()
+                .SetSegment("route", "tpdb/movie/changed")
+                .AddQueryParam("since", startDate)
+                .Build();
+
+            request.AllowAutoRedirect = true;
+            request.SuppressHttpError = true;
+
+            var response = _httpClient.Get<List<int>>(request);
+
+            return new HashSet<int>(response.Resource);
+        }
+
         public HashSet<string> GetChangedScenes(DateTime startTime)
         {
             // Round down to the hour to ensure we cover gap and don't kill cache every call

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DryIoc.ImTools;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
@@ -343,7 +344,16 @@ namespace NzbDrone.Core.Movies
 
                 if (message.LastStartTime.HasValue && message.LastStartTime.Value.AddDays(14) > DateTime.UtcNow)
                 {
-                    updatedMovies = _movieInfo.GetChangedMovies(message.LastStartTime.Value).Select(x => x.ToString()).ToHashSet();
+                    if (_configService.WhisparrMovieMetadataSource == MovieMetadataType.TMDB)
+                    {
+                        updatedMovies = _movieInfo.GetChangedMovies(message.LastStartTime.Value).Select(x => x.ToString()).ToHashSet();
+                    }
+                    else if (_configService.WhisparrMovieMetadataSource == MovieMetadataType.TPDB)
+                    {
+                        updatedMovies = _movieInfo.GetChangedTpdbMovies(message.LastStartTime.Value).Select(x => x.ToString()).ToHashSet();
+                        updatedMovies = updatedMovies.Map(up => up.Insert(0, "tpdbid:")).ToHashSet();
+                    }
+
                     updatedScenes = _movieInfo.GetChangedScenes(message.LastStartTime.Value);
                 }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Call the TPDB endpoint to find out any changed movies.

TPDB movies have a prefix so that is applied.

https://github.com/Whisparr/WhisparrAPI.Metadata/pull/27

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX