### PR TITLE
Fix: Update List Exclusion modal and movieYear validator

### DIFF
--- a/frontend/src/Settings/ImportLists/ImportListExclusions/EditImportListExclusionModalContent.tsx
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/EditImportListExclusionModalContent.tsx
@@ -28,10 +28,36 @@ import translate from 'Utilities/String/translate';
 import styles from './EditImportListExclusionModalContent.css';
 
 const newImportListExclusion = {
-  movieTitle: '',
-  movieYear: 0,
-  type: 'scene',
-  foreignId: '',
+  movie: {
+    movieTitle: '',
+    movieYear: 0,
+    type: 'movie',
+    foreignId: '',
+  },
+  scene: {
+    movieTitle: '',
+    movieYear: 0,
+    type: 'scene',
+    foreignId: '',
+  },
+  studio: {
+    movieTitle: '',
+    movieYear: null,
+    type: 'studio',
+    foreignId: '',
+  },
+  performer: {
+    movieTitle: '',
+    movieYear: null,
+    type: 'performer',
+    foreignId: '',
+  },
+  tag: {
+    movieTitle: '',
+    movieYear: null,
+    type: 'tag',
+    foreignId: '',
+  },
 };
 
 const typeOptions = [
@@ -56,9 +82,18 @@ function createImportListExclusionSelector(id?: number) {
         importListExclusions;
 
       const mapping = id
-        ? items.find((i) => i.id === id) ?? newImportListExclusion
-        : newImportListExclusion;
-      const settings = selectSettings(mapping, pendingChanges, saveError);
+        ? items.find((i) => i.id === id) || newImportListExclusion.scene
+        : newImportListExclusion.scene;
+
+      const normalized = {
+        ...mapping,
+        movieYear:
+          mapping.type === 'movie' || mapping.type === 'scene'
+            ? mapping.movieYear
+            : null,
+      };
+
+      const settings = selectSettings(normalized, pendingChanges, saveError);
 
       return {
         isFetching,
@@ -87,7 +122,7 @@ function EditImportListExclusionModalContent({
 
   const dispatchSetImportListExclusionValue = (payload: {
     name: string;
-    value: string | number;
+    value: string | number | null;
   }) => {
     // @ts-expect-error 'setImportListExclusionValue' isn't typed yet
     dispatch(setImportListExclusionValue(payload));
@@ -95,7 +130,10 @@ function EditImportListExclusionModalContent({
 
   useEffect(() => {
     if (!id) {
-      Object.entries(newImportListExclusion).forEach(([name, value]) => {
+      const defaults =
+        newImportListExclusion[type.value] ?? newImportListExclusion.scene;
+
+      Object.entries(defaults).forEach(([name, value]) => {
         dispatchSetImportListExclusionValue({ name, value });
       });
     }
@@ -109,8 +147,31 @@ function EditImportListExclusionModalContent({
   }, [previousIsSaving, isSaving, saveError, onModalClose]);
 
   const onSavePress = useCallback(() => {
-    dispatch(saveImportListExclusion({ id }));
-  }, [dispatch, id]);
+    const payload: ImportListExclusion = {
+      id: item.id?.value,
+      foreignId: item.foreignId.value,
+      movieTitle: item.movieTitle.value,
+      movieYear: item.movieYear.value,
+      type: item.type.value,
+    };
+
+    if (
+      (payload.type === 'movie' || payload.type === 'scene') &&
+      (payload.movieYear == null ||
+        Number.isNaN(payload.movieYear) ||
+        payload.movieYear <= 0)
+    ) {
+      payload.movieYear = 0;
+    }
+
+    if (payload.type !== 'movie' && payload.type !== 'scene') {
+      payload.movieYear = null;
+    } else if (payload.movieYear == null || Number.isNaN(payload.movieYear)) {
+      payload.movieYear = null;
+    }
+
+    dispatch(saveImportListExclusion(payload));
+  }, [dispatch, item]);
 
   const onInputChange = useCallback(
     (change: InputChanged) => {
@@ -201,7 +262,6 @@ function EditImportListExclusionModalContent({
             {translate('Delete')}
           </Button>
         )}
-        : null
         <Button onPress={onModalClose}>{translate('Cancel')}</Button>
         <SpinnerErrorButton
           isSpinning={isSaving}

--- a/frontend/src/typings/ImportListExclusion.ts
+++ b/frontend/src/typings/ImportListExclusion.ts
@@ -3,6 +3,6 @@ import ModelBase from 'App/ModelBase';
 export default interface ImportListExclusion extends ModelBase {
   foreignId: string;
   movieTitle: string;
-  movieYear: number;
-  type: string;
+  movieYear: number | null;
+  type: 'movie' | 'scene' | 'studio' | 'performer' | 'tag';
 }

--- a/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportListExclusionService.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportExclusions/ImportListExclusionService.cs
@@ -39,6 +39,15 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
 
         public ImportListExclusion AddExclusion(ImportListExclusion exclusion)
         {
+            if (exclusion.Type != ImportExclusionType.Movie &&
+                exclusion.Type != ImportExclusionType.Scene)
+            {
+                if (exclusion.MovieYear == 0)
+                {
+                    exclusion.MovieYear = null;
+                }
+            }
+
             if (_exclusionRepository.IsExcluded(exclusion.ForeignId, exclusion.Type))
             {
                 return _exclusionRepository.GetByForeignId(exclusion.ForeignId);
@@ -101,6 +110,15 @@ namespace NzbDrone.Core.ImportLists.ImportExclusions
 
         public ImportListExclusion Update(ImportListExclusion exclusion)
         {
+            if (exclusion.Type != ImportExclusionType.Movie &&
+                exclusion.Type != ImportExclusionType.Scene)
+            {
+                if (exclusion.MovieYear == 0)
+                {
+                    exclusion.MovieYear = null;
+                }
+            }
+
             int.TryParse(exclusion.ForeignId, out var tmbdId);
             if (exclusion.Type == ImportExclusionType.Scene && tmbdId != 0)
             {

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -781,7 +781,7 @@
   "FollowPerson": "Follow Person",
   "Forecast": "Forecast",
   "ForeignId": "Foreign Id",
-  "ForiegnIdHelpText": "The Foriegn Id of the item to exclude",
+  "ForiegnIdHelpText": "The Foreign ID of the item to exclude",
   "FormatAgeDay": "day",
   "FormatAgeDays": "days",
   "FormatAgeHour": "hour",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1302,7 +1302,7 @@
   "MovieSearchResultsLoadError": "Unable to load results for this movie search. Try again later",
   "MoviesSelectedInterp": "{count} Movie(s) Selected",
   "MovieTitle": "Movie Title",
-  "MovieTitleToExcludeHelpText": "The title of the movie to exclude (can be anything meaningful)",
+  "MovieTitleToExcludeHelpText": "The title of the item to exclude (can be random, except for Tags, which must be the StashDB Tag's Name.)",
   "MovieYear": "Movie Year",
   "MovieYearToExcludeHelpText": "The year of the movie to exclude",
   "MultiLanguage": "Multi-Language",

--- a/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -45,7 +45,7 @@ namespace Whisparr.Api.V3.ImportLists
                 .When(c => c.Type == ImportExclusionType.Movie || c.Type == ImportExclusionType.Scene);
 
             SharedValidator.RuleFor(c => c.MovieYear)
-                .Null()
+                .Must(y => y == null || y == 0)
                 .When(c => c.Type == ImportExclusionType.Studio
                         || c.Type == ImportExclusionType.Performer
                         || c.Type == ImportExclusionType.Tag);

--- a/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListExclusionController.cs
@@ -40,8 +40,15 @@ namespace Whisparr.Api.V3.ImportLists
                 .NotEmpty()
                 .SetValidator(importListExclusionExistsValidator);
 
-            SharedValidator.RuleFor(c => c.MovieTitle).NotEmpty();
-            SharedValidator.RuleFor(c => c.MovieYear).GreaterThan(0);
+            SharedValidator.RuleFor(c => c.MovieYear)
+                .GreaterThan(0)
+                .When(c => c.Type == ImportExclusionType.Movie || c.Type == ImportExclusionType.Scene);
+
+            SharedValidator.RuleFor(c => c.MovieYear)
+                .Null()
+                .When(c => c.Type == ImportExclusionType.Studio
+                        || c.Type == ImportExclusionType.Performer
+                        || c.Type == ImportExclusionType.Tag);
         }
 
         // Endpoint only used by stasharr to show excluded scenes


### PR DESCRIPTION
#### Database Migration
NO

#### Description
-fixed validator to accept to null values for studio, performer, and tag exclusions
-normalize movieYear handling in exclusion editor and prevent invalid years for movie and scene

_Unfinished_

#### Screenshot (if UI related)
It looks the same, just less errors.

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #925 