### PR TITLE
Fix: Unable to add performer or studio from search

### DIFF
--- a/src/Whisparr.Api.V3/Movies/MovieEditorController.cs
+++ b/src/Whisparr.Api.V3/Movies/MovieEditorController.cs
@@ -39,6 +39,7 @@ namespace Whisparr.Api.V3.Movies
         }
 
         [HttpPut]
+        [Consumes("application/json")]
         public IActionResult SaveAll([FromBody] MovieEditorResource resource)
         {
             var moviesToUpdate = _movieService.GetMovies(resource.MovieIds);

--- a/src/Whisparr.Api.V3/Performers/PerformerController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerController.cs
@@ -117,7 +117,9 @@ namespace Whisparr.Api.V3.Performers
         }
 
         [RestPostById]
-        public ActionResult<PerformerResource> AddPerformer(PerformerResource performerResource)
+        [Consumes("application/json")]
+        [Produces("application/json")]
+        public ActionResult<PerformerResource> AddPerformer([FromBody] PerformerResource performerResource)
         {
             var performer = _addPerformerService.AddPerformer(performerResource.ToModel());
 

--- a/src/Whisparr.Api.V3/Performers/PerformerEditorController.cs
+++ b/src/Whisparr.Api.V3/Performers/PerformerEditorController.cs
@@ -23,6 +23,7 @@ namespace Whisparr.Api.V3.Performers
         }
 
         [HttpPut]
+        [Consumes("application/json")]
         public IActionResult SaveAll([FromBody] PerformerEditorResource resource)
         {
             var performersToUpdate = _performerService.GetPerformers(resource.PerformerIds);

--- a/src/Whisparr.Api.V3/Profiles/Release/ReleaseProfileController.cs
+++ b/src/Whisparr.Api.V3/Profiles/Release/ReleaseProfileController.cs
@@ -47,6 +47,7 @@ namespace Whisparr.Api.V3.Profiles.Release
         }
 
         [RestPostById]
+        [Consumes("application/json")]
         public ActionResult<ReleaseProfileResource> Create([FromBody] ReleaseProfileResource resource)
         {
             var model = resource.ToModel();
@@ -61,6 +62,7 @@ namespace Whisparr.Api.V3.Profiles.Release
         }
 
         [RestPutById]
+        [Consumes("application/json")]
         public ActionResult<ReleaseProfileResource> Update([FromBody] ReleaseProfileResource resource)
         {
             var model = resource.ToModel();

--- a/src/Whisparr.Api.V3/Studios/StudioController.cs
+++ b/src/Whisparr.Api.V3/Studios/StudioController.cs
@@ -113,7 +113,9 @@ namespace Whisparr.Api.V3.Studios
         }
 
         [RestPostById]
-        public ActionResult<StudioResource> AddStudio(StudioResource studioResource)
+        [Consumes("application/json")]
+        [Produces("application/json")]
+        public ActionResult<StudioResource> AddStudio([FromBody] StudioResource studioResource)
         {
             var studio = _addStudioService.AddStudio(studioResource.ToModel());
 


### PR DESCRIPTION
.NET 8 is more strict with defining backend API handlers, and these two methods were missing some decorations for `Produces` & `Consumes `as well as `FromBody`.

#### Database Migration
NO

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX