### PR TITLE
Add Github release workflow for eros builds

### DIFF
--- a/.github/workflows/eros-build-release.yml
+++ b/.github/workflows/eros-build-release.yml
@@ -1,0 +1,567 @@
+name: Eros cross-release from in-repo build
+description: >
+  Build and create a GitHub Release for Eros across all supported platforms
+  using a GitHub Actions workflow. This workflow builds the backend and frontend,
+  creates packages, builds Windows installers, and creates a GitHub Release with
+  the generated assets.  It is intended to be temporary, until eros is moved to its own repo.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v3.1.123). If set, the workflow will use this tag instead of the pushed ref.'
+        required: false
+        default: ''
+
+env:
+  DOTNET_VERSION: '8.0.405'
+  NODE_VERSION: '20.x'
+  INNO_VERSION: '6.2.2'
+  RUNTIMES_LIST: "win-x64 win-x86 linux-x64 linux-musl-x64 linux-arm64 linux-musl-arm64 linux-arm linux-musl-arm osx-x64 osx-arm64"
+  CHECKOUT_REF: ${{ github.event.inputs.tag != '' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
+jobs:
+  resolve-ref:
+    name: Resolve Checkout Ref
+    runs-on: ubuntu-22.04
+    outputs:
+      tag: ${{ steps.set.outputs.tag }}
+      whisparr: ${{ steps.set.outputs.whisparr }}
+      majorversion: ${{ steps.set.outputs.majorversion }}
+      minorversion: ${{ steps.set.outputs.minorversion }}
+      build_id: ${{ steps.set.outputs.build_id }}
+      checkout_ref: ${{ steps.set.outputs.checkout_ref }}
+    steps:
+      - name: Resolve tag/version and export outputs
+        id: set
+        shell: pwsh
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          # Determine tag (manual override or triggering ref)
+          if ($env:INPUT_TAG -and $env:INPUT_TAG -ne '') {
+            $TAG = $env:INPUT_TAG
+          } else {
+            $TAG = $env:GITHUB_REF -replace '^refs/tags/'
+          }
+          $WHISPARR = $TAG -replace '^v',''
+          $BUILD_ID = ($TAG -split '\.')[-1]
+          # MAJORVERSION: first.two.parts.0
+          $parts = $WHISPARR -split '\.'
+          if ($parts.Length -ge 2) { $MAJOR = "$($parts[0]).$($parts[1]).0" } else { $MAJOR = "$WHISPARR.0.0" }
+          $MINOR = $BUILD_ID
+          # Emit outputs
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "tag=$TAG"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "whisparr=$WHISPARR"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "majorversion=$MAJOR"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "minorversion=$MINOR"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "build_id=$BUILD_ID"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "checkout_ref=$($env:CHECKOUT_REF)"
+          Write-Host "Resolved: TAG=$TAG, WHISPARR=$WHISPARR, MAJOR=$MAJOR, MINOR=$MINOR"
+
+  token:
+    name: Mint GitHub App installation token
+    needs: resolve-ref
+    uses: ./.github/workflows/mint-app-token.yml
+    # pass org secrets (ensure CI_APP_ID and CI_APP_KEY are set at org or repo level)
+    secrets:
+      CI_APP_ID: ${{ secrets.CI_APP_ID }}
+      CI_APP_KEY: ${{ secrets.CI_APP_KEY }}
+      #base64 from app private key
+
+  backend:
+    name: Build Backend (${{ matrix.runtime }})
+    runs-on: 'ubuntu-22.04'
+    needs: [resolve-ref, token]
+    env:
+      TAG: ${{ needs.resolve-ref.outputs.tag }}
+      WHISPARRVERSION: ${{ needs.resolve-ref.outputs.whisparr }}
+      BUILD_ID: ${{ needs.resolve-ref.outputs.build_id }}
+      MAJORVERSION: ${{ needs.resolve-ref.outputs.majorversion }}
+      MINORVERSION: ${{ needs.resolve-ref.outputs.minorversion }}
+    strategy:
+      matrix:
+        runtime: [
+          'win-x64', 'win-x86', 'linux-x64', 'linux-musl-x64', 'linux-arm64',
+          'linux-musl-arm64', 'linux-arm', 'linux-musl-arm', 'osx-x64', 'osx-arm64'
+        ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Reclaim Runner Disk (best-effort)
+        shell: pwsh
+        run: |
+          Write-Host 'Disk usage before cleanup'
+          & df -h
+          try { sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc 2>$null } catch { }
+          try { sudo rm -rf /usr/lib/jvm 2>$null } catch { }
+          try { sudo apt-get clean 2>$null } catch { }
+          Write-Host 'Disk usage after cleanup'
+          & df -h
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Enable Extra Platform Support
+        shell: pwsh
+        run: |
+          $candidates = Get-ChildItem -Path /usr/share/dotnet/sdk -Recurse -Filter Microsoft.NETCoreSdk.BundledVersions.props -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($null -ne $candidates) {
+            Write-Host "Found: $($candidates.FullName)"
+            $content = Get-Content $candidates.FullName -Raw
+            if ($content -match 'freebsd-x64') {
+              Write-Host 'Extra platforms already enabled'
+            } else {
+              Write-Host 'Enabling extra platform support'
+              $new = $content -replace 'osx-x64','osx-x64;freebsd-x64'
+              $new | Set-Content -Path $candidates.FullName -Force
+            }
+          } else {
+            Write-Host 'BundledVersions.props not found; skipping extra platform enable step (best-effort)'
+          }
+
+      - name: Build Backend for ${{ matrix.runtime }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $RID = '${{ matrix.runtime }}'
+          if ($RID -like 'win-*') { $PLATFORM = 'Windows' } else { $PLATFORM = 'Posix' }
+
+          Write-Host 'Using resolved tag/version from resolve-ref job'
+          $TAG = $env:TAG
+          $WHISPARRVERSION = $env:WHISPARRVERSION
+          $BUILD_SOURCEBRANCHNAME = $env:GITHUB_REF -replace '^refs/heads/',''
+          Write-Host "Tag: $TAG, Version: $WHISPARRVERSION, Config: $BUILD_SOURCEBRANCHNAME"
+
+          if ($WHISPARRVERSION -ne '') {
+            Write-Host 'Updating version info in repo files'
+            $dbProps = 'src/Directory.Build.props'
+            if (Test-Path $dbProps) {
+              $c = Get-Content -Path $dbProps -Raw
+              $c = $c -replace '<AssemblyVersion>.*?<\/AssemblyVersion>', "<AssemblyVersion>$WHISPARRVERSION</AssemblyVersion>"
+              $c = $c -replace '<AssemblyConfiguration>.*?<\/AssemblyConfiguration>', "<AssemblyConfiguration>$BUILD_SOURCEBRANCHNAME</AssemblyConfiguration>"
+              Set-Content -Path $dbProps -Value $c -Force
+            }
+            $plist = 'distribution/osx/Whisparr.app/Contents/Info.plist'
+            if (Test-Path $plist) {
+              (Get-Content -Path $plist -Raw) -replace '<string>10.0.0.0<\/string>', "<string>$WHISPARRVERSION</string>" | Set-Content -Path $plist -Force
+            }
+          }
+
+          Write-Host "Running dotnet msbuild publish for runtime: $RID (Platform=$PLATFORM)"
+          dotnet --info
+          dotnet msbuild -restore src/Whisparr.sln -p:SelfContained=True -p:Configuration=Release -p:Platform=$PLATFORM -p:RuntimeIdentifier=$RID -p:PublishDir="_output/net8.0/$RID/publish/" -t:Publish
+        env:
+          FORCE_COLOR: 0
+
+      - name: Upload Backend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.runtime }}-backend
+          path: _output/net8.0/${{ matrix.runtime }}
+
+  frontend:
+    name: Build Frontend
+    runs-on: 'ubuntu-22.04'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Build Frontend
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $$dest = 'frontend'
+          New-Item -ItemType Directory -Path $$dest -Force | Out-Null
+          Push-Location $$dest
+          yarn install --frozen-lockfile --network-timeout 120000
+          yarn run build --env production
+          Pop-Location
+
+      - name: Collect Frontend artifacts
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $src = 'frontend/build'
+          $ui = '_output/UI'
+          $dest = 'frontend_artifacts'
+          New-Item -ItemType Directory -Path $dest -Force | Out-Null
+          if (Test-Path $src) {
+            Copy-Item -Path "$($src/*)" -Destination $dest -Recurse -Force -ErrorAction SilentlyContinue
+          }else {
+            Write-Host 'No frontend/build directory found!'
+            Exit 1
+          }
+          if (Test-Path $ui) {
+            Copy-Item -Path "$($ui/*)" -Destination $dest -Recurse -Force -ErrorAction SilentlyContinue
+          }else {
+            Write-Host 'No _output/UI directory found!'
+            Exit 1
+          }
+          Get-ChildItem -Path $dest -Force -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_.FullName }
+
+      - name: Upload Frontend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Frontend
+          path: frontend_artifacts
+
+  packages:
+    name: Create Packages
+    runs-on: 'ubuntu-22.04'
+    needs: [backend, frontend]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: .
+
+      - name: Merge downloaded artifacts into _output
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $outputFolder = '_output'
+          New-Item -ItemType Directory -Path $outputFolder -Force | Out-Null
+          $runtimes = $env:RUNTIMES_LIST -split ' '
+          foreach ($r in $runtimes) {
+            $artifact = "$($r)-backend"
+            if (-not (Test-Path $artifact)) {
+              Write-Host "No $artifact artifact found!"
+              continue
+            }
+            # Prefer artifact layout that already contains net8.0/<rid>/publish
+            $possiblePublish1 = Join-Path $artifact "net8.0/$r/publish"
+            $possiblePublish2 = Join-Path $artifact 'publish'
+            $dest = Join-Path $outputFolder "net8.0/$r"
+            New-Item -ItemType Directory -Path $dest -Force | Out-Null
+            if (Test-Path $possiblePublish1) {
+              Write-Host "Copying artifact net8.0/$r/publish -> $dest"
+              Copy-Item -Path (Join-Path $possiblePublish1 '*') -Destination $dest -Recurse -Force -ErrorAction SilentlyContinue
+            } elseif (Test-Path $possiblePublish2) {
+              Write-Host "Copying artifact publish -> $dest"
+              Copy-Item -Path (Join-Path $possiblePublish2 '*') -Destination $dest -Recurse -Force -ErrorAction SilentlyContinue
+            } else {
+              Write-Host "Copying artifact contents -> $dest"
+              Copy-Item -Path (Join-Path $artifact '*') -Destination $dest -Recurse -Force -ErrorAction SilentlyContinue
+            }
+          }
+          if (Test-Path 'Frontend') {
+            Write-Host 'Merging Frontend into _output'
+            Copy-Item -Path 'Frontend/*' -Destination $outputFolder -Recurse -Force -ErrorAction SilentlyContinue
+          } else {
+            Write-Host 'No Frontend artifact found!'
+            Exit 1
+          }
+
+      - name: Create Packages (native)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Set-StrictMode -Version Latest
+          $outputFolder = '_output'
+          $artifactsFolder = '_artifacts'
+          $framework = 'net8.0'
+          $runtimes = $env:RUNTIMES_LIST -split ' '
+
+          New-Item -ItemType Directory -Path $artifactsFolder -Force | Out-Null
+
+          foreach ($r in $runtimes) {
+            Write-Host "Packaging runtime: $($r)"
+            $folder = Join-Path $artifactsFolder ("$($r)/$framework/Whisparr")
+            if (Test-Path $folder) { Remove-Item -LiteralPath $folder -Recurse -Force -ErrorAction SilentlyContinue }
+            New-Item -ItemType Directory -Path $folder -Force | Out-Null
+
+            #macOS and Linux
+            $pub1 = Join-Path $outputFolder "$framework/$($r)/publish"
+            if (Test-Path $pub1) { Copy-Item -Path (Join-Path $pub1 '*') -Destination $folder -Recurse -Force -ErrorAction SilentlyContinue }
+
+            # WIndows only
+            $pub2 = "$outputFolder/${framework}-windows/$($r)/publish"
+            if (Test-Path $pub2) { Copy-Item -Path (Join-Path $pub2 '*') -Destination $folder -Recurse -Force -ErrorAction SilentlyContinue }
+
+            $upd = Join-Path $outputFolder "Whisparr.Update/$framework/$($r)/publish"
+            if (Test-Path $upd) { New-Item -ItemType Directory -Path (Join-Path $folder 'Whisparr.Update') -Force | Out-Null; Copy-Item -Path (Join-Path $upd '*') -Destination (Join-Path $folder 'Whisparr.Update') -Recurse -Force -ErrorAction SilentlyContinue }
+
+            if (Test-Path (Join-Path $outputFolder 'UI'))
+              {
+                Copy-Item -Path (Join-Path $outputFolder 'UI/*') -Destination $folder -Recurse -Force -ErrorAction SilentlyContinue
+              }
+
+            if (Test-Path 'LICENSE') { Copy-Item -Path 'LICENSE' -Destination $folder -Force -ErrorAction SilentlyContinue }
+
+            # Clean up incompatible binaries and prepare update folder
+            switch -Wildcard ($r) {
+              'linux*' {
+                Remove-Item -Path (Join-Path $folder 'ServiceUninstall.*') -ErrorAction SilentlyContinue -Force
+                Remove-Item -Path (Join-Path $folder 'ServiceInstall.*') -ErrorAction SilentlyContinue -Force
+                Get-ChildItem -Path $folder -Filter 'Whisparr.Windows.*' -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+                New-Item -ItemType Directory -Path (Join-Path $folder 'Whisparr.Update') -Force | Out-Null
+                Copy-Item -Path (Join-Path $folder 'Whisparr.Mono.*') -Destination (Join-Path $folder 'Whisparr.Update') -ErrorAction SilentlyContinue -Force
+                Copy-Item -Path (Join-Path $folder 'Mono.Posix.NETStandard.*') -Destination (Join-Path $folder 'Whisparr.Update') -ErrorAction SilentlyContinue -Force
+                Copy-Item -Path (Join-Path $folder 'libMonoPosixHelper.*') -Destination (Join-Path $folder 'Whisparr.Update') -ErrorAction SilentlyContinue -Force
+              }
+              'osx*' {
+                Remove-Item -Path (Join-Path $folder 'ServiceUninstall.*') -ErrorAction SilentlyContinue -Force
+                Remove-Item -Path (Join-Path $folder 'ServiceInstall.*') -ErrorAction SilentlyContinue -Force
+                Get-ChildItem -Path $folder -Filter 'Whisparr.Windows.*' -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+                New-Item -ItemType Directory -Path (Join-Path $folder 'Whisparr.Update') -Force | Out-Null
+                Copy-Item -Path (Join-Path $folder 'Whisparr.Mono.*') -Destination (Join-Path $folder 'Whisparr.Update') -ErrorAction SilentlyContinue -Force
+                Copy-Item -Path (Join-Path $folder 'Mono.Posix.NETStandard.*') -Destination (Join-Path $folder 'Whisparr.Update') -ErrorAction SilentlyContinue -Force
+                Copy-Item -Path (Join-Path $folder 'libMonoPosixHelper.*') -Destination (Join-Path $folder 'Whisparr.Update') -ErrorAction SilentlyContinue -Force
+                $appfolder = Join-Path $artifactsFolder ("${r}-app/$framework")
+                if (Test-Path $appfolder) { Remove-Item -LiteralPath $appfolder -Recurse -Force -ErrorAction SilentlyContinue }
+                New-Item -ItemType Directory -Path $appfolder -Force | Out-Null
+                if (Test-Path 'distribution/osx/Whisparr.app') {
+                  Copy-Item -Path 'distribution/osx/Whisparr.app' -Destination $appfolder -Recurse -Force -ErrorAction SilentlyContinue
+                  New-Item -ItemType Directory -Path (Join-Path $appfolder 'Whisparr.app/Contents/MacOS') -Force | Out-Null
+                  Copy-Item -Path (Join-Path $folder '*') -Destination (Join-Path $appfolder 'Whisparr.app/Contents/MacOS') -Recurse -Force -ErrorAction SilentlyContinue
+                  Remove-Item -LiteralPath (Join-Path $appfolder 'Whisparr.app/Contents/MacOS/Whisparr.Update') -Recurse -Force -ErrorAction SilentlyContinue
+                }
+              }
+              'win-*' {
+                Get-ChildItem -Path $folder -Filter 'Whisparr.Mono.*' -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+                Get-ChildItem -Path $folder -Filter 'Mono.Posix.NETStandard.*' -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+                Get-ChildItem -Path $folder -Filter 'libMonoPosixHelper.*' -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+                New-Item -ItemType Directory -Path (Join-Path $folder 'Whisparr.Update') -Force | Out-Null
+                Copy-Item -Path (Join-Path $folder 'Whisparr.Windows.*') -Destination (Join-Path $folder 'Whisparr.Update') -ErrorAction SilentlyContinue -Force
+              }
+            }
+          }
+
+          # Ensure executables
+          Get-ChildItem -Path $artifactsFolder -Recurse -Filter 'ffprobe' -ErrorAction SilentlyContinue | ForEach-Object { & chmod a+x $_.FullName }
+          Get-ChildItem -Path $artifactsFolder -Recurse -Filter 'Whisparr' -ErrorAction SilentlyContinue | ForEach-Object { & chmod a+x $_.FullName }
+          Get-ChildItem -Path $artifactsFolder -Recurse -Filter 'Whisparr.Update' -ErrorAction SilentlyContinue | ForEach-Object { & chmod a+x $_.FullName }
+
+          # Create archives
+          New-Item -ItemType Directory -Path 'release_assets' -Force | Out-Null
+          foreach ($r in $runtimes) {
+            $base = Join-Path $artifactsFolder "$r/$framework"
+            if (Test-Path $base) {
+              if ($r -like 'win-*') {
+                $zipDest = Join-Path (Get-Location) "release_assets/Whisparr.$r.zip"
+                $src = Join-Path $artifactsFolder $r
+                & zip -r $zipDest (Join-Path $src $framework) || Write-Host "zip failed for $r"
+              } else {
+                & tar -C (Join-Path $artifactsFolder $r) -czf "release_assets/Whisparr.$r.tar.gz" "$framework" || Write-Host "tar failed for $r"
+              }
+            }
+            $appbase = Join-Path $artifactsFolder ("${r}-app/$framework")
+            if (Test-Path $appbase) {
+              & tar -C (Join-Path $artifactsFolder "${r}-app") -czf "release_assets/Whisparr.${r}-app.tar.gz" "$framework" || Write-Host "tar failed for ${r}-app"
+            }
+          }
+
+      - name: Create package archives
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $artifactsPath = '_artifacts'
+          $releasePath = 'release_assets'
+          New-Item -ItemType Directory -Path $releasePath -Force | Out-Null
+          $runtimes = $env:RUNTIMES_LIST -split ' '
+          foreach ($r in $runtimes) {
+            $base = Join-Path $artifactsPath "$r/net8.0"
+            if (Test-Path $base) {
+              Write-Host "Packaging $r"
+              New-Item -ItemType Directory -Path $releasePath -Force | Out-Null
+              if ($r -like 'win-*') {
+                $zipPath = Join-Path (Get-Location) "$releasePath/Whisparr.$r.zip"
+                & zip -r $zipPath $base || Write-Host "zip failed for $r"
+              } else {
+                & tar -C (Join-Path $artifactsPath $r) -czf "$releasePath/Whisparr.$r.tar.gz" "net8.0" || Write-Host "tar failed for $r"
+              }
+            }
+          }
+          Get-ChildItem -Path $releasePath -Force | ForEach-Object { Write-Host $_.FullName }
+
+      - name: Create windows-only packages
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $src = 'release_assets'
+          $dst = 'release_assets_windows'
+          New-Item -ItemType Directory -Path $dst -Force | Out-Null
+          if (Test-Path $src) {
+            Get-ChildItem -Path $src -File -Filter '*win-*.zip' -ErrorAction SilentlyContinue | ForEach-Object {
+              Copy-Item -Path $_.FullName -Destination $dst -Force -ErrorAction SilentlyContinue
+            }
+          }
+
+      - name: Upload windows packages bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-windows
+          path: release_assets_windows
+
+      - name: Upload packages bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: release_assets
+
+  windows-installer:
+    name: Build Windows Installers
+    runs-on: windows-latest
+    needs: [packages, resolve-ref]
+    env:
+      TAG: ${{ needs.resolve-ref.outputs.tag }}
+      WHISPARRVERSION: ${{ needs.resolve-ref.outputs.whisparr }}
+      BUILD_ID: ${{ needs.resolve-ref.outputs.build_id }}
+      MAJORVERSION: ${{ needs.resolve-ref.outputs.majorversion }}
+      MINORVERSION: ${{ needs.resolve-ref.outputs.minorversion }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Download packages artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: packages-windows
+          path: .
+
+      - name: Extract Windows packages into _artifacts
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $artifactsPath = '_artifacts'
+          New-Item -ItemType Directory -Path $artifactsPath -Force | Out-Null
+          $runtimes = @('win-x64','win-x86')
+          foreach ($r in $runtimes) {
+            $zipCandidates = Get-ChildItem -Path 'release_assets' -Filter "*${r}*.zip" -File -ErrorAction SilentlyContinue
+            if ($zipCandidates) {
+              foreach ($zip in $zipCandidates) {
+                Write-Host "Extracting $($zip.Name) for $r"
+                $dest = Join-Path $artifactsPath $r
+                $frameworkDir = Join-Path $dest 'net8.0'
+                New-Item -ItemType Directory -Path $frameworkDir -Force | Out-Null
+                Expand-Archive -Path $zip.FullName -DestinationPath $frameworkDir -Force
+                # Some zips include a top-level folder named 'net8.0' or the framework; normalize to Whisparr folder
+                $extracted = Get-ChildItem -Path $frameworkDir | Where-Object { $_.PSIsContainer }
+                foreach ($e in $extracted) {
+                  if ($e.Name -ieq 'Whisparr') { continue }
+                  $target = Join-Path $frameworkDir 'Whisparr'
+                  New-Item -ItemType Directory -Path $target -Force | Out-Null
+                  Copy-Item -Path (Join-Path $e.FullName '*') -Destination $target -Recurse -Force -ErrorAction SilentlyContinue
+                }
+              }
+            } else {
+              Write-Host "No package zip found for $r in release_assets"
+            }
+          }
+
+      - name: Install portable Inno Setup
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $innoExe = 'innosetup.exe'
+          Invoke-WebRequest -Uri "https://files.jrsoftware.org/is/6/innosetup-${{ env.INNO_VERSION }}.exe" -OutFile $innoExe -UseBasicParsing
+          Remove-Item -Recurse -Force _inno -ErrorAction SilentlyContinue
+          & .\$innoExe //portable=1 //silent //currentuser //dir=.\\_inno
+          Remove-Item $innoExe -Force -ErrorAction SilentlyContinue
+
+      - name: Run Inno Setup to build installers
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $framework = 'net8.0'
+          $runtimes = @('win-x64','win-x86')
+          foreach ($r in $runtimes) {
+            Write-Host "Building installer for $r (MAJOR=$env:MAJORVERSION MINOR=$env:MINORVERSION WHISPARR=$env:WHISPARRVERSION)"
+            & .\_inno\ISCC.exe distribution/windows/setup/whisparr.iss "//DFramework=$framework" "//DRuntime=$r" || Write-Host "ISCC failed for $r"
+          }
+
+      - name: Collect installers
+        shell: pwsh
+        run: |
+          $out = 'distribution/windows/setup/output'
+          if (Test-Path $out) {
+            Get-ChildItem -Path $out -File | ForEach-Object { Write-Host "Found installer: $($_.FullName)" }
+            New-Item -ItemType Directory -Path installers -Force | Out-Null
+            Copy-Item -Path (Join-Path $out '*') -Destination installers -Force -Recurse -ErrorAction SilentlyContinue
+          } else {
+            Write-Host 'No installer output directory found'
+          }
+
+      - name: Upload Windows installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: WindowsInstallers
+          path: installers
+
+  create_release:
+    name: Create GitHub Release and upload assets
+    runs-on: 'ubuntu-22.04'
+    needs: [windows-installer, token, resolve-ref]
+    env:
+      TAG: ${{ needs.resolve-ref.outputs.tag }}
+      WHISPARRVERSION: ${{ needs.resolve-ref.outputs.whisparr }}
+      BUILD_ID: ${{ needs.resolve-ref.outputs.build_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Download packages artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: packages
+          path: release_assets
+
+      - name: Download packages artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: packages-windows
+          path: release_assets
+
+      - name: Download Windows installers artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: WindowsInstallers
+          path: release_assets
+
+      - name: Set release tag output from resolve-ref
+        id: tag_info
+        run: |
+          echo "tag=${{ needs.resolve-ref.outputs.tag }}" >> $GITHUB_OUTPUT
+          echo "build_id=${{ needs.resolve-ref.outputs.build_id }}" >> $GITHUB_OUTPUT
+
+      - name: Create release and upload assets
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_info.outputs.tag }}
+          name: ${{ steps.tag_info.outputs.tag }}
+          body: Automated release created from build ${{ steps.tag_info.outputs.build_id }}
+          draft: false
+          generateReleaseNotes: true
+          prerelease: true
+          artifacts: release_assets/**
+          token: ${{ needs.token.outputs.release_token }}

--- a/.github/workflows/mint-app-token.yml
+++ b/.github/workflows/mint-app-token.yml
@@ -1,0 +1,57 @@
+name: Mint GitHub App installation token
+description: >
+  Mint a GitHub App installation token for the current repository using
+  the provided App ID and private key.
+
+on:
+  workflow_call:
+    secrets:
+      CI_APP_ID:
+        required: true
+      CI_APP_KEY:
+        required: true
+
+jobs:
+  mint:
+    runs-on: ubuntu-latest
+    outputs:
+      release_token: ${{ steps.create.outputs.release_token }}
+      installation_id: ${{ steps.create.outputs.installation_id }}
+    steps:
+      - name: Generate installation token
+        id: create
+        env:
+          CI_APP_ID: ${{ secrets.CI_APP_ID }}
+          CI_APP_KEY: ${{ secrets.CI_APP_KEY }}
+        run: |
+          set -euo pipefail
+          # Decode private key
+          echo "$CI_APP_KEY" | base64 --decode > /tmp/app_private_key.pem
+
+          # Install minimal Python deps
+          python -m pip install --upgrade pip
+          python -m pip install PyJWT requests
+
+          # Create JWT, exchange for installation token, and emit outputs
+          python - <<'PY' > /tmp/mint_out.env
+            import os, time, jwt, requests
+            app_id = os.environ['CI_APP_ID']
+            private_key = open('/tmp/app_private_key.pem','r').read()
+            now = int(time.time())
+            payload = {'iat': now - 60, 'exp': now + (9*60), 'iss': int(app_id)}
+            jwt_token = jwt.encode(payload, private_key, algorithm='RS256')
+            owner, repo = os.environ['GITHUB_REPOSITORY'].split('/')
+            headers = {'Authorization': f'Bearer {jwt_token}', 'Accept': 'application/vnd.github+json'}
+            # Get installation ID for this repo (works for org or repo installations)
+            resp = requests.get(f'https://api.github.com/repos/{owner}/{repo}/installation', headers=headers)
+            resp.raise_for_status()
+            installation_id = resp.json()['id']
+            resp2 = requests.post(f'https://api.github.com/app/installations/{installation_id}/access_tokens', headers=headers)
+            resp2.raise_for_status()
+            token_value = resp2.json()['token']
+            print(f"release_token={token_value}")
+            print(f"installation_id={installation_id}")
+          PY
+
+          # Append the values to GITHUB_OUTPUT so they become step outputs
+          cat /tmp/mint_out.env >> $GITHUB_OUTPUT


### PR DESCRIPTION
Adds an automated workflow to build releases and publish to Github.  Intended to run side by side with Azure, as that feeds the updater in th eapp, for now.  This workflow will also be able to be triggered manually with a commit tag, to make testing easier.

#### Database Migration
YES - XXXX | NO

#### Description
A few sentences describing the overall goals of the pull request's commits.

#### Screenshot (if UI related)

#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX