### PR TITLE
Fix: Update default naming, monitoring, and search-on-add settings

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewPerformer/AddNewPerformerModalContent.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewPerformer/AddNewPerformerModalContent.js
@@ -37,7 +37,8 @@ class AddNewPerformerModalContent extends Component {
       images,
       isAdding,
       rootFolderPath,
-      monitor,
+      monitored,
+      moviesMonitored,
       qualityProfileId,
       searchForMovie,
       tags,
@@ -91,15 +92,26 @@ class AddNewPerformerModalContent extends Component {
                 </FormGroup>
 
                 <FormGroup>
-                  <FormLabel>
-                    {translate('Monitor')}
-                  </FormLabel>
+                  <FormLabel>{translate('MonitoredScene')}</FormLabel>
 
                   <FormInputGroup
-                    type={inputTypes.MONITOR_MOVIES_SELECT}
-                    name="monitor"
+                    type={inputTypes.CHECK}
+                    name="monitored"
+                    helpText={translate('MonitoredPerformerHelpText')}
+                    {...monitored}
                     onChange={onInputChange}
-                    {...monitor}
+                  />
+                </FormGroup>
+
+                <FormGroup>
+                  <FormLabel>{translate('MonitoredMovie')}</FormLabel>
+
+                  <FormInputGroup
+                    type={inputTypes.CHECK}
+                    name="moviesMonitored"
+                    helpText={translate('MonitoredPerformerHelpText')}
+                    {...moviesMonitored}
+                    onChange={onInputChange}
                   />
                 </FormGroup>
 
@@ -164,7 +176,8 @@ AddNewPerformerModalContent.propTypes = {
   isAdding: PropTypes.bool.isRequired,
   addError: PropTypes.object,
   rootFolderPath: PropTypes.object,
-  monitor: PropTypes.object.isRequired,
+  monitored: PropTypes.bool.isRequired,
+  moviesMonitored: PropTypes.bool.isRequired,
   qualityProfileId: PropTypes.object,
   searchForMovie: PropTypes.object.isRequired,
   tags: PropTypes.object.isRequired,

--- a/frontend/src/AddMovie/AddNewMovie/AddNewPerformer/AddNewPerformerModalContentConnector.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewPerformer/AddNewPerformerModalContentConnector.js
@@ -58,7 +58,8 @@ class AddNewPerformerModalContentConnector extends Component {
     const {
       foreignId,
       rootFolderPath,
-      monitor,
+      monitored,
+      moviesMonitored,
       qualityProfileId,
       searchForMovie,
       tags
@@ -67,7 +68,8 @@ class AddNewPerformerModalContentConnector extends Component {
     this.props.addPerformer({
       foreignId,
       rootFolderPath: rootFolderPath.value,
-      monitor: monitor.value,
+      monitored: monitored.value,
+      moviesMonitored: moviesMonitored.value,
       qualityProfileId: qualityProfileId.value,
       searchForMovie: searchForMovie.value,
       tags: tags.value
@@ -91,7 +93,8 @@ class AddNewPerformerModalContentConnector extends Component {
 AddNewPerformerModalContentConnector.propTypes = {
   foreignId: PropTypes.string.isRequired,
   rootFolderPath: PropTypes.object,
-  monitor: PropTypes.object.isRequired,
+  monitored: PropTypes.bool.isRequired,
+  moviesMonitored: PropTypes.bool.isRequired,
   qualityProfileId: PropTypes.object,
   searchForMovie: PropTypes.object.isRequired,
   tags: PropTypes.object.isRequired,

--- a/frontend/src/AddMovie/AddNewMovie/AddNewStudio/AddNewStudioModalContent.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewStudio/AddNewStudioModalContent.js
@@ -37,7 +37,8 @@ class AddNewStudioModalContent extends Component {
       images,
       isAdding,
       rootFolderPath,
-      monitor,
+      monitored,
+      moviesMonitored,
       qualityProfileId,
       searchForMovie,
       tags,
@@ -91,15 +92,26 @@ class AddNewStudioModalContent extends Component {
                 </FormGroup>
 
                 <FormGroup>
-                  <FormLabel>
-                    {translate('Monitor')}
-                  </FormLabel>
+                  <FormLabel>{translate('MonitoredScene')}</FormLabel>
 
                   <FormInputGroup
-                    type={inputTypes.MONITOR_MOVIES_SELECT}
-                    name="monitor"
+                    type={inputTypes.CHECK}
+                    name="monitored"
+                    helpText={translate('MonitoredPerformerHelpText')}
+                    {...monitored}
                     onChange={onInputChange}
-                    {...monitor}
+                  />
+                </FormGroup>
+
+                <FormGroup>
+                  <FormLabel>{translate('MonitoredMovie')}</FormLabel>
+
+                  <FormInputGroup
+                    type={inputTypes.CHECK}
+                    name="moviesMonitored"
+                    helpText={translate('MonitoredPerformerHelpText')}
+                    {...moviesMonitored}
+                    onChange={onInputChange}
                   />
                 </FormGroup>
 
@@ -164,7 +176,8 @@ AddNewStudioModalContent.propTypes = {
   isAdding: PropTypes.bool.isRequired,
   addError: PropTypes.object,
   rootFolderPath: PropTypes.object,
-  monitor: PropTypes.object.isRequired,
+  monitored: PropTypes.bool.isRequired,
+  moviesMonitored: PropTypes.bool.isRequired,
   qualityProfileId: PropTypes.object,
   searchForMovie: PropTypes.object.isRequired,
   tags: PropTypes.object.isRequired,

--- a/frontend/src/AddMovie/AddNewMovie/AddNewStudio/AddNewStudioModalContentConnector.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewStudio/AddNewStudioModalContentConnector.js
@@ -58,7 +58,8 @@ class AddNewStudioModalContentConnector extends Component {
     const {
       foreignId,
       rootFolderPath,
-      monitor,
+      monitored,
+      moviesMonitored,
       qualityProfileId,
       searchForMovie,
       tags
@@ -67,7 +68,8 @@ class AddNewStudioModalContentConnector extends Component {
     this.props.addStudio({
       foreignId,
       rootFolderPath: rootFolderPath.value,
-      monitor: monitor.value,
+      monitored: monitored.value,
+      moviesMonitored: moviesMonitored.value,
       qualityProfileId: qualityProfileId.value,
       searchForMovie: searchForMovie.value,
       tags: tags.value
@@ -91,7 +93,8 @@ class AddNewStudioModalContentConnector extends Component {
 AddNewStudioModalContentConnector.propTypes = {
   foreignId: PropTypes.string.isRequired,
   rootFolderPath: PropTypes.object,
-  monitor: PropTypes.object.isRequired,
+  monitored: PropTypes.bool.isRequired,
+  moviesMonitored: PropTypes.bool.isRequired,
   qualityProfileId: PropTypes.object,
   searchForMovie: PropTypes.object.isRequired,
   tags: PropTypes.object.isRequired,

--- a/frontend/src/Components/MonitorToggleButton.js
+++ b/frontend/src/Components/MonitorToggleButton.js
@@ -74,7 +74,8 @@ class MonitorToggleButton extends Component {
       default:
         monitorType = undefined;
     }
-    const monitoredValue = monitorType ? moviesMonitored : monitored;
+
+    const monitoredValue = monitorType === 'movie' ? moviesMonitored : monitored;
 
     let iconName = icons.UNMONITORED;
 

--- a/frontend/src/Store/Actions/addMovieActions.js
+++ b/frontend/src/Store/Actions/addMovieActions.js
@@ -32,22 +32,24 @@ export const defaultState = {
 
   movieDefaults: {
     rootFolderPath: '',
-    monitor: 'movieOnly',
+    monitored: 'sceneOnly',
     qualityProfileId: 0,
-    searchForMovie: true,
+    searchForMovie: false,
     tags: []
   },
   performerDefaults: {
     rootFolderPath: '',
-    monitor: 'movieOnly',
+    monitored: true,
+    moviesMonitored: false,
     qualityProfileId: 0,
     minimumAvailability: 'released',
-    searchForMovie: true,
+    searchForMovie: false,
     tags: []
   },
   studioDefaults: {
     rootFolderPath: '',
-    monitor: 'movieOnly',
+    monitored: true,
+    moviesMonitored: false,
     qualityProfileId: 0,
     searchForMovie: false,
     tags: []

--- a/frontend/src/Utilities/Performer/getNewPerformer.js
+++ b/frontend/src/Utilities/Performer/getNewPerformer.js
@@ -2,20 +2,22 @@
 function getNewPerformer(performer, payload) {
   const {
     rootFolderPath,
-    monitor,
+    monitored,
+    moviesMonitored,
     qualityProfileId,
     tags,
     searchForMovie = false
   } = payload;
 
   const addOptions = {
-    monitor,
+    monitored,
+    moviesMonitored,
     searchForMovie
   };
 
   performer.addOptions = addOptions;
-  performer.monitored = monitor === 'movieAndScene' || monitor === 'sceneOnly';
-  performer.movieMonitored = monitor === 'movieAndScene' || monitor === 'movieOnly';
+  performer.monitored = monitored;
+  performer.moviesMonitored = moviesMonitored;
   performer.qualityProfileId = qualityProfileId;
   performer.rootFolderPath = rootFolderPath;
   performer.tags = tags;

--- a/frontend/src/Utilities/Studio/getNewStudio.js
+++ b/frontend/src/Utilities/Studio/getNewStudio.js
@@ -2,20 +2,22 @@
 function getNewStudio(performer, payload) {
   const {
     rootFolderPath,
-    monitor,
+    monitored,
+    moviesMonitored,
     qualityProfileId,
     tags,
     searchForMovie = false
   } = payload;
 
   const addOptions = {
-    monitor,
+    monitored,
+    moviesMonitored,
     searchForMovie
   };
 
   performer.addOptions = addOptions;
-  performer.monitored = monitor === 'movieAndScene' || monitor === 'sceneOnly';
-  performer.movieMonitored = monitor === 'movieAndScene' || monitor === 'movieOnly';
+  performer.monitored = monitored;
+  performer.moviesMonitored = moviesMonitored;
   performer.qualityProfileId = qualityProfileId;
   performer.rootFolderPath = rootFolderPath;
   performer.tags = tags;

--- a/src/NzbDrone.Core/Organizer/NamingConfig.cs
+++ b/src/NzbDrone.Core/Organizer/NamingConfig.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Core.Organizer
             RenameScenes = false,
             ReplaceIllegalCharacters = true,
             ColonReplacementFormat = ColonReplacementFormat.Smart,
-            MovieFolderFormat = OsInfo.IsWindows ? "movies\\{Movie Title} {(Release Year)}" :  "movies/{Movie Title} {(Release Year)}",
+            MovieFolderFormat = OsInfo.IsWindows ? "movies\\{Studio CleanNetwork}\\{Studio CleanTitle}\\{Movie Title} {(Release Year)}" : "movies/{Studio CleanNetwork}/{Studio CleanTitle}/{Movie Title} {(Release Year)}",
             SceneFolderFormat = OsInfo.IsWindows ? "scenes\\{Studio CleanNetwork}\\{Studio CleanTitle}\\{Release Date} - {Scene CleanTitle} {[StashId]}" : "scenes/{Studio CleanNetwork}/{Studio CleanTitle}/{Release Date} - {Scene CleanTitle} {[StashId]}",
             SceneImportFolderFormat = OsInfo.IsWindows ? "import\\" : "import/",
             StandardMovieFormat = "{Movie Title} {(Release Year)} {[Quality Title]}",


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Update the default naming for Movie Folders to match Scene Structure

Default Monitoring of Scenes Only, as Movies Only is now movies.

Turn off the search on Add, as it always causes an issue

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX