### PR TITLE
Fix: Do not map the Studio from Sky Hook if it is not mapped.

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/IProvideMovieInfo.cs
+++ b/src/NzbDrone.Core/MetadataSource/IProvideMovieInfo.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.MetadataSource
         Studio GetStudioInfo(string stashId);
         (List<string> Scenes, List<string> TpdbMovies, List<int> Movies) GetPerformerWorks(string stashId);
         List<string> GetStudioScenes(string stashId);
-        (List<string> Scenes, List<string> TpdbMovies) GetStudioWorks(string stashId);
+        (List<string> Scenes, List<string> TpdbMovies, List<int> Movies) GetStudioWorks(string stashId);
         HashSet<int> GetChangedMovies(DateTime startTime);
         HashSet<string> GetChangedTpdbMovies(DateTime startTime);
         HashSet<string> GetChangedScenes(DateTime startTime);

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/StudioWorksResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/StudioWorksResource.cs
@@ -6,5 +6,6 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
     {
         public List<string> Scenes { get; set; }
         public List<string> TpdbMovies { get; set; }
+        public List<string> Movies { get; set; }
     }
 }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -183,7 +183,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
             var performers = httpResponse.Resource.Credits.Select(c => MapPerformer(c.Performer)).DistinctBy(p => p.ForeignId).ToList();
 
-            return new Tuple<MovieMetadata, Studio, List<Performer>>(movie, null, performers);
+            return new Tuple<MovieMetadata, Studio, List<Performer>>(movie, MapStudio(httpResponse.Resource.Studio), performers);
         }
 
         public Tuple<MovieMetadata, Studio, List<Performer>> GetTpdbMovieInfo(string tpdbId)
@@ -1350,6 +1350,12 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
         private Studio MapStudio(StudioResource studio)
         {
+            // Do not Map the Studio if it has not mapped to a StashDB studio. For Movies as the name is stored in the movie Metadata.
+            if (string.IsNullOrEmpty(studio?.ForeignIds?.StashId))
+            {
+                return null;
+            }
+
             var newStudio = new Studio
             {
                 Title = studio.Title,

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -183,7 +183,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
             var performers = httpResponse.Resource.Credits.Select(c => MapPerformer(c.Performer)).DistinctBy(p => p.ForeignId).ToList();
 
-            return new Tuple<MovieMetadata, Studio, List<Performer>>(movie, null, performers);
+            return new Tuple<MovieMetadata, Studio, List<Performer>>(movie, MapStudio(httpResponse.Resource.Studio), performers);
         }
 
         public Tuple<MovieMetadata, Studio, List<Performer>> GetTpdbMovieInfo(string tpdbId)
@@ -536,13 +536,11 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             }
             else if (resource.Studio.ForeignIds != null && resource.Studio.ForeignIds.TmdbId > 0)
             {
-                movie.StudioForeignId = resource.Studio.ForeignIds.TmdbId.ToString();
                 movie.StudioTitle = resource.Studio.Title;
                 movie.Studio = resource.Studio;
             }
             else if (resource.Studio.ForeignIds != null && resource.Studio.ForeignIds.TpdbId.IsNotNullOrWhiteSpace())
             {
-                movie.StudioForeignId = resource.Studio.ForeignIds.TpdbId;
                 movie.StudioTitle = resource.Studio.Title;
                 movie.Studio = resource.Studio;
             }
@@ -1350,6 +1348,12 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
         private Studio MapStudio(StudioResource studio)
         {
+            // Do not Map the Studio if it has not mapped to a StashDB studio. For Movies as the name is stored in the movie Metadata.
+            if (string.IsNullOrEmpty(studio?.ForeignIds?.StashId))
+            {
+                return null;
+            }
+
             var newStudio = new Studio
             {
                 Title = studio.Title,

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -452,7 +452,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             return scenes;
         }
 
-        public (List<string> Scenes, List<string> TpdbMovies) GetStudioWorks(string stashId)
+        public (List<string> Scenes, List<string> TpdbMovies, List<int> Movies) GetStudioWorks(string stashId)
         {
             var httpRequest = _whisparrMetadata.Create()
                                              .SetSegment("route", "site")
@@ -465,6 +465,13 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             var httpResponse = _httpClient.Get<StudioWorksResource>(httpRequest);
             var scenes = httpResponse.Resource.Scenes;
             var tpdbMovies = httpResponse.Resource.TpdbMovies;
+            var movies = new List<int>();
+
+         // Check while Skyhook is transitioning to return TMDB company movies.
+            if (httpResponse.Resource.Movies != null)
+            {
+                movies = httpResponse.Resource.Movies.ConvertAll(int.Parse);
+            }
 
             if (httpResponse.HasHttpError)
             {
@@ -478,7 +485,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 }
             }
 
-            return (scenes, tpdbMovies);
+            return (scenes, tpdbMovies, movies);
         }
 
         public MovieMetadata MapMovie(MovieResource resource)

--- a/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
+++ b/src/NzbDrone.Core/Movies/Studios/RefreshStudioService.cs
@@ -112,9 +112,8 @@ namespace NzbDrone.Core.Movies.Studios
                 // var studioWork = _movieInfo.GetStudioWorks(studio.ForeignId);
 
                 var existingScenes = _movieService.AllMovieStashIds();
-                var studioScenes = studioWork.Scenes;
                 var excludedScenes = _importListExclusionService.GetAllExclusions().Select(e => e.ForeignId);
-                var scenesToAdd = studioScenes.Where(m => !existingScenes.Contains(m)).Where(m => !excludedScenes.Contains(m));
+                var scenesToAdd = studioWork.Scenes.Where(m => !existingScenes.Contains(m)).Where(m => !excludedScenes.Contains(m));
                 var scenesAdded = 0;
 
                 if (scenesToAdd.Any())
@@ -138,12 +137,46 @@ namespace NzbDrone.Core.Movies.Studios
                         scenesAdded += _addMovieService.AddMovies(sceneList.ToList(), true).Count;
                     }
 
-                    _logger.Info("Synced studio {0} has {1} movies adding {2} and added {3}", studio.Title, studioScenes.Count, scenesToAdd.Count(), scenesAdded);
+                    _logger.Info("Synced studio {0} has {1} movies adding {2} and added {3}", studio.Title, studioWork.Scenes.Count, scenesToAdd.Count(), scenesAdded);
                 }
             }
 
             if (studio.MoviesMonitored)
             {
+                if (_configService.WhisparrMovieMetadataSource == MovieMetadataType.TMDB)
+                {
+                    var moviesAdded = 0;
+                    var tmbdId = 0;
+                    var existingMovies = _movieService.AllMovieTmdbIds();
+                    var excludedMovies = _importListExclusionService.GetAllExclusions().Select(e => int.TryParse(e.ForeignId, out tmbdId)).Select(e => tmbdId).Where(e => e != 0).ToList();
+                    var moviesToAdd = studioWork.Movies.Where(m => !existingMovies.Contains(m)).Where(m => !excludedMovies.Contains(m));
+
+                    if (moviesToAdd.Any())
+                    {
+                        var movieLists = moviesToAdd.Select(m => new Movie
+                        {
+                            ForeignId = m.ToString(),
+                            TmdbId = m,
+                            QualityProfileId = studio.QualityProfileId,
+                            RootFolderPath = studio.RootFolderPath,
+                            AddOptions = new AddMovieOptions
+                            {
+                                SearchForMovie = studio.SearchOnAdd,
+                                AddMethod = AddMovieMethod.Studio
+                            },
+                            Monitored = true,
+                            Tags = studio.Tags
+                        }).Chunk(chunkSize);
+
+                        foreach (var movieList in movieLists)
+                        {
+                            moviesAdded += _addMovieService.AddMovies(movieList.ToList(), true).Count;
+                        }
+                    }
+
+                    _logger.Info("Synced studio {0} has {1} movies adding {2} and added {3}", studio.Title, studioWork.Movies.Count, moviesToAdd.Count(), moviesAdded);
+                }
+
                 if (_configService.WhisparrMovieMetadataSource == MovieMetadataType.TPDB)
                 {
                     var moviesAdded = 0;
@@ -162,7 +195,7 @@ namespace NzbDrone.Core.Movies.Studios
                             AddOptions = new AddMovieOptions
                             {
                                 SearchForMovie = studio.SearchOnAdd,
-                                AddMethod = AddMovieMethod.Performer
+                                AddMethod = AddMovieMethod.Studio
                             },
                             Monitored = true,
                             Tags = studio.Tags


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Map the Movie Studio correctly for TPDB, and pending TMDB

Client would add the studio for TPDB but the link would initially be incorrect in the client when navigating from the add form directly after the add. The movie refresh that is triggered at the add correct the link by may be incorrect for a second. It believed that the tpdbid for the studio was the StashDB id.
 

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX