### PR TITLE
Fix: Do not map the Studio from Sky Hook if it is not mapped

### DIFF
--- a/src/NzbDrone.Core/MetadataSource/IProvideMovieInfo.cs
+++ b/src/NzbDrone.Core/MetadataSource/IProvideMovieInfo.cs
@@ -16,9 +16,9 @@ namespace NzbDrone.Core.MetadataSource
         List<MovieMetadata> GetBulkTpdbMovieInfo(List<string> tpdbIds);
         Performer GetPerformerInfo(string stashId);
         Studio GetStudioInfo(string stashId);
-        (List<string> Scenes, List<string> TpdbMovies, List<int> Movies) GetPerformerWorks(string stashId);
+        (List<string> StashdbIds, List<string> TpdbIds, List<int> TmdbIds) GetPerformerWorks(string stashId);
         List<string> GetStudioScenes(string stashId);
-        (List<string> Scenes, List<string> TpdbMovies) GetStudioWorks(string stashId);
+        (List<string> StashdbIds, List<string> TpdbIds, List<int> TmdbIds) GetStudioWorks(string stashId);
         HashSet<int> GetChangedMovies(DateTime startTime);
         HashSet<string> GetChangedTpdbMovies(DateTime startTime);
         HashSet<string> GetChangedScenes(DateTime startTime);

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/StudioWorksResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/StudioWorksResource.cs
@@ -6,5 +6,6 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
     {
         public List<string> Scenes { get; set; }
         public List<string> TpdbMovies { get; set; }
+        public List<string> Movies { get; set; }
     }
 }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -183,7 +183,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
             var performers = httpResponse.Resource.Credits.Select(c => MapPerformer(c.Performer)).DistinctBy(p => p.ForeignId).ToList();
 
-            return new Tuple<MovieMetadata, Studio, List<Performer>>(movie, null, performers);
+            return new Tuple<MovieMetadata, Studio, List<Performer>>(movie, MapStudio(httpResponse.Resource.Studio), performers);
         }
 
         public Tuple<MovieMetadata, Studio, List<Performer>> GetTpdbMovieInfo(string tpdbId)
@@ -536,13 +536,11 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             }
             else if (resource.Studio.ForeignIds != null && resource.Studio.ForeignIds.TmdbId > 0)
             {
-                movie.StudioForeignId = resource.Studio.ForeignIds.TmdbId.ToString();
                 movie.StudioTitle = resource.Studio.Title;
                 movie.Studio = resource.Studio;
             }
             else if (resource.Studio.ForeignIds != null && resource.Studio.ForeignIds.TpdbId.IsNotNullOrWhiteSpace())
             {
-                movie.StudioForeignId = resource.Studio.ForeignIds.TpdbId;
                 movie.StudioTitle = resource.Studio.Title;
                 movie.Studio = resource.Studio;
             }
@@ -1350,6 +1348,12 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
 
         private Studio MapStudio(StudioResource studio)
         {
+            // Do not Map the Studio if it has not mapped to a StashDB studio. For Movies as the name is stored in the movie Metadata.
+            if (string.IsNullOrEmpty(studio?.ForeignIds?.StashId))
+            {
+                return null;
+            }
+
             var newStudio = new Studio
             {
                 Title = studio.Title,

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -394,7 +394,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             return MapStudio(httpResponse.Resource);
         }
 
-        public (List<string> Scenes, List<string> TpdbMovies, List<int> Movies) GetPerformerWorks(string stashId)
+        public (List<string> StashdbIds, List<string> TpdbIds, List<int> TmdbIds) GetPerformerWorks(string stashId)
         {
             var httpRequest = _whisparrMetadata.Create()
                                              .SetSegment("route", "performer")
@@ -405,9 +405,9 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             httpRequest.SuppressHttpError = true;
 
             var httpResponse = _httpClient.Get<PerformerWorksResource>(httpRequest);
-            var scenes = httpResponse.Resource.Scenes;
-            var tpdbMovies = httpResponse.Resource.TpdbMovies;
-            var movies = httpResponse.Resource.Movies.ConvertAll(int.Parse);
+            var stashIds = httpResponse.Resource.Scenes;
+            var tpdbIds = httpResponse.Resource.TpdbMovies;
+            var tmdbIds = httpResponse.Resource.Movies.ConvertAll(int.Parse);
 
             if (httpResponse.HasHttpError)
             {
@@ -421,7 +421,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 }
             }
 
-            return (scenes, tpdbMovies, movies);
+            return (stashIds, tpdbIds, tmdbIds);
         }
 
         public List<string> GetStudioScenes(string stashId)
@@ -452,7 +452,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             return scenes;
         }
 
-        public (List<string> Scenes, List<string> TpdbMovies) GetStudioWorks(string stashId)
+        public (List<string> StashdbIds, List<string> TpdbIds, List<int> TmdbIds) GetStudioWorks(string stashId)
         {
             var httpRequest = _whisparrMetadata.Create()
                                              .SetSegment("route", "site")
@@ -463,8 +463,15 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             httpRequest.SuppressHttpError = true;
 
             var httpResponse = _httpClient.Get<StudioWorksResource>(httpRequest);
-            var scenes = httpResponse.Resource.Scenes;
-            var tpdbMovies = httpResponse.Resource.TpdbMovies;
+            var stashdbIds = httpResponse.Resource.Scenes;
+            var tpdbIds = httpResponse.Resource.TpdbMovies;
+            var tmpdIds = new List<int>();
+
+         // Check while Skyhook is transitioning to return TMDB company movies.
+            if (httpResponse.Resource.Movies != null)
+            {
+                tmpdIds = httpResponse.Resource.Movies.ConvertAll(int.Parse);
+            }
 
             if (httpResponse.HasHttpError)
             {
@@ -478,7 +485,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 }
             }
 
-            return (scenes, tpdbMovies);
+            return (stashdbIds, tpdbIds, tmpdIds);
         }
 
         public MovieMetadata MapMovie(MovieResource resource)
@@ -528,21 +535,20 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
                 movie.Status = MovieStatusType.Released;
             }
 
-            if (resource.Studio.ForeignIds != null && resource.Studio.ForeignIds.StashId.IsNotNullOrWhiteSpace())
+            var foreignIds = resource.Studio?.ForeignIds;
+            if (foreignIds != null)
             {
-                movie.StudioForeignId = resource.Studio.ForeignIds.StashId;
-                movie.StudioTitle = resource.Studio.Title;
-                movie.Studio = resource.Studio;
-            }
-            else if (resource.Studio.ForeignIds != null && resource.Studio.ForeignIds.TmdbId > 0)
-            {
-                movie.StudioTitle = resource.Studio.Title;
-                movie.Studio = resource.Studio;
-            }
-            else if (resource.Studio.ForeignIds != null && resource.Studio.ForeignIds.TpdbId.IsNotNullOrWhiteSpace())
-            {
-                movie.StudioTitle = resource.Studio.Title;
-                movie.Studio = resource.Studio;
+                if (!string.IsNullOrWhiteSpace(foreignIds.StashId))
+                {
+                    movie.StudioForeignId = foreignIds.StashId;
+                    movie.StudioTitle = resource.Studio.Title;
+                    movie.Studio = resource.Studio;
+                }
+                else if (foreignIds.TmdbId > 0 || !string.IsNullOrWhiteSpace(foreignIds.TpdbId))
+                {
+                    movie.StudioTitle = resource.Studio.Title;
+                    movie.Studio = resource.Studio;
+                }
             }
 
             return movie;

--- a/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
+++ b/src/NzbDrone.Core/Movies/Performers/RefreshPerformerService.cs
@@ -147,7 +147,7 @@ namespace NzbDrone.Core.Movies.Performers
             {
                 var existingScenes = _movieService.AllMovieStashIds();
                 var excludedScenes = _importListExclusionService.GetAllExclusions().Select(e => e.ForeignId);
-                var scenesToAdd = performerWork.Scenes.Where(m => !existingScenes.Contains(m)).Where(m => !excludedScenes.Contains(m));
+                var scenesToAdd = performerWork.StashdbIds.Where(m => !existingScenes.Contains(m)).Where(m => !excludedScenes.Contains(m));
                 var scenesAdded = 0;
 
                 if (scenesToAdd.Any())
@@ -172,7 +172,11 @@ namespace NzbDrone.Core.Movies.Performers
                     }
                 }
 
-                _logger.Info("Synced performer {0} has {1} scenes adding {2} and added {3}", performer.Name, performerWork.Scenes.Count, scenesToAdd.Count(), scenesAdded);
+                _logger.Info("Synced performer {0} has {1} scenes adding {2} and added {3}",
+                    performer.Name,
+                    performerWork.StashdbIds.Count,
+                    scenesToAdd.Count(),
+                    scenesAdded);
             }
 
             if (performer.MoviesMonitored)
@@ -184,7 +188,7 @@ namespace NzbDrone.Core.Movies.Performers
                     var tmbdId = 0;
                     var existingMovies = _movieService.AllMovieTmdbIds();
                     var excludedMovies = _importListExclusionService.GetAllExclusions().Select(e => int.TryParse(e.ForeignId, out tmbdId)).Select(e => tmbdId).Where(e => e != 0).ToList();
-                    var moviesToAdd = performerWork.Movies.Where(m => !existingMovies.Contains(m)).Where(m => !excludedMovies.Contains(m));
+                    var moviesToAdd = performerWork.TmdbIds.Where(m => !existingMovies.Contains(m)).Where(m => !excludedMovies.Contains(m));
 
                     if (moviesToAdd.Any())
                     {
@@ -209,14 +213,18 @@ namespace NzbDrone.Core.Movies.Performers
                         }
                     }
 
-                    _logger.Info("Synced performer {0} has {1} movies adding {2} and added {3}", performer.Name, performerWork.Movies.Count, moviesToAdd.Count(), moviesAdded);
+                    _logger.Info("Synced performer {0} has {1} movies adding {2} and added {3}",
+                        performer.Name,
+                        performerWork.TmdbIds.Count,
+                        moviesToAdd.Count(),
+                        moviesAdded);
                 }
 
                 if (_configService.WhisparrMovieMetadataSource == MovieMetadataType.TPDB)
                 {
                     var existingMovies = _movieService.AllMovieTpdbIds();
                     var excludedMovies = _importListExclusionService.GetAllExclusions().Where(e => e.Type == ImportExclusionType.Movie).Select(e => e.ForeignId).ToList();
-                    var moviesToAdd = performerWork.TpdbMovies.Where(m => !existingMovies.Contains(m)).Where(m => !excludedMovies.Contains(m));
+                    var moviesToAdd = performerWork.TpdbIds.Where(m => !existingMovies.Contains(m)).Where(m => !excludedMovies.Contains(m));
 
                     if (moviesToAdd.Any())
                     {
@@ -241,7 +249,11 @@ namespace NzbDrone.Core.Movies.Performers
                         }
                     }
 
-                    _logger.Info("Synced performer {0} has {1} movies adding {2} and added {3}", performer.Name, performerWork.TpdbMovies.Count, moviesToAdd.Count(), moviesAdded);
+                    _logger.Info("Synced performer {0} has {1} movies adding {2} and added {3}",
+                        performer.Name,
+                        performerWork.TpdbIds.Count,
+                        moviesToAdd.Count(),
+                        moviesAdded);
                 }
             }
         }


### PR DESCRIPTION
#### Database Migration
NO

#### Description
Map the Movie Studio correctly for TPDB, and pending TMDB

Client would add the studio for TPDB but the link would initially be incorrect in the client when navigating from the add form directly after the add. The movie refresh that is triggered at the add correct the link by may be incorrect for a second. It believed that the tpdbid for the studio was the StashDB id.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX