### PR TITLE
New: Add Token without SE in Scene Title

### DIFF
--- a/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingModal.tsx
@@ -140,6 +140,7 @@ const movieTokens = [
 const sceneTokens = [
   { token: '{Scene Title}', example: "Scene's Title" },
   { token: '{Scene CleanTitle}', example: 'Scenes Title' },
+  { token: '{Scene CleanTitleNoSeasonEpisode}', example: 'Scenes Title' },
   { token: '{Scene TitleThe}', example: "Scene's Title, The" },
   { token: '{Scene TitleFirstCharacter}', example: 'S' },
   {

--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -202,6 +202,46 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
                    .Should().Be("Pure Taboo - 2025-11-25 - The Last Train Home [Maddy OReilly Reagan Foxx Rissa May]");
         }
 
+        [TestCase("My Scene Title S01:E02", "My Scene Title")]
+        [TestCase("My Scene Title s01:e02", "My Scene Title")]
+        [TestCase("My Scene Title S01:e02", "My Scene Title")]
+        [TestCase("My Scene Title s01:E02", "My Scene Title")]
+        [TestCase("My Scene Title S1:E2", "My Scene Title")]
+        [TestCase("My Scene Title S1:E02", "My Scene Title")]
+        [TestCase("My Scene Title S01:E2", "My Scene Title")]
+        [Test]
+        public void scene_clean_title_no_se_Title(string title, string expected)
+        {
+            _scene.Title = title;
+            _namingConfig.StandardSceneFormat = "{Scene CleanTitleNoSeasonEpisode}";
+
+            Subject.BuildFileName(_scene, _movieFile)
+                .Should().Be(expected);
+        }
+
+        [Test]
+        public void scene_clean_title_no_se_format()
+        {
+            _scene.Title = "My Scene Title S01:E02";
+            _scene.MovieMetadata.Value.ReleaseDate = "2025-11-25";
+
+            _namingConfig.StandardSceneFormat = "{Studio Title} - {Release-Date} - {Scene CleanTitleNoSeasonEpisode}";
+
+            Subject.BuildFileName(_scene, _movieFile)
+                .Should().Be("Pure Taboo - 2025-11-25 - My Scene Title");
+        }
+
+        [Test]
+        public void scene_clean_title_no_se_should_trim_when_too_long()
+        {
+            _sceneLongTitle.Title = "This is a very long scene title S01:E02";
+            _namingConfig.StandardSceneFormat = "{Scene CleanTitleNoSeasonEpisode}";
+
+            var result = Subject.BuildFileName(_sceneLongTitle, _movieFile);
+
+            result.Length.Should().BeLessThanOrEqualTo(_namingConfig.MaxFilePathLength);
+        }
+
         [Test]
         public void scene_folder_format_length()
         {

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Core.Organizer
         public static readonly Regex MainFolderRegex = new Regex(@"^(?<main>(?:[a-zA-Z0-9]+(?:\\|\/)))",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        public static readonly Regex SceneTitleRegex = new Regex(@"(?<token>\{((?:(Scene|Original))(?<separator>[- ._])(Clean)?(Original)?(Title|Filename)(The)?)(?::(?<customFormat>[a-z0-9|]+))?\})",
+        public static readonly Regex SceneTitleRegex = new Regex(@"(?<token>\{((?:(Scene|Original))(?<separator>[- ._])(Clean)?(Original)?(Title|Filename)(The)?(NoSeasonEpisode)?)(?::(?<customFormat>[a-z0-9|]+))?\})",
                                                                             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private static readonly Regex FileNameCleanupRegex = new Regex(@"([- ._])(\1)+", RegexOptions.Compiled);
@@ -324,6 +324,22 @@ namespace NzbDrone.Core.Organizer
             return title;
         }
 
+        public string CleanTitleNoSeasonEpisode(string title)
+        {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
+            title = CleanTitle(title);
+
+            title = Regex.Replace(title, @"\s*-?\s*S\d+:E\d+\s*", "", RegexOptions.IgnoreCase);
+
+            title = Regex.Replace(title, @"\s+", " ").Trim();
+
+            return title;
+        }
+
         private void AddMovieTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie)
         {
             tokenHandlers["{Movie Title}"] = m => Truncate(GetLanguageTitle(movie, m.CustomFormat), m.CustomFormat);
@@ -479,6 +495,7 @@ namespace NzbDrone.Core.Organizer
             tokenHandlers["{Scene CleanTitle}"] = m => CleanTitle(GetLanguageTitle(movie, m.CustomFormat)).Remove(CleanTitle(GetLanguageTitle(movie, m.CustomFormat)).Length - _trimEnd, _trimEnd);
             tokenHandlers["{Scene TitleThe}"] = m => TitleThe(movie.Title).Remove(TitleThe(movie.Title).Length - _trimEnd, _trimEnd);
             tokenHandlers["{Scene TitleFirstCharacter}"] = m => TitleFirstCharacter(TitleThe(GetLanguageTitle(movie, m.CustomFormat))).Remove(TitleFirstCharacter(TitleThe(GetLanguageTitle(movie, m.CustomFormat))).Length - _trimEnd, _trimEnd);
+            tokenHandlers["{Scene CleanTitleNoSeasonEpisode}"] = m => CleanTitleNoSeasonEpisode(GetLanguageTitle(movie, m.CustomFormat)).Remove(CleanTitleNoSeasonEpisode(GetLanguageTitle(movie, m.CustomFormat)).Length - _trimEnd, _trimEnd);
         }
 
         private void AddSceneTitleTokens(Dictionary<string, Func<TokenMatch, string>> tokenHandlers, Movie movie, int maxLength)


### PR DESCRIPTION
#### Database Migration
NO

#### Description
{Scene CleanTitle} includes the season and episode numbers, but some media players don't play well with that, so I implemented a new token like Scene CleanTitle but removes the "S#:E#" as {Scene CleanTitleNoSeasonEpisode}.

#### Screenshot (if UI related)
<img width="1472" height="1221" alt="image" src="https://github.com/user-attachments/assets/7f8423ac-809e-4f70-bf0a-53d4ef18fbad" />


#### Todos
- [x] Tests
- [x] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [x] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

N/A