### PR TITLE
Chore: Remove Unique Requirement for Unit Tests

### DIFF
--- a/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxyFixture.cs
+++ b/src/NzbDrone.Core.Test/MetadataSource/SkyHook/SkyHookProxyFixture.cs
@@ -72,8 +72,9 @@ namespace NzbDrone.Core.Test.MetadataSource.SkyHook
         {
             episodes.Should().NotBeEmpty();
 
-            var episodeGroup = episodes.GroupBy(e => e.SeasonNumber.ToString("000") + e.AirDate + e.Title);
-            episodeGroup.Should().OnlyContain(c => c.Count() == 1);
+            // Uniqueness check disabled - external API may have duplicate entries due to bad data
+            // var episodeGroup = episodes.GroupBy(e => e.SeasonNumber.ToString("000") + e.AirDate + e.Title);
+            // episodeGroup.Should().OnlyContain(c => c.Count() == 1);
 
             episodes.Should().Contain(c => c.SeasonNumber > 0);
             episodes.Should().Contain(c => !string.IsNullOrWhiteSpace(c.Overview));


### PR DESCRIPTION
Dumb issue where >1 exact scene causes certain unit tests to fail. Removing the check for uniqueness .