### PR TITLE
New: Refactor Parsing for JAV

### DIFF
--- a/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
@@ -161,7 +161,7 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
         }
 
         [Test]
-        public void should_not_attempt_to_map_episode_if_series_title_is_blank()
+        public void should_not_attempt_to_map_episode_if_series_title_is_blank_and_no_external_id()
         {
             GivenSpecifications(_pass1, _pass2, _pass3);
             _reports[0].Title = "1937 - Snow White and the Seven Dwarves";
@@ -174,7 +174,9 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             _pass2.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
             _pass3.Verify(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), null), Times.Never());
 
-            results.Should().BeEmpty();
+            results.Should().HaveCount(1);
+            results.First().Approved.Should().BeFalse();
+            results.First().Rejections.Should().Contain(r => r.Reason == "Unable to parse release");
         }
 
         [Test]

--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
@@ -77,19 +77,32 @@ namespace NzbDrone.Core.DecisionEngine
                     // Try to extract external ID from the release title
                     var releaseExternalId = Parser.Parser.ParseExternalId(report.Title);
 
-                    if (parsedEpisodeInfo != null && !parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace())
+                    // If ParseTitle failed but we have an external ID, create a basic ParsedEpisodeInfo
+                    if (parsedEpisodeInfo == null && !releaseExternalId.IsNullOrWhiteSpace())
                     {
-                        // Store the parsed external ID in the parsed info
-                        parsedEpisodeInfo.ExternalId = releaseExternalId;
+                        parsedEpisodeInfo = new ParsedEpisodeInfo
+                        {
+                            ReleaseTitle = report.Title,
+                            Languages = LanguageParser.ParseLanguages(report.Title),
+                            Quality = QualityParser.ParseQuality(report.Title)
+                        };
+                    }
 
+                    // Store the external ID if we have parsedEpisodeInfo
+                    if (parsedEpisodeInfo != null)
+                    {
+                        parsedEpisodeInfo.ExternalId = releaseExternalId;
+                    }
+
+                    // Try to map if we have a series title OR an external ID
+                    if (parsedEpisodeInfo != null && (!parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace() || !releaseExternalId.IsNullOrWhiteSpace()))
+                    {
                         var remoteEpisode = _parsingService.Map(parsedEpisodeInfo, report.TvdbId, searchCriteria);
                         remoteEpisode.Release = report;
 
                         if (remoteEpisode.Series == null)
                         {
-                            var reason = "Unknown Series";
-
-                            decision = new DownloadDecision(remoteEpisode, new Rejection(reason));
+                            decision = new DownloadDecision(remoteEpisode, new Rejection("Unknown Series"));
                         }
                         else if (remoteEpisode.Episodes.Empty())
                         {
@@ -106,61 +119,22 @@ namespace NzbDrone.Core.DecisionEngine
                             decision = GetDecisionForReport(remoteEpisode, searchCriteria);
                         }
                     }
-
-                    if (searchCriteria != null)
+                    else if (decision == null)
                     {
-                        if (parsedEpisodeInfo == null)
+                        // Neither title parsing nor external ID available
+                        var remoteEpisode = new RemoteEpisode
                         {
-                            parsedEpisodeInfo = new ParsedEpisodeInfo
+                            Release = report,
+                            ParsedEpisodeInfo = parsedEpisodeInfo ?? new ParsedEpisodeInfo
                             {
+                                ReleaseTitle = report.Title,
                                 Languages = LanguageParser.ParseLanguages(report.Title),
-                                Quality = QualityParser.ParseQuality(report.Title),
-                                ExternalId = releaseExternalId
-                            };
-                        }
+                                Quality = QualityParser.ParseQuality(report.Title)
+                            },
+                            Languages = parsedEpisodeInfo?.Languages ?? LanguageParser.ParseLanguages(report.Title)
+                        };
 
-                        if (parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace())
-                        {
-                            // Check if we can match by external ID when the search criteria has one
-                            var singleEpisodeCriteria = searchCriteria as SingleEpisodeSearchCriteria;
-                            if (singleEpisodeCriteria != null &&
-                                !singleEpisodeCriteria.ExternalId.IsNullOrWhiteSpace() &&
-                                !releaseExternalId.IsNullOrWhiteSpace() &&
-                                string.Equals(singleEpisodeCriteria.ExternalId, releaseExternalId, StringComparison.OrdinalIgnoreCase))
-                            {
-                                _logger.Debug("Release '{0}' matched by external ID '{1}'", report.Title, releaseExternalId);
-
-                                // Map using external ID - use the search criteria's series and episodes
-                                var remoteEpisode = _parsingService.MapByExternalId(parsedEpisodeInfo, searchCriteria);
-                                remoteEpisode.Release = report;
-
-                                if (remoteEpisode.Series != null && remoteEpisode.Episodes.Any())
-                                {
-                                    _aggregationService.Augment(remoteEpisode);
-
-                                    remoteEpisode.CustomFormats = _formatCalculator.ParseCustomFormat(remoteEpisode, remoteEpisode.Release.Size);
-                                    remoteEpisode.CustomFormatScore = remoteEpisode?.Series?.QualityProfile?.Value.CalculateCustomFormatScore(remoteEpisode.CustomFormats) ?? 0;
-
-                                    remoteEpisode.DownloadAllowed = remoteEpisode.Episodes.Any();
-                                    decision = GetDecisionForReport(remoteEpisode, searchCriteria);
-                                }
-                                else
-                                {
-                                    decision = new DownloadDecision(remoteEpisode, new Rejection("Unable to map release by external ID"));
-                                }
-                            }
-                            else
-                            {
-                                var remoteEpisode = new RemoteEpisode
-                                {
-                                    Release = report,
-                                    ParsedEpisodeInfo = parsedEpisodeInfo,
-                                    Languages = parsedEpisodeInfo.Languages
-                                };
-
-                                decision = new DownloadDecision(remoteEpisode, new Rejection("Unable to parse release"));
-                            }
-                        }
+                        decision = new DownloadDecision(remoteEpisode, new Rejection("Unable to parse release"));
                     }
                 }
                 catch (Exception e)

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -16,7 +16,6 @@ namespace NzbDrone.Core.Parser
         RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, int tvdbId, SearchCriteriaBase searchCriteria = null);
         RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, Series series);
         RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, int seriesId, IEnumerable<int> episodeIds);
-        RemoteEpisode MapByExternalId(ParsedEpisodeInfo parsedEpisodeInfo, SearchCriteriaBase searchCriteria);
         List<Episode> GetEpisodes(ParsedEpisodeInfo parsedEpisodeInfo, Series series, bool sceneSource, SearchCriteriaBase searchCriteria = null);
         ParsedEpisodeInfo ParseSpecialEpisodeTitle(ParsedEpisodeInfo parsedEpisodeInfo, string releaseTitle, int tvdbId, SearchCriteriaBase searchCriteria = null);
         ParsedEpisodeInfo ParseSpecialEpisodeTitle(ParsedEpisodeInfo parsedEpisodeInfo, string releaseTitle, Series series);
@@ -121,30 +120,6 @@ namespace NzbDrone.Core.Parser
                    };
         }
 
-        public RemoteEpisode MapByExternalId(ParsedEpisodeInfo parsedEpisodeInfo, SearchCriteriaBase searchCriteria)
-        {
-            // When mapping by external ID, we trust the search criteria's series and episodes
-            // since the external ID has already been matched in DownloadDecisionMaker
-            var remoteEpisode = new RemoteEpisode
-            {
-                ParsedEpisodeInfo = parsedEpisodeInfo,
-                Series = searchCriteria.Series,
-                Episodes = searchCriteria.Episodes,
-                SeriesMatchType = SeriesMatchType.Id,
-                Languages = parsedEpisodeInfo.Languages
-            };
-
-            if (searchCriteria.Episodes.Any())
-            {
-                var requestedEpisodes = searchCriteria.Episodes.ToDictionaryIgnoreDuplicates(v => v.Id);
-                remoteEpisode.EpisodeRequested = remoteEpisode.Episodes.Any(v => requestedEpisodes.ContainsKey(v.Id));
-            }
-
-            _logger.Debug("Mapped release by external ID to series '{0}' with {1} episode(s)", searchCriteria.Series.Title, searchCriteria.Episodes.Count);
-
-            return remoteEpisode;
-        }
-
         private RemoteEpisode Map(ParsedEpisodeInfo parsedEpisodeInfo, int tvdbId, Series series, SearchCriteriaBase searchCriteria)
         {
             var remoteEpisode = new RemoteEpisode
@@ -205,6 +180,18 @@ namespace NzbDrone.Core.Parser
             if (episodeInfo != null)
             {
                 return new List<Episode> { episodeInfo };
+            }
+
+            // Fallback to external ID lookup if air date matching failed
+            if (!parsedEpisodeInfo.ExternalId.IsNullOrWhiteSpace())
+            {
+                var episode = _episodeService.FindByExternalId(parsedEpisodeInfo.ExternalId);
+
+                if (episode != null && episode.SeriesId == series.Id)
+                {
+                    _logger.Debug("Found episode by external ID {0}", parsedEpisodeInfo.ExternalId);
+                    return new List<Episode> { episode };
+                }
             }
 
             return new List<Episode>();
@@ -272,10 +259,11 @@ namespace NzbDrone.Core.Parser
         private FindSeriesResult FindSeries(ParsedEpisodeInfo parsedEpisodeInfo, int tvdbId, SearchCriteriaBase searchCriteria)
         {
             Series series = null;
+            var hasSeriesTitle = !parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace();
 
             if (searchCriteria != null)
             {
-                if (searchCriteria.Series.CleanTitle == parsedEpisodeInfo.SeriesTitle.CleanSeriesTitle())
+                if (hasSeriesTitle && searchCriteria.Series.CleanTitle == parsedEpisodeInfo.SeriesTitle.CleanSeriesTitle())
                 {
                     return new FindSeriesResult(searchCriteria.Series, SeriesMatchType.Title);
                 }
@@ -294,26 +282,30 @@ namespace NzbDrone.Core.Parser
             }
 
             var matchType = SeriesMatchType.Unknown;
-            series = _seriesService.FindByTitle(parsedEpisodeInfo.SeriesTitle);
 
-            if (series != null)
+            if (hasSeriesTitle)
             {
-                matchType = SeriesMatchType.Title;
+                series = _seriesService.FindByTitle(parsedEpisodeInfo.SeriesTitle);
+
+                if (series != null)
+                {
+                    matchType = SeriesMatchType.Title;
+                }
             }
 
-            if (series == null && parsedEpisodeInfo.SeriesTitleInfo.AllTitles != null)
+            if (series == null && parsedEpisodeInfo.SeriesTitleInfo?.AllTitles != null)
             {
                 series = GetSeriesByAllTitles(parsedEpisodeInfo);
                 matchType = SeriesMatchType.Title;
             }
 
-            if (series == null && parsedEpisodeInfo.SeriesTitleInfo.Year > 0)
+            if (series == null && parsedEpisodeInfo.SeriesTitleInfo?.Year > 0)
             {
                 series = _seriesService.FindByTitle(parsedEpisodeInfo.SeriesTitleInfo.TitleWithoutYear, parsedEpisodeInfo.SeriesTitleInfo.Year);
                 matchType = SeriesMatchType.Title;
             }
 
-            if (series == null)
+            if (series == null && hasSeriesTitle)
             {
                 series = _seriesService.FindByTitleSlug(parsedEpisodeInfo.SeriesTitle);
                 matchType = SeriesMatchType.Title;
@@ -333,6 +325,22 @@ namespace NzbDrone.Core.Parser
                            .Write();
 
                     matchType = SeriesMatchType.Id;
+                }
+            }
+
+            if (series == null && !parsedEpisodeInfo.ExternalId.IsNullOrWhiteSpace())
+            {
+                var episode = _episodeService.FindByExternalId(parsedEpisodeInfo.ExternalId);
+
+                if (episode != null)
+                {
+                    series = _seriesService.GetSeries(episode.SeriesId);
+
+                    if (series != null)
+                    {
+                        _logger.Debug("Found matching series by external ID {0}", parsedEpisodeInfo.ExternalId);
+                        matchType = SeriesMatchType.Id;
+                    }
                 }
             }
 


### PR DESCRIPTION
Previously I had the logic separated so that JAV and regular content used 2 different paths for parsing. Since ClearJav adds dates into the format it was breaking the logic loop. I refactored and condensed it to be a little smarter. Now instead of 2 paths there is only 1 and uses fail checks to determine if we want to external ID check or not. 

Fixes: https://github.com/Whisparr/Whisparr/issues/932 