### PR TITLE
Fix: Remove Duplicate Text in Modal

### DIFF
--- a/frontend/src/Movie/Index/Select/Delete/DeleteMovieModalContent.tsx
+++ b/frontend/src/Movie/Index/Select/Delete/DeleteMovieModalContent.tsx
@@ -110,11 +110,6 @@ function DeleteMovieModalContent(props: DeleteMovieModalContentProps) {
           ? translate('DeleteSelectedMovies')
           : translate('DeleteSelectedMovie')}
       </ModalHeader>
-      <ModalHeader>
-        {movies.length > 1
-          ? translate('DeleteSelectedMovies')
-          : translate('DeleteSelectedMovie')}
-      </ModalHeader>
 
       <ModalBody>
         <div>
@@ -131,11 +126,6 @@ function DeleteMovieModalContent(props: DeleteMovieModalContentProps) {
           </FormGroup>
 
           <FormGroup>
-            <FormLabel>
-              {movies.length > 1
-                ? translate('DeleteMovieFolders')
-                : translate('DeleteMovieFolder')}
-            </FormLabel>
             <FormLabel>
               {movies.length > 1
                 ? translate('DeleteMovieFolders')
@@ -158,13 +148,6 @@ function DeleteMovieModalContent(props: DeleteMovieModalContentProps) {
         </div>
 
         <div className={styles.message}>
-          {deleteFiles
-            ? translate('DeleteMovieFolderCountWithFilesConfirmation', {
-                count: movies.length,
-              })
-            : translate('DeleteMovieFolderCountConfirmation', {
-                count: movies.length,
-              })}
           {deleteFiles
             ? translate('DeleteMovieFolderCountWithFilesConfirmation', {
                 count: movies.length,
@@ -204,15 +187,6 @@ function DeleteMovieModalContent(props: DeleteMovieModalContentProps) {
             );
           })}
         </ul>
-
-        {deleteFiles && !!totalMovieFileCount ? (
-          <div className={styles.deleteFilesMessage}>
-            {translate('DeleteMovieFolderMovieCount', {
-              movieFileCount: totalMovieFileCount,
-              size: formatBytes(totalSizeOnDisk),
-            })}
-          </div>
-        ) : null}
 
         {deleteFiles && !!totalMovieFileCount ? (
           <div className={styles.deleteFilesMessage}>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
-Duplicate content was removed from the multi-select delete modal for the movies page

#### Screenshot (if UI related)
Before: 
<img width="1620" height="679" alt="image" src="https://github.com/user-attachments/assets/0010a12f-7b22-4c36-9ab7-f4b475ec4898" />

After:
<img width="1472" height="467" alt="image" src="https://github.com/user-attachments/assets/6b48e91f-5fa0-4cd1-9711-4009906bec97" />

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR
N/A