### PR TITLE
January-radarr-upstream-10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -964,19 +964,16 @@ stages:
           failTaskOnMissingResultsFile: true
         displayName: Publish Test Results
 
-  - stage: Release
-    displayName: Create Release
-    dependsOn:
-    - Integration
-    - Packages
-    - Installer
+  - stage: Tag_Commit
+    displayName: Tag
+    dependsOn: Integration
     condition: and(
       succeeded(),
       ne(variables['Build.Reason'],'PullRequest'),
       eq(variables['Build.SourceBranch'], 'refs/heads/eros')
       )
     jobs:
-    - job: GitHub_Release
+    - job: Tag_Commit
       pool:
         vmImage: ${{ variables.linuxImage }}
 
@@ -984,36 +981,12 @@ stages:
       - checkout: self
         persistCredentials: true
         fetchDepth: 0
-      - task: DownloadPipelineArtifact@2
-        displayName: Download All Packages
-        inputs:
-          artifactName: 'Packages'
-          targetPath: $(Build.ArtifactStagingDirectory)/packages
-      - task: DownloadPipelineArtifact@2
-        displayName: Download Windows Installer
-        inputs:
-          artifactName: 'WindowsInstaller'
-          targetPath: $(Build.ArtifactStagingDirectory)/installer
       - bash: |
-          # Generate release notes from commits since last tag
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$LAST_TAG" ]; then
-            RELEASE_NOTES=$(git log --pretty=format:"- %s" $LAST_TAG..HEAD)
-          else
-            RELEASE_NOTES=$(git log --pretty=format:"- %s" -10)
-          fi
-
-          # Create pre-release with all artifacts
-          gh release create v$(whisparrVersion) \
-            --title "Whisparr v$(whisparrVersion) (Pre-release)" \
-            --notes "$RELEASE_NOTES" \
-            --target $(Build.SourceVersion) \
-            --prerelease \
-            $(Build.ArtifactStagingDirectory)/packages/* \
-            $(Build.ArtifactStagingDirectory)/installer/*
-        displayName: Create GitHub Pre-Release
-        env:
-          GH_TOKEN: $(System.AccessToken)
+          git config user.name "Whisparr Pipelines"
+          git config user.email "ci@whisparr.com"
+          git tag v$(whisparrVersion)
+          git push origin v$(whisparrVersion)
+        displayName: Commit
 
   - stage: Automation
     displayName: Automation
@@ -1266,4 +1239,3 @@ stages:
             DISCORDCHANNELID: $(discordChannelId)
             DISCORDWEBHOOKKEY: $(discordWebhookKey)
             DISCORDTHREADID: 1191571521781649499
-

--- a/frontend/src/FirstRun/AuthenticationRequiredModalContent.tsx
+++ b/frontend/src/FirstRun/AuthenticationRequiredModalContent.tsx
@@ -54,7 +54,7 @@ export default function AuthenticationRequiredModalContent() {
     dispatch(fetchGeneralSettings());
 
     return () => {
-      dispatch(clearPendingChanges());
+      dispatch(clearPendingChanges({ section: \`settings.\${SECTION}\` }));
     };
   }, [dispatch]);
 

--- a/frontend/src/FirstRun/AuthenticationRequiredModalContent.tsx
+++ b/frontend/src/FirstRun/AuthenticationRequiredModalContent.tsx
@@ -54,7 +54,7 @@ export default function AuthenticationRequiredModalContent() {
     dispatch(fetchGeneralSettings());
 
     return () => {
-      dispatch(clearPendingChanges({ section: \`settings.\${SECTION}\` }));
+      dispatch(clearPendingChanges({ section: `settings.${SECTION}` }));
     };
   }, [dispatch]);
 

--- a/frontend/src/MovieFile/Editor/MovieFileEditorRow.js
+++ b/frontend/src/MovieFile/Editor/MovieFileEditorRow.js
@@ -161,7 +161,7 @@ class MovieFileEditorRow extends Component {
                 >
                   {indexerFlags ? (
                     <Popover
-                      anchor={<Icon name={icons.FLAG} kind={kinds.PRIMARY} />}
+                      anchor={<Icon name={icons.FLAG} />}
                       title={translate('IndexerFlags')}
                       body={<IndexerFlags indexerFlags={indexerFlags} />}
                       position={tooltipPositions.LEFT}

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -120,7 +120,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             // Aliases should be used if present, otherwise fallback to real name.
             Subject.BuildFileName(_scene, _movieFile)
-                .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Axel Chuck Maddy O Reilly Manuel Ferrara]");
+                .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Axel Chuck Maddy OReilly Manuel Ferrara]");
         }
 
         [Test]
@@ -140,7 +140,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             // Only female aliases, fallback to real name if alias is not present
             Subject.BuildFileName(_scene, _movieFile)
-                .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Maddy O Reilly Reagan Rissa]");
+                .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Maddy OReilly Reagan Rissa]");
         }
 
         [Test]
@@ -179,7 +179,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             // First 4 performers
             Subject.BuildFileName(_scene, _movieFile)
-                   .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Axel Haze Charles Dera Maddy O Reilly Manuel Ferrara]");
+                   .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Axel Haze Charles Dera Maddy OReilly Manuel Ferrara]");
         }
 
         [Test]
@@ -199,7 +199,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
 
             // First 4 female performers
             Subject.BuildFileName(_scene, _movieFile)
-                   .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Maddy O Reilly Reagan Foxx Rissa May]");
+                   .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Maddy OReilly Reagan Foxx Rissa May]");
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -58,7 +58,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie Name (2017) (Showtime) (1080p.BD.DD5.1.x265-TheSickle[TAoE])", "TheSickle")]
         public void should_parse_release_group(string title, string expected)
         {
-            Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
+            Parser.ReleaseGroupParser.ParseReleaseGroup(title).Should().Be(expected);
         }
 
         [TestCase("Movie Name (2020) [2160p x265 10bit S82 Joy]", "Joy")]
@@ -117,13 +117,13 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie Title (2024) (1080p BluRay x265 SDR DDP 5.1 English -BEN THE MEN", "BEN THE MEN")]
         public void should_parse_exception_release_group(string title, string expected)
         {
-            Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
+            Parser.ReleaseGroupParser.ParseReleaseGroup(title).Should().Be(expected);
         }
 
         [TestCase(@"C:\Test\Doctor.Series.2005.s01e01.internal.bdrip.x264-archivist.mkv", "archivist")]
         public void should_not_include_extension_in_release_group(string title, string expected)
         {
-            Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
+            Parser.ReleaseGroupParser.ParseReleaseGroup(title).Should().Be(expected);
         }
 
         [TestCase("Some.Movie.S02E04.720p.WEBRip.x264-SKGTV English", "SKGTV")]
@@ -132,7 +132,7 @@ namespace NzbDrone.Core.Test.ParserTests
 
         public void should_not_include_language_in_release_group(string title, string expected)
         {
-            Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
+            Parser.ReleaseGroupParser.ParseReleaseGroup(title).Should().Be(expected);
         }
 
         [TestCase("Some.Movie.2019.1080p.BDRip.X264.AC3-EVO-RP", "EVO")]
@@ -162,13 +162,25 @@ namespace NzbDrone.Core.Test.ParserTests
 
         public void should_not_include_bad_suffix_in_release_group(string title, string expected)
         {
-            Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
+            Parser.ReleaseGroupParser.ParseReleaseGroup(title).Should().Be(expected);
         }
+
+        /*
+        [TestCase("[FFF] Invaders of the Movies!! - S01E11 - Someday, With Movies", "FFF")]
+        [TestCase("[HorribleSubs] Invaders of the Movies!! - S01E12 - Movies Going Well!!", "HorribleSubs")]
+        [TestCase("[Anime-Koi] Movies - S01E06 - Guys From Movies", "Anime-Koi")]
+        [TestCase("[Anime-Koi] Movies - S01E07 - A High-Grade Movies", "Anime-Koi")]
+        [TestCase("[Anime-Koi] Kami-sama Movies 2 - 01 [h264-720p][28D54E2C]", "Anime-Koi")]
+
+        public void should_parse_anime_release_groups(string title, string expected)
+        {
+            Parser.ReleaseGroupParser.ParseReleaseGroup(title).Should().Be(expected);
+        }*/
 
         [TestCase("Terrible.Anime.Title.2020.DBOX.480p.x264-iKaos [v3] [6AFFEF6B]")]
         public void should_not_parse_anime_hash_as_release_group(string title)
         {
-            Parser.Parser.ParseReleaseGroup(title).Should().BeNull();
+            Parser.ReleaseGroupParser.ParseReleaseGroup(title).Should().BeNull();
         }
 
         [TestCase("[Deeper] Key Mistress - Jessi Rae - 2025-12-18 - 1080p")]

--- a/src/NzbDrone.Core.Test/ParserTests/UrlFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/UrlFixture.cs
@@ -38,7 +38,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Movie Title Future 2023 DVDRip XviD RUNNER[www.allstate.net]", null)]
         public void should_not_parse_url_in_group(string title, string expected)
         {
-            Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
+            Parser.ReleaseGroupParser.ParseReleaseGroup(title).Should().Be(expected);
         }
     }
 }

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -227,9 +227,20 @@ namespace NzbDrone.Core.Configuration
                     return AuthenticationType.Forms;
                 }
 
-                return Enum.TryParse<AuthenticationType>(_authOptions.Method, out var enumValue)
+                var value = Enum.TryParse<AuthenticationType>(_authOptions.Method, out var enumValue)
                     ? enumValue
                     : GetValueEnum("AuthenticationMethod", AuthenticationType.None);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (value == AuthenticationType.Basic)
+#pragma warning restore CS0618 // Type or member is obsolete
+                {
+                    SetValue("AuthenticationMethod", AuthenticationType.Forms);
+
+                    return AuthenticationType.Forms;
+                }
+
+                return value;
             }
         }
 
@@ -402,6 +413,12 @@ namespace NzbDrone.Core.Configuration
             if (EnableSsl && (GetValue("SslCertHash", string.Empty, false).IsNotNullOrWhiteSpace() || SslCertPath.IsNullOrWhiteSpace()))
             {
                 SetValue("EnableSsl", false);
+            }
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (AuthenticationMethod == AuthenticationType.Basic)
+#pragma warning restore CS0618 // Type or member is obsolete
+            {
+                SetValue("AuthenticationMethod", AuthenticationType.Forms);
             }
         }
 

--- a/src/NzbDrone.Core/HealthCheck/Checks/NamingConfigCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/NamingConfigCheck.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.Localization;
 using NzbDrone.Core.Organizer;
@@ -20,25 +17,6 @@ namespace NzbDrone.Core.HealthCheck.Checks
 
         public override HealthCheck Check()
         {
-            var namingConfig = _namingConfigService.GetConfig();
-
-            if (namingConfig.MovieFolderFormat.IsNotNullOrWhiteSpace())
-            {
-                var match = FileNameValidation.DeprecatedMovieFolderTokensRegex.Matches(namingConfig.MovieFolderFormat);
-
-                if (match.Any())
-                {
-                    return new HealthCheck(
-                        GetType(),
-                        HealthCheckResult.Warning,
-                        _localizationService.GetLocalizedString(
-                            "NamingConfigMovieFolderFormatDeprecatedHealthCheckMessage", new Dictionary<string, object>
-                            {
-                                { "tokens", string.Join(", ", match.Select(c => c.Value).ToArray()) },
-                            }));
-                }
-            }
-
             return new HealthCheck(GetType());
         }
     }

--- a/src/NzbDrone.Core/MediaFiles/FileExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/FileExtensions.cs
@@ -1,11 +1,21 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace NzbDrone.Core.MediaFiles
 {
-    internal static class FileExtensions
+    public static class FileExtensions
     {
-        private static List<string> _archiveExtensions = new List<string>
+        private static readonly Regex FileExtensionRegex = new (@"\.[a-z0-9]{2,4}$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly HashSet<string> UsenetExtensions = new HashSet<string>()
+        {
+            ".par2",
+            ".nzb"
+        };
+
+        public static HashSet<string> ArchiveExtensions => new (StringComparer.OrdinalIgnoreCase)
         {
             ".7z",
             ".bz2",
@@ -20,8 +30,7 @@ namespace NzbDrone.Core.MediaFiles
             ".tgz",
             ".zip"
         };
-
-        private static List<string> _dangerousExtensions = new List<string>
+        public static HashSet<string> DangerousExtensions => new (StringComparer.OrdinalIgnoreCase)
         {
             ".arj",
             ".lnk",
@@ -31,8 +40,7 @@ namespace NzbDrone.Core.MediaFiles
             ".vbs",
             ".zipx"
         };
-
-        private static List<string> _executableExtensions = new List<string>
+        public static HashSet<string> ExecutableExtensions => new (StringComparer.OrdinalIgnoreCase)
         {
             ".bat",
             ".cmd",
@@ -40,8 +48,20 @@ namespace NzbDrone.Core.MediaFiles
             ".sh"
         };
 
-        public static HashSet<string> ArchiveExtensions => new HashSet<string>(_archiveExtensions, StringComparer.OrdinalIgnoreCase);
-        public static HashSet<string> DangerousExtensions => new HashSet<string>(_dangerousExtensions, StringComparer.OrdinalIgnoreCase);
-        public static HashSet<string> ExecutableExtensions => new HashSet<string>(_executableExtensions, StringComparer.OrdinalIgnoreCase);
+        public static string RemoveFileExtension(string title)
+        {
+            title = FileExtensionRegex.Replace(title, m =>
+            {
+                var extension = m.Value.ToLower();
+                if (MediaFileExtensions.Extensions.Contains(extension) || UsenetExtensions.Contains(extension))
+                {
+                    return string.Empty;
+                }
+
+                return m.Value;
+            });
+
+            return title;
+        }
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -293,7 +293,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
         private static string GetSceneNameMatch(string sceneName, params string[] tokens)
         {
-            sceneName = sceneName.IsNotNullOrWhiteSpace() ? Parser.Parser.RemoveFileExtension(sceneName) : string.Empty;
+            sceneName = sceneName.IsNotNullOrWhiteSpace() ? FileExtensions.RemoveFileExtension(sceneName) : string.Empty;
 
             foreach (var token in tokens)
             {

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/Manual/ManualImportService.cs
@@ -156,7 +156,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
 
             var downloadClientItem = GetTrackedDownload(downloadId)?.DownloadItem;
             var finalReleaseGroup = releaseGroup.IsNullOrWhiteSpace()
-                ? Parser.Parser.ParseReleaseGroup(path)
+                ? ReleaseGroupParser.ParseReleaseGroup(path)
                 : releaseGroup;
             var finalQuality = (quality?.Quality ?? Quality.Unknown) == Quality.Unknown ? QualityParser.ParseQuality(path) : quality;
             var finalLanguages =
@@ -316,7 +316,8 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
                     var fileMovieInfo = Parser.Parser.ParseMoviePath(file) ?? new ParsedMovieInfo();
                     var localMovie = new LocalMovie();
                     localMovie.Path = file;
-                    localMovie.ReleaseGroup = Parser.Parser.ParseReleaseGroup(file);
+                    localMovie.ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(file);
+                    localMovie.Quality = QualityParser.ParseQuality(file);
                     localMovie.Languages = LanguageParser.ParseLanguages(file);
                     localMovie.Size = _diskProvider.GetFileSize(file);
                     localMovie.FileMovieInfo = fileMovieInfo;
@@ -364,7 +365,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport.Manual
                 localMovie.Path = file;
                 localMovie.Quality = new QualityModel(Quality.Unknown);
                 localMovie.Languages = new List<Language> { Language.Unknown };
-                localMovie.ReleaseGroup = Parser.Parser.ParseReleaseGroup(file);
+                localMovie.ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(file);
                 localMovie.Size = _diskProvider.GetFileSize(file);
 
                 items.Add(MapItem(new ImportDecision(localMovie), rootFolder, null, null));

--- a/src/NzbDrone.Core/MediaFiles/MovieImport/SceneNameCalculator.cs
+++ b/src/NzbDrone.Core/MediaFiles/MovieImport/SceneNameCalculator.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.MediaFiles.MovieImport
 
             if (!otherVideoFiles && downloadClientInfo != null)
             {
-                return Parser.Parser.RemoveFileExtension(downloadClientInfo.ReleaseTitle);
+                return FileExtensions.RemoveFileExtension(downloadClientInfo.ReleaseTitle);
             }
 
             var fileName = Path.GetFileNameWithoutExtension(localMovie.Path.CleanFilePath());

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -224,7 +224,6 @@ namespace NzbDrone.Core.Organizer
 
             var pattern = itemType == ItemType.Movie ? namingConfig.MovieFolderFormat : namingConfig.SceneFolderFormat;
             var tokenHandlers = new Dictionary<string, Func<TokenMatch, string>>(FileNameBuilderTokenEqualityComparer.Instance);
-            var multipleTokens = TitleRegex.Matches(pattern).Count > 1;
 
             if (itemType == ItemType.Movie)
             {
@@ -239,20 +238,6 @@ namespace NzbDrone.Core.Organizer
             AddStudioTokens(tokenHandlers, movie);
             AddReleaseDateTokens(tokenHandlers, movie.Year);
             AddIdTokens(tokenHandlers, movie);
-
-            var movieFile = movie.MovieFile;
-
-            if (movie.MovieFile != null)
-            {
-                AddQualityTokens(tokenHandlers, movie, movieFile);
-                AddMediaInfoTokens(tokenHandlers, movieFile);
-                AddMovieFileTokens(tokenHandlers, movieFile, multipleTokens);
-                AddEditionTagsTokens(tokenHandlers, movieFile);
-            }
-            else
-            {
-                AddMovieFileTokens(tokenHandlers, new MovieFile { SceneName = $"{movie.Title} {movie.Year}", RelativePath = $"{movie.Title} {movie.Year}" }, multipleTokens);
-            }
 
             var splitPatterns = pattern.Split(new char[] { '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
             var components = new List<string>();

--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -50,6 +50,7 @@ namespace NzbDrone.Core.Organizer
         {
             ruleBuilder.SetValidator(new NotEmptyValidator(null));
             ruleBuilder.SetValidator(new IllegalCharactersValidator());
+            ruleBuilder.SetValidator(new IllegalMovieFolderTokensValidator());
 
             return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.MainFolderRegex)).WithMessage("Must start with a relative path inside root folder, ex. 'scenes/'");
         }
@@ -83,6 +84,30 @@ namespace NzbDrone.Core.Organizer
             }
 
             return FileNameBuilder.MovieTitleRegex.IsMatch(value);
+        }
+    }
+
+    public class IllegalMovieFolderTokensValidator : PropertyValidator
+    {
+        protected override string GetDefaultMessageTemplate() => "Must not contain deprecated tokens derived from file properties: {tokens}";
+
+        protected override bool IsValid(PropertyValidatorContext context)
+        {
+            if (context.PropertyValue is not string value)
+            {
+                return false;
+            }
+
+            var match = FileNameValidation.DeprecatedMovieFolderTokensRegex.Matches(value);
+
+            if (match.Any())
+            {
+                context.MessageFormatter.AppendArgument("tokens", string.Join(", ", match.Select(c => c.Value).ToArray()));
+
+                return false;
+            }
+
+            return true;
         }
     }
 

--- a/src/NzbDrone.Core/Organizer/FileNameValidation.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameValidation.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using FluentValidation;
 using FluentValidation.Validators;
 using NzbDrone.Common.Extensions;
@@ -9,14 +8,10 @@ namespace NzbDrone.Core.Organizer
 {
     public static class FileNameValidation
     {
-        public static readonly Regex DeprecatedMovieFolderTokensRegex = new (@"(\{[- ._\[\(]?(?:Original[- ._](?:Title|Filename)|Release[- ._]Group|Edition[- ._]Tags|Quality[- ._](?:Full|Title|Proper|Real)|MediaInfo[- ._](?:Video|VideoCodec|VideoBitDepth|Audio|AudioCodec|AudioChannels|AudioLanguages|AudioLanguagesAll|SubtitleLanguages|SubtitleLanguagesAll|3D|Simple|Full|VideoDynamicRange|VideoDynamicRangeType))[- ._\]\)]?\})",
-                                                                            RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
         public static IRuleBuilderOptions<T, string> ValidMovieFolderFormat<T>(this IRuleBuilder<T, string> ruleBuilder)
         {
             ruleBuilder.SetValidator(new NotEmptyValidator(null));
             ruleBuilder.SetValidator(new IllegalCharactersValidator());
-            ruleBuilder.SetValidator(new IllegalMovieFolderTokensValidator());
 
             return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.MovieTitleRegex)).WithMessage("Must contain movie title");
         }
@@ -41,7 +36,6 @@ namespace NzbDrone.Core.Organizer
         {
             ruleBuilder.SetValidator(new NotEmptyValidator(null));
             ruleBuilder.SetValidator(new IllegalCharactersValidator());
-            ruleBuilder.SetValidator(new IllegalMovieFolderTokensValidator());
 
             return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.SceneFolderRegex)).WithMessage("Must contain scene studio");
         }
@@ -50,7 +44,6 @@ namespace NzbDrone.Core.Organizer
         {
             ruleBuilder.SetValidator(new NotEmptyValidator(null));
             ruleBuilder.SetValidator(new IllegalCharactersValidator());
-            ruleBuilder.SetValidator(new IllegalMovieFolderTokensValidator());
 
             return ruleBuilder.SetValidator(new RegularExpressionValidator(FileNameBuilder.MainFolderRegex)).WithMessage("Must start with a relative path inside root folder, ex. 'scenes/'");
         }
@@ -84,54 +77,6 @@ namespace NzbDrone.Core.Organizer
             }
 
             return FileNameBuilder.MovieTitleRegex.IsMatch(value);
-        }
-    }
-
-    public class IllegalMovieFolderTokensValidator : PropertyValidator
-    {
-        protected override string GetDefaultMessageTemplate() => "Must not contain deprecated tokens derived from file properties: {tokens}";
-
-        protected override bool IsValid(PropertyValidatorContext context)
-        {
-            if (context.PropertyValue is not string value)
-            {
-                return false;
-            }
-
-            var match = FileNameValidation.DeprecatedMovieFolderTokensRegex.Matches(value);
-
-            if (match.Any())
-            {
-                context.MessageFormatter.AppendArgument("tokens", string.Join(", ", match.Select(c => c.Value).ToArray()));
-
-                return false;
-            }
-
-            return true;
-        }
-    }
-
-    public class IllegalMovieFolderTokensValidator : PropertyValidator
-    {
-        protected override string GetDefaultMessageTemplate() => "Must not contain deprecated tokens derived from file properties: {tokens}";
-
-        protected override bool IsValid(PropertyValidatorContext context)
-        {
-            if (context.PropertyValue is not string value)
-            {
-                return false;
-            }
-
-            var match = FileNameValidation.DeprecatedMovieFolderTokensRegex.Matches(value);
-
-            if (match.Any())
-            {
-                context.MessageFormatter.AppendArgument("tokens", string.Join(", ", match.Select(c => c.Value).ToArray()));
-
-                return false;
-            }
-
-            return true;
         }
     }
 

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Movies;
 using NzbDrone.Core.Parser.Model;
 
@@ -197,9 +198,6 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex NormalizeRegex = new Regex(@"((?:\b|_)(?<!^|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])([aà](?!$|[^a-zA-Z0-9_']\w[^a-zA-Z0-9_'])|an|the|and|or|of)(?!$)(?:\b|_))|\W|_",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex FileExtensionRegex = new Regex(@"\.[a-z0-9]{2,4}$",
-                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
         private static readonly Regex ReportImdbId = new Regex(@"(?<imdbid>tt\d{7,8})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex ReportTmdbId = new Regex(@"tmdb(id)?-(?<tmdbid>\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
@@ -215,48 +213,16 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex SimpleReleaseTitleRegex = new Regex(@"\s*(?:[<>?*|])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         // Valid TLDs http://data.iana.org/TLD/tlds-alpha-by-domain.txt
-        private static readonly RegexReplace WebsitePrefixRegex = new RegexReplace(@"^(?:(?:\[|\()\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?<!Naruto-Kun\.)(?:[a-z]{2,6}\.[a-z]{2,6}|xn--[a-z0-9-]{4,}|[a-z]{2,})\b(?:\s*(?:\]|\))|[ -]{2,})[ -]*",
-                                                                string.Empty,
-                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        private static readonly RegexReplace WebsitePostfixRegex = new RegexReplace(@"(?:\[\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?:xn--[a-z0-9-]{4,}|[a-z]{2,6})\b(?:\s*\])$",
-                                                        string.Empty,
-                                                        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        private static readonly RegexReplace CleanReleaseGroupRegex = new RegexReplace(@"(-(RP|1|NZBGeek|Obfuscated|Obfuscation|Scrambled|sample|Pre|postbot|xpost|Rakuv[a-z0-9]*|WhiteRev|BUYMORE|AsRequested|AlternativeToRequested|GEROV|Z0iDS3N|Chamele0n|4P|4Planet|AlteZachen|RePACKPOST))+$",
-                                                                string.Empty,
-                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        private static readonly RegexReplace CleanTorrentSuffixRegex = new RegexReplace(@"\[(?:ettv|rartv|rarbg|cttv|publichd)\]$",
-                                                                string.Empty,
-                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex CleanQualityBracketsRegex = new Regex(@"\[[a-z0-9 ._-]+\]$",
                                                                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|576p|720p|1080p|2160p)))(?<!(?:WEB-(DL|Rip)|Blu-Ray|480p|576p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|-ES|-EN|-CAT|-ENG|-JAP|-GER|-FRA|-FRE|-ITA|-HDRip|\d{1,2}-bit|[ ._]\d{4}-\d{2}|-\d{2}|tmdb(id)?-(?<tmdbid>\d+)|(?<imdbid>tt\d{7,8}))(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
-                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        private static readonly Regex InvalidReleaseGroupRegex = new Regex(@"^([se]\d+|[0-9a-f]{8})$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        private static readonly Regex AnimeReleaseGroupRegex = new Regex(@"^(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",
-                                                                RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
         private static readonly Regex YearInTitleRegex = new Regex(@"^(?<title>.+?)(?:\W|_.)?[\(\[]?(?<year>\d{4})[\]\)]?",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        // Handle Exception Release Groups that don't follow -RlsGrp; Manual List
-        // groups whose releases end with RlsGroup) or RlsGroup]
-        private static readonly Regex ExceptionReleaseGroupRegex = new Regex(@"(?<=[._ \[])(?<releasegroup>(Silence|afm72|Panda|Ghost|MONOLITH|Tigole|Joy|ImE|UTR|t3nzin|Anime Time|Project Angel|Hakata Ramen|HONE|Vyndros|SEV|Garshasp|Kappa|Natty|RCVR|SAMPA|YOGI|r00t|EDGE2020|RZeroX|FreetheFish|Anna|Bandi|Qman|theincognito|HDO|DusIctv|DHD|CtrlHD|-ZR-|ADC|XZVN|RH|Kametsu|Garshasp)(?=\]|\)))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        // Handle Exception Release Groups that don't follow -RlsGrp; Manual List
-        // name only...BE VERY CAREFUL WITH THIS, HIGH CHANCE OF FALSE POSITIVES
-        private static readonly Regex ExceptionReleaseGroupRegexExact = new Regex(@"\b(?<releasegroup>KRaLiMaRKo|E\.N\.D|D\-Z0N3|Koten_Gars|BluDragon|ZØNEHD|Tigole|HQMUX|VARYG|YIFY|YTS(.(MX|LT|AG))?|TMd|Eml HDTeam|LMain|DarQ|BEN THE MEN)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-        private static readonly Regex WordDelimiterRegex = new Regex(@"(\s|\.|,|_|-|=|’|'|\|)+", RegexOptions.Compiled);
         private static readonly Regex SpecialCharRegex = new Regex(@"(\&|\:|\\|\/)+", RegexOptions.Compiled);
         private static readonly Regex PunctuationRegex = new Regex(@"[^\w\s]", RegexOptions.Compiled);
-        private static readonly Regex CommonWordRegex = new Regex(@"\b(a|an|the|and|or|of)\b\s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex ArticleWordRegex = new Regex(@"^(a|an|the)\s", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex SpecialEpisodeWordRegex = new Regex(@"\b(part|special|edition|christmas)\b\s?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex DuplicateSpacesRegex = new Regex(@"\s{2,}", RegexOptions.Compiled);
         private static readonly Regex NamerDuplicateRegex = new Regex(@"_\d$", RegexOptions.Compiled);
@@ -309,7 +275,7 @@ namespace NzbDrone.Core.Parser
 
                 if (ReversedTitleRegex.IsMatch(title))
                 {
-                    var titleWithoutExtension = RemoveFileExtension(title).ToCharArray();
+                    var titleWithoutExtension = FileExtensions.RemoveFileExtension(title).ToCharArray();
                     Array.Reverse(titleWithoutExtension);
 
                     title = $"{titleWithoutExtension}{title.Substring(titleWithoutExtension.Length)}";
@@ -317,14 +283,14 @@ namespace NzbDrone.Core.Parser
                     Logger.Debug("Reversed name detected. Converted to '{0}'", title);
                 }
 
-                var releaseTitle = RemoveFileExtension(title);
+                var releaseTitle = FileExtensions.RemoveFileExtension(title);
 
                 // Trim dashes from end
                 releaseTitle = releaseTitle.Trim('-', '_');
 
                 releaseTitle = releaseTitle.Replace("【", "[").Replace("】", "]");
 
-                foreach (var replace in PreSubstitutionRegex)
+                foreach (var replace in ParserCommon.PreSubstitutionRegex)
                 {
                     if (replace.TryReplace(ref releaseTitle))
                     {
@@ -336,10 +302,10 @@ namespace NzbDrone.Core.Parser
                 var simpleTitle = SimpleTitleRegex.Replace(releaseTitle);
 
                 // TODO: Quick fix stripping [url] - prefixes.
-                simpleTitle = WebsitePrefixRegex.Replace(simpleTitle);
-                simpleTitle = WebsitePostfixRegex.Replace(simpleTitle);
+                simpleTitle = ParserCommon.WebsitePrefixRegex.Replace(simpleTitle);
+                simpleTitle = ParserCommon.WebsitePostfixRegex.Replace(simpleTitle);
 
-                simpleTitle = CleanTorrentSuffixRegex.Replace(simpleTitle);
+                simpleTitle = ParserCommon.CleanTorrentSuffixRegex.Replace(simpleTitle);
 
                 simpleTitle = CleanQualityBracketsRegex.Replace(simpleTitle, m =>
                 {
@@ -393,7 +359,7 @@ namespace NzbDrone.Core.Parser
                                     }
                                 }
 
-                                result.ReleaseGroup = ParseReleaseGroup(simpleReleaseTitle);
+                                result.ReleaseGroup = ReleaseGroupParser.ParseReleaseGroup(simpleReleaseTitle);
 
                                 var subGroup = GetSubGroup(match);
                                 if (!subGroup.IsNullOrWhiteSpace())
@@ -653,9 +619,8 @@ namespace NzbDrone.Core.Parser
                 return title;
             }
 
-            title = WordDelimiterRegex.Replace(title, " ");
             title = PunctuationRegex.Replace(title, string.Empty);
-            title = CommonWordRegex.Replace(title, string.Empty);
+            title = ArticleWordRegex.Replace(title, string.Empty);
             title = DuplicateSpacesRegex.Replace(title, " ");
             title = SpecialCharRegex.Replace(title, string.Empty);
 
@@ -711,9 +676,8 @@ namespace NzbDrone.Core.Parser
                 return string.Empty;
             }
 
-            title = WordDelimiterRegex.Replace(title, " ");
             title = PunctuationRegex.Replace(title, string.Empty);
-            title = CommonWordRegex.Replace(title, string.Empty);
+            title = ArticleWordRegex.Replace(title, string.Empty);
             title = DuplicateSpacesRegex.Replace(title, " ");
             title = SpecialCharRegex.Replace(title, string.Empty);
 
@@ -777,80 +741,6 @@ namespace NzbDrone.Core.Parser
             }
 
             return null;
-        }
-
-        public static string ParseReleaseGroup(string title)
-        {
-            if (title.IsNullOrWhiteSpace())
-            {
-                return string.Empty;
-            }
-
-            title = title.Trim();
-            title = RemoveFileExtension(title);
-            title = WebsitePrefixRegex.Replace(title);
-            title = CleanTorrentSuffixRegex.Replace(title);
-
-            // Removed AnimeReleaseGroupRegex check as it incorrectly matches studio names in brackets
-            // Studios appear at the beginning in brackets, release groups appear at the end
-
-            title = CleanReleaseGroupRegex.Replace(title);
-
-            var exceptionReleaseGroupRegex = ExceptionReleaseGroupRegex.Matches(title);
-
-            if (exceptionReleaseGroupRegex.Count != 0)
-            {
-                return exceptionReleaseGroupRegex.OfType<Match>().Last().Groups["releasegroup"].Value;
-            }
-
-            var exceptionExactMatch = ExceptionReleaseGroupRegexExact.Matches(title);
-
-            if (exceptionExactMatch.Count != 0)
-            {
-                return exceptionExactMatch.OfType<Match>().Last().Groups["releasegroup"].Value;
-            }
-
-            var matches = ReleaseGroupRegex.Matches(title);
-
-            if (matches.Count != 0)
-            {
-                var group = matches.OfType<Match>().Last().Groups["releasegroup"].Value;
-
-                if (int.TryParse(group, out _))
-                {
-                    return null;
-                }
-
-                if (InvalidReleaseGroupRegex.IsMatch(group))
-                {
-                    return null;
-                }
-
-                return group;
-            }
-
-            return null;
-        }
-
-        public static string RemoveFileExtension(string title)
-        {
-            if (title.IsNullOrWhiteSpace())
-            {
-                return string.Empty;
-            }
-
-            title = FileExtensionRegex.Replace(title, m =>
-            {
-                var extension = m.Value.ToLower();
-                if (MediaFiles.MediaFileExtensions.Extensions.Contains(extension) || new[] { ".par2", ".nzb" }.Contains(extension))
-                {
-                    return string.Empty;
-                }
-
-                return m.Value;
-            });
-
-            return title;
         }
 
         private static ParsedMovieInfo ParseMatchCollection(MatchCollection matchCollection, string releaseTitle)
@@ -1088,7 +978,7 @@ namespace NzbDrone.Core.Parser
                 return false;
             }
 
-            var titleWithoutExtension = RemoveFileExtension(title);
+            var titleWithoutExtension = FileExtensions.RemoveFileExtension(title);
 
             if (RejectHashedReleasesRegex.Any(v => v.IsMatch(titleWithoutExtension)))
             {

--- a/src/NzbDrone.Core/Parser/ParserCommon.cs
+++ b/src/NzbDrone.Core/Parser/ParserCommon.cs
@@ -1,0 +1,23 @@
+using System.Text.RegularExpressions;
+
+namespace NzbDrone.Core.Parser;
+
+// These are functions shared between different parser functions
+// they are not intended to be used outside of them parsing.
+internal static class ParserCommon
+{
+    internal static readonly RegexReplace[] PreSubstitutionRegex = System.Array.Empty<RegexReplace>();
+
+    // Valid TLDs http://data.iana.org/TLD/tlds-alpha-by-domain.txt
+    internal static readonly RegexReplace WebsitePrefixRegex = new (@"^(?:(?:\[|\()\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?<!Naruto-Kun\.)(?:[a-z]{2,6}\.[a-z]{2,6}|xn--[a-z0-9-]{4,}|[a-z]{2,})\b(?:\s*(?:\]|\))|[ -]{2,})[ -]*",
+        string.Empty,
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    internal static readonly RegexReplace WebsitePostfixRegex = new (@"(?:\[\s*)?(?:www\.)?[-a-z0-9-]{1,256}\.(?:xn--[a-z0-9-]{4,}|[a-z]{2,6})\b(?:\s*\])$",
+        string.Empty,
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    internal static readonly RegexReplace CleanTorrentSuffixRegex = new (@"\[(?:ettv|rartv|rarbg|cttv|publichd)\]$",
+        string.Empty,
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+}

--- a/src/NzbDrone.Core/Parser/ReleaseGroupParser.cs
+++ b/src/NzbDrone.Core/Parser/ReleaseGroupParser.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using NzbDrone.Core.MediaFiles;
+
+namespace NzbDrone.Core.Parser;
+
+public static class ReleaseGroupParser
+{
+    private static readonly Regex ReleaseGroupRegex = new (@"-(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|576p|720p|1080p|2160p)))(?<!(?:WEB-(DL|Rip)|Blu-Ray|480p|576p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|-ES|-EN|-CAT|-ENG|-JAP|-GER|-FRA|-FRE|-ITA|-HDRip|\d{1,2}-bit|[ ._]\d{4}-\d{2}|-\d{2}|tmdb(id)?-(?<tmdbid>\d+)|(?<imdbid>tt\d{7,8}))(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex InvalidReleaseGroupRegex = new (@"^([se]\d+|[0-9a-f]{8})$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /* Anime release groups are often in the format [SubGroup] at the start of the release title
+     * e.g. [HorribleSubs] My Hero Academia S03E05 720p.  Adult studios expect this format as well.
+     * Example: [Deeper] Nine (1080p).
+     * Disabling this for now as it causes too many false positives with other release types.
+    private static readonly Regex AnimeReleaseGroupRegex = new (@"^(?:\[(?<subgroup>(?!\s).+?(?<!\s))\](?:_|-|\s|\.)?)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    */
+
+    // Handle Exception Release Groups that don't follow -RlsGrp; Manual List
+    // name only...be very careful with this last; high chance of false positives
+    private static readonly Regex ExceptionReleaseGroupRegexExact = new (@"\b(?<releasegroup>KRaLiMaRKo|E\.N\.D|D\-Z0N3|Koten_Gars|BluDragon|ZØNEHD|Tigole|HQMUX|VARYG|YIFY|YTS(.(MX|LT|AG))?|TMd|Eml HDTeam|LMain|DarQ|BEN THE MEN)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // groups whose releases end with RlsGroup) or RlsGroup]
+    private static readonly Regex ExceptionReleaseGroupRegex = new (@"(?<=[._ \[])(?<releasegroup>(Silence|afm72|Panda|Ghost|MONOLITH|Tigole|Joy|ImE|UTR|t3nzin|Anime Time|Project Angel|Hakata Ramen|HONE|Vyndros|SEV|Garshasp|Kappa|Natty|RCVR|SAMPA|YOGI|r00t|EDGE2020|RZeroX|FreetheFish|Anna|Bandi|Qman|theincognito|HDO|DusIctv|DHD|CtrlHD|-ZR-|ADC|XZVN|RH|Kametsu)(?=\]|\)))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly RegexReplace CleanReleaseGroupRegex = new (@"(-(RP|1|NZBGeek|Obfuscated|Obfuscation|Scrambled|sample|Pre|postbot|xpost|Rakuv[a-z0-9]*|WhiteRev|BUYMORE|AsRequested|AlternativeToRequested|GEROV|Z0iDS3N|Chamele0n|4P|4Planet|AlteZachen|RePACKPOST))+$",
+        string.Empty,
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public static string ParseReleaseGroup(string title)
+    {
+        title = title.Trim();
+        title = FileExtensions.RemoveFileExtension(title);
+        foreach (var replace in ParserCommon.PreSubstitutionRegex)
+        {
+            if (replace.TryReplace(ref title))
+            {
+                break;
+            }
+        }
+
+        title = ParserCommon.WebsitePrefixRegex.Replace(title);
+        title = ParserCommon.CleanTorrentSuffixRegex.Replace(title);
+
+        /*
+        var animeMatch = AnimeReleaseGroupRegex.Match(title);
+
+        if (animeMatch.Success)
+        {
+            return animeMatch.Groups["subgroup"].Value;
+        }*/
+
+        title = CleanReleaseGroupRegex.Replace(title);
+
+        var exceptionReleaseGroupRegex = ExceptionReleaseGroupRegex.Matches(title);
+
+        if (exceptionReleaseGroupRegex.Count != 0)
+        {
+            return exceptionReleaseGroupRegex.OfType<Match>().Last().Groups["releasegroup"].Value;
+        }
+
+        var exceptionExactMatch = ExceptionReleaseGroupRegexExact.Matches(title);
+
+        if (exceptionExactMatch.Count != 0)
+        {
+            return exceptionExactMatch.OfType<Match>().Last().Groups["releasegroup"].Value;
+        }
+
+        var matches = ReleaseGroupRegex.Matches(title);
+
+        if (matches.Count != 0)
+        {
+            var group = matches.OfType<Match>().Last().Groups["releasegroup"].Value;
+
+            if (int.TryParse(group, out _))
+            {
+                return null;
+            }
+
+            if (InvalidReleaseGroupRegex.IsMatch(group))
+            {
+                return null;
+            }
+
+            return group;
+        }
+
+        return null;
+    }
+}

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -6,9 +6,9 @@
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Diacritical.Net" Version="1.0.4" />
     <PackageReference Include="Equ" Version="2.3.0" />
-    <PackageReference Include="MailKit" Version="4.12.1" />
+    <PackageReference Include="MailKit" Version="4.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.17" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.1" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="Polly" Version="8.6.0" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />

--- a/src/Whisparr.Api.V3/Tags/TagController.cs
+++ b/src/Whisparr.Api.V3/Tags/TagController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.AutoTagging;
@@ -25,7 +26,10 @@ namespace Whisparr.Api.V3.Tags
         {
             _tagService = tagService;
 
-            SharedValidator.RuleFor(c => c.Label).NotEmpty();
+            SharedValidator.RuleFor(c => c.Label).Cascade(CascadeMode.Stop)
+                .NotEmpty()
+                .Matches("^[a-z0-9-]+$", RegexOptions.IgnoreCase)
+                .WithMessage("Allowed characters a-z, 0-9 and -");
         }
 
         protected override TagResource GetResourceById(int id)

--- a/src/Whisparr.Http/Authentication/AuthenticationBuilderExtensions.cs
+++ b/src/Whisparr.Http/Authentication/AuthenticationBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Whisparr.Http.Authentication
 
         public static AuthenticationBuilder AddAppAuthentication(this IServiceCollection services)
         {
-            services.AddOptions<CookieAuthenticationOptions>(AuthenticationType.Forms.ToString())
+            services.AddOptions<CookieAuthenticationOptions>(nameof(AuthenticationType.Forms))
                 .Configure<IConfigFileProvider>((options, configFileProvider) =>
                 {
                     // Replace diacritics and replace non-word characters to ensure cookie name doesn't contain any valid URL characters not allowed in cookie names
@@ -47,12 +47,9 @@ namespace Whisparr.Http.Authentication
                 });
 
             return services.AddAuthentication()
-                .AddNone(AuthenticationType.None.ToString())
-                .AddExternal(AuthenticationType.External.ToString())
-#pragma warning disable CS0618 // Type or member is obsolete
-                .AddCookie(AuthenticationType.Basic.ToString())
-#pragma warning restore CS0618 // Type or member is obsolete
-                .AddCookie(AuthenticationType.Forms.ToString())
+                .AddNone(nameof(AuthenticationType.None))
+                .AddExternal(nameof(AuthenticationType.External))
+                .AddCookie(nameof(AuthenticationType.Forms))
                 .AddApiKey("API", options =>
                 {
                     options.HeaderName = "X-Api-Key";

--- a/src/Whisparr.Http/Authentication/UiAuthorizationPolicyProvider.cs
+++ b/src/Whisparr.Http/Authentication/UiAuthorizationPolicyProvider.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Http.Authentication
 {
     public class UiAuthorizationPolicyProvider : IAuthorizationPolicyProvider
     {
-        private const string POLICY_NAME = "UI";
+        private const string PolicyName = "UI";
         private readonly IConfigFileProvider _config;
 
         public DefaultAuthorizationPolicyProvider FallbackPolicyProvider { get; }
@@ -26,7 +26,7 @@ namespace NzbDrone.Http.Authentication
 
         public Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
         {
-            if (policyName.Equals(POLICY_NAME, StringComparison.OrdinalIgnoreCase))
+            if (policyName.Equals(PolicyName, StringComparison.OrdinalIgnoreCase))
             {
                 var policy = new AuthorizationPolicyBuilder(_config.AuthenticationMethod.ToString())
                     .AddRequirements(new BypassableDenyAnonymousAuthorizationRequirement());


### PR DESCRIPTION
align parsing with upstream
(chery picked from radarr/radarr@6bdbc9c600)

Fixed: Fix Indexer Flag color
(cherry picked from commit radarr/radarr@3429fe0696)

Fix syntax
(cherry picked from commit radarr/radarr@f49c35563d)

Fix clearing pending changes for First Run
`TypeError: can't access property "section", a is undefined`
(cherry picked from commit radarr/radarr@6e23750705)

Bump MailKit and Microsoft.Data.SqlClient
(cherry picked from commit radarr/radarr@30fc50e049)

Change authentication to Forms if set to Basic
(cherry picked from commit radarr/radarr@8000abc2be)

Fixed: Validation for tags label
(cherry picked from commit radarr/radarr@62a05e2765)

Fixed: Removed support for movie file tokens in Movie Folder Format
(cherry picked from commit radarr/radarr@f04bff8e91)

New: Validation for movie file tokens in Movie Folder Format
(cherry picked from commit radarr/radarr@84593502a3)

Fix: Revert to tagged commits only
Need to work with someone to get permissions to push releases sorted out

#### Database Migration
NO

#### Description
ANother round of mostly small stuff.  I'll note that the parsing alignment was intentionally not 100%, since our rules differ.  I did break the RelaseGroupParser out, as in the upstream.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #683