### PR TITLE
Fix: Restore header search for scenes

### DIFF
--- a/frontend/src/Components/Page/Header/MovieSearchResult.css
+++ b/frontend/src/Components/Page/Header/MovieSearchResult.css
@@ -2,29 +2,61 @@
   display: flex;
   align-items: center;
   flex-direction: row;
-  padding: 3px;
+  padding: 3px 4px;
   border-top: 1px solid var(--borderColor);
   cursor: pointer;
 }
 
-.poster {
+.posterContainer {
   display: flex;
-  align-content: center;
   align-items: center;
-  width: 80px;
+  justify-content: center;
+  flex: 0 0 140px;
+  overflow: hidden;
+  margin-right: 12px;
+  width: 140px;
+  height: 120px;
+}
 
+.poster {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.runtime {
+  color: var(--mutedColor);
+  font-size: 12px;
 }
 
 .screenshot {
-  margin-top: 5px;
   width: 80px;
+}
+
+.sceneContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 140px;
+  overflow: hidden;
+  margin-right: 12px;
+  width: 140px;
+}
+
+.scene {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .titles {
   display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   overflow: hidden;
-  white-space: nowrap;
+  min-width: 0;
 }
 
 .titleContainer {
@@ -36,37 +68,46 @@
 
 .title {
   overflow: hidden;
-  margin-left: 5px;
-  max-width: 500px;
+  margin-bottom: 6px;
+  margin-left: 0;
+  max-width: 100%;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 600;
+}
+
+.studioIcon{
+  margin-right: 6px;
 }
 
 .studioTitle {
-  display: flex;
-  align-content: center;
-  float: left;
-  margin-left: 5px;
-  font-size: 12px;
+  margin-left: 8px;
+  color: var(--mutedColor);
+  font-size: 14px;
 }
 
 .releaseDate {
-  display: flex;
-  align-content: center;
-  float: left;
-  overflow: hidden;
-  margin-left: 5px;
+  margin-left: 8px;
+  color: var(--mutedColor);
   font-size: 12px;
 }
 
 .itemTypeContainer {
   display: flex;
+  align-items: center;
 }
 
 .itemType {
   display: inline-flex;
-  float: left;
-  margin-left: 5px;
+}
+
+.metaRow {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+
+  margin-bottom: 4px;
 }
 
 .alternateTitle {
@@ -74,10 +115,6 @@
 
   color: var(--disabledColor);
   font-size: $smallFontSize;
-}
-
-.tagContainer {
-  composes: title;
 }
 
 @media only screen and (max-width: $breakpointSmall) {

--- a/frontend/src/Components/Page/Header/MovieSearchResult.css.d.ts
+++ b/frontend/src/Components/Page/Header/MovieSearchResult.css.d.ts
@@ -4,12 +4,17 @@ interface CssExports {
   'alternateTitle': string;
   'itemType': string;
   'itemTypeContainer': string;
+  'metaRow': string;
   'poster': string;
+  'posterContainer': string;
   'releaseDate': string;
   'result': string;
+  'runtime': string;
+  'scene': string;
+  'sceneContainer': string;
   'screenshot': string;
+  'studioIcon': string;
   'studioTitle': string;
-  'tagContainer': string;
   'title': string;
   'titleContainer': string;
   'titles': string;

--- a/frontend/src/Components/Page/Header/MovieSearchResult.tsx
+++ b/frontend/src/Components/Page/Header/MovieSearchResult.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
-import { Tag } from 'App/State/TagsAppState';
+import { useSelector } from 'react-redux';
+import Icon from 'Components/Icon';
 import Label from 'Components/Label';
-import { kinds } from 'Helpers/Props';
+import { icons, kinds, sizes } from 'Helpers/Props';
 import MoviePoster from 'Movie/MoviePoster';
+import ScenePoster from 'Scene/ScenePoster';
+import createUISettingsSelector from 'Store/Selectors/createUISettingsSelector';
+import formatRuntime from 'Utilities/Date/formatRuntime';
+import getRelativeDate from 'Utilities/Date/getRelativeDate';
+import firstCharToUpper from 'Utilities/String/firstCharToUpper';
 import { SuggestedMovie } from './MovieSearchInput';
 import styles from './MovieSearchResult.css';
 
@@ -16,40 +22,74 @@ interface MovieSearchResultProps extends SuggestedMovie {
 }
 
 function MovieSearchResult(props: MovieSearchResultProps) {
-  const { match, title, year, images, tmdbId, tags } = props;
+  const { title, year, images, itemType, studioTitle, runtime, releaseDate } =
+    props;
 
-  let tag: Tag | null = null;
+  const { showRelativeDates, shortDateFormat, timeFormat } = useSelector(
+    createUISettingsSelector()
+  );
 
-  if (match.key === 'tags.label') {
-    tag = tags[match.refIndex];
+  let releaseText = '';
+
+  if (releaseDate) {
+    releaseText = getRelativeDate({
+      date: releaseDate,
+      shortDateFormat,
+      showRelativeDates,
+      timeFormat,
+      timeForToday: false,
+    });
+  } else if (year > 0) {
+    releaseText = `${year}`;
   }
 
   return (
     <div className={styles.result}>
-      <MoviePoster
-        className={styles.poster}
-        images={images}
-        size={250}
-        lazy={false}
-        overflow={true}
-      />
-
-      <div className={styles.titles}>
-        <div className={styles.title}>
-          {title} {year > 0 ? `(${year})` : ''}
+      {itemType === 'scene' ? (
+        <div className={styles.sceneContainer}>
+          <ScenePoster
+            className={styles.scene}
+            images={images}
+            size={180}
+            lazy={false}
+            overflow={true}
+            safeForWorkMode={false}
+          />
         </div>
+      ) : (
+        <div className={styles.posterContainer}>
+          <MoviePoster
+            className={styles.poster}
+            images={images}
+            size={250}
+            lazy={false}
+            overflow={true}
+          />
+        </div>
+      )}
+      <div className={styles.titles}>
+        <div className={styles.title}>{title}</div>
 
-        {match.key === 'tmdbId' && tmdbId ? (
-          <div className={styles.alternateTitle}>TmdbId: {tmdbId}</div>
-        ) : null}
+        <div>{releaseText ? `${releaseText}` : ''}</div>
 
-        {tag ? (
-          <div className={styles.tagContainer}>
-            <Label key={tag.id} kind={kinds.INFO}>
-              {tag.label}
+        <div className={styles.metaRow}>
+          <div className={styles.itemType}>
+            <Label size={sizes.LARGE} kind={kinds.INVERSE} outline={true}>
+              {firstCharToUpper(itemType)}
             </Label>
           </div>
-        ) : null}
+
+          {studioTitle ? (
+            <Label size={sizes.LARGE} kind={kinds.INVERSE} outline={true}>
+              <Icon name={icons.STUDIO} className={styles.studioIcon} />
+              {studioTitle}
+            </Label>
+          ) : null}
+
+          {runtime ? (
+            <div className={styles.runtime}>{formatRuntime(runtime)}</div>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/Store/Selectors/createAllMoviesSelector.ts
+++ b/frontend/src/Store/Selectors/createAllMoviesSelector.ts
@@ -5,7 +5,9 @@ function createAllMoviesSelector() {
   return createSelector(
     (state: AppState) => state.movies,
     (movies) => {
-      return movies.items.filter((movie) => movie.itemType === 'movie');
+      return movies.items.filter(
+        (movie) => movie.itemType === 'movie' || movie.itemType === 'scene'
+      );
     }
   );
 }


### PR DESCRIPTION
This was broken when incorporating upstream Radarr page components in #840.  I ended up re-building this from scratch.  It's probably not perfect, but it's on parity with previous iteration.

#### Database Migration
NO

#### Screenshot (if UI related)
<details><summary>click to show</summary>
<img width="573" height="559" alt="image" src="https://github.com/user-attachments/assets/19cdbfcd-67bb-474f-bd60-30b274a34c0b" />
</details>


#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #854