### PR TITLE
Fix: Regex Pattern for ReleaseGroupRegex

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -138,5 +138,23 @@ namespace NzbDrone.Core.Test.ParserTests
         {
             Parser.Parser.ParseReleaseGroup(title).Should().BeNull();
         }
+
+        [TestCase("Lubed.25.06.24.Tess.Thompson.XXX.1080p.HEVC.x265.PRT", "PRT")]
+        [TestCase("Series.Title.S01E01.720p.WEB.H264.WRB", "WRB")]
+        [TestCase("Series.Title.S01E01.720p.WEB.H264.KTR", "KTR")]
+        [TestCase("Some.Series.23.05.15.Title.1080p.WEB.x265.ABC", "ABC")]
+        public void should_parse_period_prefixed_release_group(string title, string expected)
+        {
+            Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
+        }
+
+        [TestCase("Series.Title.S01E01.720p.WEB.x264")]
+        [TestCase("Series.Title.S01E01.720p.WEB.hevc")]
+        [TestCase("Series.Title.S01E01.720p.WEB.English")]
+        [TestCase("Series.Title.S01E01.720p.WEB.dvdrip")]
+        public void should_not_parse_codec_or_language_as_period_release_group(string title)
+        {
+            Parser.Parser.ParseReleaseGroup(title).Should().BeNull();
+        }
     }
 }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -221,7 +221,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex CleanQualityBracketsRegex = new Regex(@"\[[a-z0-9 ._-]+\]$",
                                                                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex ReleaseGroupRegex = new Regex(@"(-|.)(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|576p|720p|1080p|2160p)))(?<!(?:WEB-DL|Blu-Ray|480p|576p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|-ES|-EN|-CAT|[ ._]\d{4}-\d{2}|-\d{2})(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
+        private static readonly Regex ReleaseGroupRegex = new Regex(@"[.-](?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|576p|720p|1080p|2160p)))(?<!(?:WEB-DL|Blu-Ray|480p|576p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|-ES|-EN|-CAT|[ ._]\d{4}-\d{2}|-\d{2})(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex InvalidReleaseGroupRegex = new Regex(@"^([se]\d+|[0-9a-f]{8})$", RegexOptions.IgnoreCase | RegexOptions.Compiled);

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -221,7 +221,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex CleanQualityBracketsRegex = new Regex(@"\[[a-z0-9 ._-]+\]$",
                                                                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex ReleaseGroupRegex = new Regex(@"[.-](?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|576p|720p|1080p|2160p)))(?<!(?:WEB-DL|Blu-Ray|480p|576p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|-ES|-EN|-CAT|[ ._]\d{4}-\d{2}|-\d{2})(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
+        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|576p|720p|1080p|2160p)))(?<!(?:WEB-DL|Blu-Ray|480p|576p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|-ES|-EN|-CAT|[ ._]\d{4}-\d{2}|-\d{2})(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex InvalidReleaseGroupRegex = new Regex(@"^([se]\d+|[0-9a-f]{8})$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -599,7 +599,71 @@ namespace NzbDrone.Core.Parser
                 return group;
             }
 
+            // Fallback: check for period-prefixed release group at end (e.g., ".PRT")
+            var lastDotIndex = title.LastIndexOf('.');
+            if (lastDotIndex > 0 && lastDotIndex < title.Length - 1)
+            {
+                var candidate = title.Substring(lastDotIndex + 1);
+                if (IsValidPeriodReleaseGroup(candidate))
+                {
+                    return candidate;
+                }
+            }
+
             return null;
+        }
+
+        private static readonly HashSet<string> InvalidPeriodReleaseGroupTerms = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Video codecs
+            "x264", "x265", "h264", "h265", "hevc", "avc", "xvid", "divx", "vp9", "av1",
+
+            // Audio codecs
+            "aac", "ac3", "dts", "flac", "mp3", "eac3", "truehd", "atmos", "opus",
+
+            // Rip types / sources
+            "dvdrip", "bdrip", "brrip", "webrip", "hdrip", "hdtv", "pdtv", "dsr", "dvdscr",
+
+            // Common languages
+            "english", "spanish", "french", "german", "italian", "portuguese",
+            "russian", "japanese", "chinese", "korean", "dutch", "swedish",
+            "norwegian", "danish", "finnish", "polish", "czech", "hindi", "arabic", "turkish"
+        };
+
+        private static bool IsValidPeriodReleaseGroup(string candidate)
+        {
+            // Must be 2-8 characters
+            if (candidate.Length < 2 || candidate.Length > 8)
+            {
+                return false;
+            }
+
+            // Must be alphanumeric only
+            if (!candidate.All(c => char.IsLetterOrDigit(c)))
+            {
+                return false;
+            }
+
+            // Exclude known non-release-group terms
+            if (InvalidPeriodReleaseGroupTerms.Contains(candidate))
+            {
+                return false;
+            }
+
+            // Exclude hex-like strings (potential hashes) - 8+ hex chars
+            if (candidate.Length >= 8 && candidate.All(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')))
+            {
+                return false;
+            }
+
+            // Exclude pure numbers
+            if (candidate.All(char.IsDigit))
+            {
+                return false;
+            }
+
+            // Passed all checks
+            return true;
         }
 
         public static string RemoveFileExtension(string title)

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -221,7 +221,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex CleanQualityBracketsRegex = new Regex(@"\[[a-z0-9 ._-]+\]$",
                                                                    RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-        private static readonly Regex ReleaseGroupRegex = new Regex(@"-(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|576p|720p|1080p|2160p)))(?<!(?:WEB-DL|Blu-Ray|480p|576p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|-ES|-EN|-CAT|[ ._]\d{4}-\d{2}|-\d{2})(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
+        private static readonly Regex ReleaseGroupRegex = new Regex(@"(-|.)(?<releasegroup>[a-z0-9]+(?<part2>-[a-z0-9]+)?(?!.+?(?:480p|576p|720p|1080p|2160p)))(?<!(?:WEB-DL|Blu-Ray|480p|576p|720p|1080p|2160p|DTS-HD|DTS-X|DTS-MA|DTS-ES|-ES|-EN|-CAT|[ ._]\d{4}-\d{2}|-\d{2})(?:\k<part2>)?)(?:\b|[-._ ]|$)|[-._ ]\[(?<releasegroup>[a-z0-9]+)\]$",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex InvalidReleaseGroupRegex = new Regex(@"^([se]\d+|[0-9a-f]{8})$", RegexOptions.IgnoreCase | RegexOptions.Compiled);


### PR DESCRIPTION
adding support for .ReleaseGroup in the regex parser. This tiny change should not break anything cause its just an optional lookup in the regex and will add for .ReleaseGroup for example .WRB, .KTR, .PRT that can happen.

Cause this was not supported before, matching anything with a . as a release group would just make it fail and not let it be found and it will not apply the custom format as a release group.

Please make any changes if needed. Have not tested it but i see no reason why it shouldn't just work fine.

#### Issues Fixed or Closed by this PR
Did not make a github issue on it yet! mentioned it earlier [today on discord](https://discord.com/channels/957516730727563285/1461555604748505362/1461771902220632249) and before on discord way back.
