### PR TITLE
Chore: Sonarr Upstream Sync - Batch 4 (July 2023)

### DIFF
--- a/src/NzbDrone.Core/Datastore/Migration/017_import_exclusion_type.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/017_import_exclusion_type.cs
@@ -1,0 +1,18 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(17)]
+    public class import_exclusion_type : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            // SQLite handles the conversion automatically
+            IfDatabase("sqlite").Alter.Table("ImportListExclusions").AlterColumn("TvdbId").AsInt32();
+
+            // PostgreSQL requires explicit USING clause for type conversion
+            IfDatabase("postgres").Execute.Sql("ALTER TABLE \"ImportListExclusions\" ALTER COLUMN \"TvdbId\" TYPE integer USING \"TvdbId\"::integer");
+        }
+    }
+}


### PR DESCRIPTION
Applied Commits

  - Sonarr/Sonarr@af8c67a24 - Fixed: Correct typing for ImportListExclusions TvdbId column

Skipped Commits

  - Sonarr/Sonarr@aa2b00316 - ToJson overload (already in Whisparr)
  - Sonarr/Sonarr@b6f3bcb30 - HDBits ContentSummary (already in Whisparr)
  - Sonarr/Sonarr@a6f2db913 - Custom Format Score in queue (already in Whisparr with better tooltip implementation)
  - Sonarr/Sonarr@3a9182b6a - Discord Custom Format fields (already in Whisparr)
  - Sonarr/Sonarr@f6ae9fd6c - Download Client Tags (already in Whisparr as migration 010)
  - Sonarr/Sonarr@85e285598 - Parse UI (already in Whisparr)
  - Sonarr/Sonarr@e7bc14508 - Kodi Episode Metadata image option (already in Whisparr)
  - Sonarr/Sonarr@a77ef187a - Nyaa search fix (Nyaa indexer removed in Whisparr)
  - Sonarr/Sonarr@45336389e - BTN search fix (BTN indexer removed in Whisparr)
  - Sonarr/Sonarr@dce6923b0 - Anime title parsing (not applicable)
  - Sonarr/Sonarr@3f0268b79 - Script Import additional info (complex conflicts, needs separate implementation)
  - Translation updates and various other commits already in Whisparr

Whisparr Adaptations:

  - Migration renumbered from 192 to 017 to match Whisparr's migration sequence
  
  NOTE: April and May were checked but had nothing worth pulling in or was already applied.