### PR TITLE
Fix: Correct the Refresh of Movies to only run when moviesMonitored is enabled.

### DIFF
--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -175,7 +175,7 @@ namespace NzbDrone.Core.Movies.Performers
                 _logger.Info("Synced performer {0} has {1} scenes adding {2} and added {3}", performer.Name, performerWork.Scenes.Count, scenesToAdd.Count(), scenesAdded);
             }
 
-            if (performer.Monitored)
+            if (performer.MoviesMonitored)
             {
                 var moviesAdded = 0;
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Make sure that movieMonitored is enabled when performers are refreshed.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX