### PR TITLE
Fix: Show Movie Performers

### DIFF
--- a/frontend/src/Helpers/Hooks/useAppPage.ts
+++ b/frontend/src/Helpers/Hooks/useAppPage.ts
@@ -88,10 +88,7 @@ const useAppPage = () => {
 
   const isPopulated = useSelector(
     (state: AppState) =>
-      state.movies.isPopulated &&
       state.customFilters.isPopulated &&
-      state.performers.isPopulated &&
-      state.studios.isPopulated &&
       state.tags.isPopulated &&
       state.settings.ui.isPopulated &&
       state.settings.qualityProfiles.isPopulated &&

--- a/frontend/src/Movie/Details/Credits/Cast/MovieCastPoster.tsx
+++ b/frontend/src/Movie/Details/Credits/Cast/MovieCastPoster.tsx
@@ -40,22 +40,24 @@ function MovieCastPoster({
   } as React.CSSProperties;
 
   const contentStyle = { width: `${posterWidth}px` } as React.CSSProperties;
-
-  if (!performer?.foreignId) return null;
-
-  const link = `/performer/${performer.foreignId}`;
+  const name = performer.fullName ?? performer.name;
+  const isPerformer = !!performer?.foreignId;
+  const isPerfotmerLoaded = !!performer?.fullName;
+  const link = isPerformer ? `/performer/${performer.foreignId}` : '';
 
   return (
     <div className={styles.content} style={contentStyle}>
       <div className={styles.posterContainer}>
-        <div className={styles.controls}>
-          <MonitorToggleButton
-            className={styles.action}
-            monitored={performer.monitored}
-            size={20}
-            onPress={onTogglePerformerMonitored}
-          />
-        </div>
+        {isPerfotmerLoaded && (
+          <div className={styles.controls}>
+            <MonitorToggleButton
+              className={styles.action}
+              monitored={performer.monitored}
+              size={20}
+              onPress={onTogglePerformerMonitored}
+            />
+          </div>
+        )}
 
         <div style={elementStyle}>
           <Link className={styles.link} to={link}>
@@ -72,14 +74,14 @@ function MovieCastPoster({
             />
 
             {hasPosterError && (
-              <div className={styles.overlayTitle}>{performer.fullName}</div>
+              <div className={styles.overlayTitle}>{name}</div>
             )}
           </Link>
         </div>
       </div>
 
       <div className={classNames(styles.title, 'swiper-no-swiping')}>
-        {performer.fullName}
+        {name}
       </div>
       <div className={classNames(styles.title, 'swiper-no-swiping')}>
         {character}

--- a/frontend/src/Performer/Details/PerformerDetails.js
+++ b/frontend/src/Performer/Details/PerformerDetails.js
@@ -424,6 +424,7 @@ class PerformerDetails extends Component {
                             key={studio.foreignId}
                             performerId={id}
                             studioForeignId={studio.foreignId}
+                            title={studio.title}
                             isScenes={false}
                             isExpanded={expandedState[studio.foreignId]}
                             onExpandPress={this.onExpandPress}

--- a/frontend/src/Performer/Details/PerformerDetailsStudio.js
+++ b/frontend/src/Performer/Details/PerformerDetailsStudio.js
@@ -181,7 +181,8 @@ class PerformerDetailsStudio extends Component {
     } = getStudioStatistics(items);
 
     const sizeOnDisk = _.sumBy(items, 'sizeOnDisk');
-    const studioLink = `/studio/${foreignId}`;
+    const isStudio = foreignId != null;
+    const studioLink = isStudio ? `/studio/${foreignId}` : '';
 
     return (
       <div
@@ -349,7 +350,7 @@ class PerformerDetailsStudio extends Component {
 PerformerDetailsStudio.propTypes = {
   performerId: PropTypes.number.isRequired,
   title: PropTypes.string.isRequired,
-  foreignId: PropTypes.string.isRequired,
+  foreignId: PropTypes.string,
   monitored: PropTypes.bool.isRequired,
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   columns: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/frontend/src/Performer/Details/PerformerDetailsStudioConnector.js
+++ b/frontend/src/Performer/Details/PerformerDetailsStudioConnector.js
@@ -11,6 +11,7 @@ import { setPerformerScenesSort, setPerformerScenesTableOption } from 'Store/Act
 import { toggleStudioMonitored } from 'Store/Actions/studioActions';
 import createDimensionsSelector from 'Store/Selectors/createDimensionsSelector';
 import createPerformerSelector from 'Store/Selectors/createPerformerSelector';
+import translate from 'Utilities/String/translate';
 import PerformerDetailsStudio from './PerformerDetailsStudio';
 
 function getSortClause(sortKey, sortDirection, sortPredicates) {
@@ -84,6 +85,12 @@ function createMapStateToProps() {
       }
       // Sort once filtered
       items = sort(items, performerScenes);
+
+      if (!studio || !('title' in studio)) {
+        studio.id = 0;
+        studio.title = translate('NoStashDBStudioLink');
+        studio.monitored = false;
+      }
 
       return {
         ...studio,

--- a/frontend/src/Performer/Performer.ts
+++ b/frontend/src/Performer/Performer.ts
@@ -3,6 +3,7 @@ import { Image } from 'Movie/Movie';
 
 interface Performer extends ModelBase {
   foreignId: string;
+  name: string;
   fullName: string;
   monitored: boolean;
   rootFolderPath: string;

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1280,6 +1280,8 @@
   "None": "None",
   "NoPerformersExist": "No Performers Exist",
   "NoResultsFound": "No results found",
+  "NoStashDBStudioLink": "Studio not linked in StashDB",
+  "NoStashDBStudioLinkHelpText": "Studio with no link to the movie metadata provider in StashDB",
   "NoScenesExist": "No scenes found, to get started you'll want to add a new scene or import some existing ones.",
   "NoStudiosExist": "No studios found, to get started you'll want to add a new studio.",
   "NoTagsHaveBeenAddedYet": "No tags have been added yet",

--- a/src/NzbDrone.Core/Movies/RefreshMovieService.cs
+++ b/src/NzbDrone.Core/Movies/RefreshMovieService.cs
@@ -183,7 +183,7 @@ namespace NzbDrone.Core.Movies
                         p.Tags = movie.Tags;
                     });
 
-            _performerService.AddPerformers(performerInfo, true);
+            _performerService.AddPerformers(performerInfo.Where(p => !string.IsNullOrWhiteSpace(p.ForeignId)).ToList(), true);
 
             _movieMetadataService.Upsert(movieMetadata);
             _creditService.UpdateCredits(movieInfo.Credits, movieMetadata);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Load Whisparr before the movies, performers, studios are populated.

Show all cast if returned from skyhook, allows for a future skyhook change to return non-mapped performer information as cast.

Only Add Performers that have a StashId.

Fix the Performers page listing studios that are not linked in StashDB.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX