### PR TITLE
New: AlternateTitle and More Movie parsing

### DIFF
--- a/frontend/src/AddMovie/AddNewMovie/AddNewMovie/AddNewMovieSearchResult.js
+++ b/frontend/src/AddMovie/AddNewMovie/AddNewMovie/AddNewMovieSearchResult.js
@@ -105,6 +105,7 @@ class AddNewMovieSearchResult extends Component {
       itemType,
       releaseDate,
       overview,
+      website,
       ratings,
       folder,
       images,
@@ -134,7 +135,7 @@ class AddNewMovieSearchResult extends Component {
     const hasMovieFile = !!movieFile || sizeOnDisk > 0;
 
     const linkProps = isExistingMovie ? { to: `/movie/${titleSlug}` } : { onPress: this.onPress };
-    const providerProps = itemType === 'movie' ? { tmdbId, tpdbId } : { stashId: foreignId };
+    const providerProps = itemType === 'movie' ? { tmdbId, tpdbId, website } : { stashId: foreignId, website };
 
     let ImageItem = MoviePoster;
     let posterWidth = 167;
@@ -398,6 +399,7 @@ AddNewMovieSearchResult.propTypes = {
   releaseDate: PropTypes.string,
   itemType: PropTypes.string.isRequired,
   overview: PropTypes.string,
+  website: PropTypes.string,
   ratings: PropTypes.object.isRequired,
   folder: PropTypes.string.isRequired,
   images: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/frontend/src/Movie/Details/MovieDetails.tsx
+++ b/frontend/src/Movie/Details/MovieDetails.tsx
@@ -89,6 +89,7 @@ interface Props {
   isAvailable: boolean;
   releaseDate?: string;
   overview: string;
+  website: string;
   images: MovieImageType[];
   alternateTitles: string[];
   tags: number[];
@@ -246,6 +247,7 @@ class MovieDetails extends Component<Props, State> {
       credits,
       genres,
       overview,
+      website,
       status,
       studio,
       isAvailable,
@@ -449,6 +451,7 @@ class MovieDetails extends Component<Props, State> {
                             tmdbId={tmdbId}
                             tpdbId={tpdbId}
                             stashId={stashId ?? undefined}
+                            website={website}
                           />
                         }
                         position={tooltipPositions.BOTTOM}

--- a/frontend/src/Movie/Details/MovieDetailsLinks.tsx
+++ b/frontend/src/Movie/Details/MovieDetailsLinks.tsx
@@ -9,13 +9,26 @@ interface MovieDetailsLinksProps {
   tmdbId?: number;
   tpdbId?: string;
   stashId?: string;
+  website?: string;
 }
 
 function MovieDetailsLinks(props: MovieDetailsLinksProps) {
-  const { tmdbId, tpdbId, stashId } = props;
+  const { tmdbId, tpdbId, stashId, website } = props;
 
   return (
     <div className={styles.links}>
+      {!!website && (
+        <Link className={styles.link} to={website}>
+          <Label
+            className={styles.linkLabel}
+            kind={kinds.INFO}
+            size={sizes.LARGE}
+          >
+            {translate('Homepage')}
+          </Label>
+        </Link>
+      )}
+
       {!!tmdbId && (
         <Link
           className={styles.link}

--- a/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
+++ b/frontend/src/Movie/Index/Overview/MovieIndexOverview.tsx
@@ -73,6 +73,7 @@ function MovieIndexOverview(props: MovieIndexOverviewProps) {
     status,
     path,
     overview,
+    website,
     statistics = {} as Statistics,
     images,
     tags,
@@ -189,7 +190,13 @@ function MovieIndexOverview(props: MovieIndexOverviewProps) {
                 <Popover
                   anchor={<Icon name={icons.EXTERNAL_LINK} size={12} />}
                   title={translate('Links')}
-                  body={<MovieDetailsLinks tmdbId={tmdbId} tpdbId={tpdbId} />}
+                  body={
+                    <MovieDetailsLinks
+                      website={website}
+                      tmdbId={tmdbId}
+                      tpdbId={tpdbId}
+                    />
+                  }
                 />
               </span>
 

--- a/frontend/src/Movie/Index/Posters/MovieIndexPoster.tsx
+++ b/frontend/src/Movie/Index/Posters/MovieIndexPoster.tsx
@@ -69,6 +69,7 @@ function MovieIndexPoster(props: MovieIndexPosterProps) {
     foreignId,
     tmdbId,
     tpdbId,
+    website,
     hasFile,
     isAvailable,
     studioTitle,
@@ -196,7 +197,14 @@ function MovieIndexPoster(props: MovieIndexPosterProps) {
             <Popover
               anchor={<Icon name={icons.EXTERNAL_LINK} size={12} />}
               title={translate('Links')}
-              body={<MovieDetailsLinks tmdbId={tmdbId} tpdbId={tpdbId} />}
+              body={
+                <MovieDetailsLinks
+                  stashId={foreignId}
+                  tmdbId={tmdbId}
+                  tpdbId={tpdbId}
+                  website={website}
+                />
+              }
             />
           </span>
         </Label>

--- a/frontend/src/Movie/Index/Table/MovieIndexRow.tsx
+++ b/frontend/src/Movie/Index/Table/MovieIndexRow.tsx
@@ -51,6 +51,7 @@ function MovieIndexRow(props: MovieIndexRowProps) {
     monitored,
     foreignId,
     title,
+    website,
     studioTitle,
     status,
     originalLanguage,
@@ -315,7 +316,12 @@ function MovieIndexRow(props: MovieIndexRowProps) {
                 <Tooltip
                   anchor={<Icon name={icons.EXTERNAL_LINK} size={12} />}
                   tooltip={
-                    <MovieDetailsLinks tmdbId={tmdbId} tpdbId={tpdbId} />
+                    <MovieDetailsLinks
+                      stashId={foreignId}
+                      tmdbId={tmdbId}
+                      tpdbId={tpdbId}
+                      website={website}
+                    />
                   }
                   canFlip={true}
                   kind={kinds.INVERSE}

--- a/frontend/src/Movie/Movie.ts
+++ b/frontend/src/Movie/Movie.ts
@@ -53,6 +53,7 @@ interface Movie extends ModelBase {
   sortTitle: string;
   cleanTitle: string;
   overview: string;
+  website: string;
   monitored: boolean;
   status: MovieStatus;
   title: string;

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -65,6 +65,13 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("40.Years.Old.Temptations.Of.A.Married.Women.XXX.2017.DVDRIP.x264-group", "40 Years Old Temptations Of A Married Women")]
         [TestCase("40.Years.Old.Temptations.Of.A.Married.Women.XXX.DVDRIP.x264-group", "40 Years Old Temptations Of A Married Women")]
         [TestCase("The.Good.German.2006.720p.BluRay.x264-RlsGrp", "The Good German", Description = "Hardcoded to exclude from German regex")]
+        [TestCase("40.Years.Old.Temptations.Of.A.Married.Women.XXX.2017.DVDRIP.x264-group", "40 Years Old Temptations Of A Married Women")]
+        [TestCase("40.Years.Old.Temptations.Of.A.Married.Women.XXX.DVDRIP.x264-group", "40 Years Old Temptations Of A Married Women")]
+        [TestCase("Roccos.Abbondanza.7.XXX.DVDRip.x264-HORNDOGS", "Roccos Abbondanza 7")]
+        [TestCase("Oil Explosion 3 (Elegant Angel) XXX DVDRip NEW 2018", "Oil Explosion 3")]
+        [TestCase("Elegant Angel.2024.Oil Explosion 8.1080p-VERIFIED", "Oil Explosion 8")]
+        [TestCase("[EvilAngel] Strap Attack #16 [2012] [1080p]", "Strap Attack #16")]
+        [TestCase("Blacked.2024.Level Up Vol. 3.1080p-VERIFIED", "Level Up Vol  3")]
         public void should_parse_movie_title(string postTitle, string title)
         {
             Parser.Parser.ParseMovieTitle(postTitle).PrimaryMovieTitle.Should().Be(title);

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -138,13 +138,6 @@ namespace NzbDrone.Core.Test.ParserTests
                 "Kjeller chitai",
                 "Basement of Shame"
             })]
-        [TestCase("Whisparr.Under.Water.(aka.Beneath.the.Code.Freeze).1997.DVDRip.x264.CG-Grzechsin.mkv",
-            new string[]
-            {
-                "Whisparr Under Water (aka Beneath the Code Freeze)",
-                "Whisparr Under Water",
-                "Beneath the Code Freeze"
-            })]
         [TestCase("Whisparr.prodavet. AKA.Whisparr.Shift.2005.DVDRip.x264-HANDJOB.mkv",
             new string[]
             {

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -65,6 +65,17 @@ namespace NzbDrone.Core.IndexerSearch
             if (movie.MovieMetadata.Value.ItemType == ItemType.Movie)
             {
                 var movieSearchSpec = Get<MovieSearchCriteria>(movie, userInvokedSearch, interactiveSearch);
+                var additionalTitles = new List<string>();
+
+                movieSearchSpec.SceneTitles.ForEach(title =>
+                {
+                    var alternateTitle = Parser.Parser.AlternateTitle(title);
+                    if (!alternateTitle.Equals(title) && !movieSearchSpec.SceneTitles.Contains(alternateTitle) && !additionalTitles.Contains(alternateTitle))
+                    {
+                        additionalTitles.Add(alternateTitle);
+                    }
+                });
+                movieSearchSpec.SceneTitles.AddRange(additionalTitles);
 
                 // For movies, add search with year
                 if (movie.Year > 1900)

--- a/src/NzbDrone.Core/Movies/MovieService.cs
+++ b/src/NzbDrone.Core/Movies/MovieService.cs
@@ -177,6 +177,7 @@ namespace NzbDrone.Core.Movies
             foreach (var title in titles)
             {
                 var cleanTitle = title.CleanMovieTitle().ToLowerInvariant();
+                var alternateTitle = title.AlternateTitle().ToLowerInvariant();
                 var romanTitle = cleanTitle;
                 var arabicTitle = cleanTitle;
 
@@ -192,7 +193,7 @@ namespace NzbDrone.Core.Movies
                 romanTitle = romanTitle.ToLowerInvariant();
 
                 otherTitles.AddRange(new List<string> { arabicTitle, romanTitle });
-                lookupTitles.AddRange(new List<string> { cleanTitle, arabicTitle, romanTitle });
+                lookupTitles.AddRange(new List<string> { cleanTitle, arabicTitle, romanTitle, alternateTitle });
             }
 
             return _movieRepository.FindByTitles(lookupTitles);


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Additional Parsing for some movie formats

Create an alternate title by removing any vol volume and removing the leading zero. Used when searching an indexer. may end up storing this as an alternateTitle as this functionality is not enabled in Whisparr.

The alternate title may be implemented on skyhook, so the data same be sourced from TMDB, or some additional calculations that cleans the titles. TPDB has a lot of crap data, duplicates etc.

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX