### PR TITLE
New: GitHub actions build

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,187 @@
+name: Build Backend
+description: Builds the backend and packages it
+
+inputs:
+  branch:
+    description: "Branch name for this build"
+    required: true
+  version:
+    description: "Version number to build"
+    required: true
+  framework:
+    description: ".net framework used for the build"
+    required: true
+  runtime:
+    description: "Run time to build for"
+    required: true
+  package_tests:
+    description: "True if tests should be packaged for later testing steps"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '6.0.x'
+
+    - name: Setup Environment Variables
+      id: variables
+      shell: bash
+      run: |
+        echo "WHISPARR_VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
+        echo "BRANCH=${{ inputs.branch }}" >> "$GITHUB_ENV"
+        echo "WHISPARR_ASSEMBLY_VERSION=${{ env.WHISPARR_ASSEMBLY_VERSION }}" >> "$GITHUB_ENV"
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          echo "NUGET_PACKAGES=D:\nuget\packages" >> "$GITHUB_ENV"
+        fi
+
+    - name: Enable Extra Platforms In SDK
+      if: ${{ inputs.runtime == 'freebsd-x64' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        DOTNET_SDK_VERSION=$(dotnet --version)
+        SDK_DIR="${DOTNET_ROOT:-/usr/share/dotnet}/sdk/${DOTNET_SDK_VERSION}"
+        if [ -f "$SDK_DIR/Microsoft.NETCoreSdk.BundledVersions.props" ]; then
+          BUNDLEDVERSIONS="$SDK_DIR/Microsoft.NETCoreSdk.BundledVersions.props"
+          echo "Patching $BUNDLEDVERSIONS"
+          if grep -q freebsd-x64 "$BUNDLEDVERSIONS"; then
+            echo "Extra platforms already enabled"
+          else
+            echo "Enabling extra platform support"
+            sed -i.ORI 's/osx-x64/osx-x64;freebsd-x64/' "$BUNDLEDVERSIONS"
+          fi
+        else
+          echo "Warning: expected SDK file not found at $SDK_DIR; searching SDK folders"
+          for d in ${DOTNET_ROOT:-/usr/share/dotnet}/sdk/*; do
+            if [ -f "$d/Microsoft.NETCoreSdk.BundledVersions.props" ]; then
+              echo "Patching $d/Microsoft.NETCoreSdk.BundledVersions.props"
+              sed -i.ORI 's/osx-x64/osx-x64;freebsd-x64/' "$d/Microsoft.NETCoreSdk.BundledVersions.props" || true
+            fi
+          done
+        fi
+        if grep -qv freebsd-x64 src/Directory.Build.props; then
+          sed -i'' -e "s^<RuntimeIdentifiers>\(.*\)</RuntimeIdentifiers>^<RuntimeIdentifiers>\1;freebsd-x64</RuntimeIdentifiers>^g" src/Directory.Build.props
+        fi
+
+    - name: Update Version Number
+      shell: bash
+      run: |
+        if [ "$WHISPARR_VERSION" != "" ]; then
+          echo "Updating version info to: $WHISPARR_VERSION"
+          sed -i'' -e "s/<AssemblyVersion>[0-9.*]\+<\/AssemblyVersion>/<AssemblyVersion>$WHISPARR_ASSEMBLY_VERSION<\/AssemblyVersion>/g" src/Directory.Build.props
+          sed -i'' -e "s/<AssemblyFileVersion>[0-9.*]\+<\/AssemblyFileVersion>/<AssemblyFileVersion>$WHISPARR_ASSEMBLY_VERSION<\/AssemblyFileVersion>/g" src/Directory.Build.props
+          sed -i'' -e "s/<AssemblyInformationalVersion>.*<\/AssemblyInformationalVersion>/<AssemblyInformationalVersion>$WHISPARR_VERSION<\/AssemblyInformationalVersion>/g" src/Directory.Build.props
+          sed -i'' -e "s/<AssemblyConfiguration>[\$()A-Za-z-]\+<\/AssemblyConfiguration>/<AssemblyConfiguration>${BRANCH}<\/AssemblyConfiguration>/g" src/Directory.Build.props
+          sed -i'' -e "s/<string>10.0.0.0<\/string>/<string>$WHISPARR_VERSION<\/string>/g" distribution/macOS/Whisparr.app/Contents/Info.plist
+        fi
+
+    - name: Build Backend
+      shell: bash
+      run: |
+        runtime="${{ inputs.runtime }}"
+        platform=Windows
+        slnFile=src/Whisparr.sln
+        targetingWindows=false
+        IFS='-' read -ra SPLIT <<< "$runtime"
+        if [ "${SPLIT[0]}" == "win" ]; then
+          platform=Windows
+          targetingWindows=true
+        else
+          platform=Posix
+        fi
+        rm -rf _output
+        rm -rf _tests
+        echo "Building Whisparr for $runtime, Platform: $platform"
+        SELF_CONTAINED=true
+        MSBUILD_EXTRA=""
+        if [[ "${runtime}" == freebsd* ]]; then
+          echo "FreeBSD target detected - using framework-dependent publish to avoid missing apphost"
+          SELF_CONTAINED=false
+          MSBUILD_EXTRA="-p:UseAppHost=false"
+        fi
+        dotnet msbuild -restore $slnFile -p:SelfContained=${SELF_CONTAINED} -p:Configuration=Release -p:Platform=$platform -p:RuntimeIdentifiers=$runtime -p:EnableWindowsTargeting=true $MSBUILD_EXTRA -t:PublishAllRids
+
+    - name: Package
+      shell: bash
+      run: |
+        framework="${{ inputs.framework }}"
+        runtime="${{ inputs.runtime }}"
+        IFS='-' read -ra SPLIT <<< "$runtime"
+        case "${SPLIT[0]}" in
+          linux|freebsd*)
+            folder=_artifacts/$runtime/$framework/Whisparr
+            echo "Packaging files"
+            rm -rf $folder
+            mkdir -p $folder
+            cp -r _output/$framework/$runtime/publish/* $folder
+            cp -r _output/Whisparr.Update/$framework/$runtime/publish $folder/Whisparr.Update
+            cp LICENSE $folder
+            echo "Removing Service helpers"
+            rm -f $folder/ServiceUninstall.*
+            rm -f $folder/ServiceInstall.*
+            echo "Removing Whisparr.Windows"
+            rm -f $folder/Whisparr.Windows.*
+            echo "Adding Whisparr.Mono to UpdatePackage"
+            cp $folder/Whisparr.Mono.* $folder/Whisparr.Update 2>/dev/null || true
+            cp $folder/Mono.Posix.NETStandard.* $folder/Whisparr.Update 2>/dev/null || true
+            cp $folder/libMonoPosixHelper.* $folder/Whisparr.Update 2>/dev/null || true
+            ;;
+          win)
+            folder=_artifacts/$runtime/$framework/Whisparr
+            echo "Packaging files"
+            rm -rf $folder
+            mkdir -p $folder
+            cp -r _output/$framework/$runtime/publish/* $folder
+            cp -r _output/Whisparr.Update/$framework/$runtime/publish $folder/Whisparr.Update
+            cp LICENSE $folder
+            cp -r _output/$framework-windows/$runtime/publish/* $folder 2>/dev/null || true
+            echo "Removing Whisparr.Mono"
+            rm -f $folder/Whisparr.Mono.*
+            rm -f $folder/Mono.Posix.NETStandard.*
+            rm -f $folder/libMonoPosixHelper.*
+            echo "Adding Whisparr.Windows to UpdatePackage"
+            cp $folder/Whisparr.Windows.* $folder/Whisparr.Update 2>/dev/null || true
+            ;;
+          osx)
+            folder=_artifacts/$runtime/$framework/Whisparr
+            echo "Packaging files"
+            rm -rf $folder
+            mkdir -p $folder
+            cp -r _output/$framework/$runtime/publish/* $folder
+            cp -r _output/Whisparr.Update/$framework/$runtime/publish $folder/Whisparr.Update
+            cp LICENSE $folder
+            echo "Removing Service helpers"
+            rm -f $folder/ServiceUninstall.*
+            rm -f $folder/ServiceInstall.*
+            echo "Removing Whisparr.Windows"
+            rm -f $folder/Whisparr.Windows.*
+            echo "Adding Whisparr.Mono to UpdatePackage"
+            cp $folder/Whisparr.Mono.* $folder/Whisparr.Update 2>/dev/null || true
+            cp $folder/Mono.Posix.NETStandard.* $folder/Whisparr.Update 2>/dev/null || true
+            cp $folder/libMonoPosixHelper.* $folder/Whisparr.Update 2>/dev/null || true
+            ;;
+        esac
+
+    - name: Package Tests
+      if: ${{ inputs.package_tests }}
+      shell: bash
+      run: |
+        framework="${{ inputs.framework }}"
+        runtime="${{ inputs.runtime }}"
+        cp scripts/test.sh "_tests/$framework/$runtime/publish" 2>/dev/null || true
+        rm -f _tests/$framework/$runtime/*.log.config
+
+    - name: Upload Test Artifacts
+      if: ${{ inputs.package_tests }}
+      uses: ./.github/actions/publish-test-artifact
+      with:
+        framework: ${{ inputs.framework }}
+        runtime: ${{ inputs.runtime }}
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-${{ inputs.runtime }}
+        path: _artifacts/**/*

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -1,0 +1,79 @@
+name: Package
+description: Packages binaries for deployment
+
+inputs:
+  runtime:
+    description: "Binary runtime"
+    required: true
+  framework:
+    description: ".net framework"
+    required: true
+  artifact:
+    description: "Binary artifact"
+    required: true
+  branch:
+    description: "Git branch used for this build"
+    required: true
+  major_version:
+    description: "Whisparr major version"
+    required: true
+  version:
+    description: "Whisparr version"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact }}
+        path: _output
+
+    - name: Download UI Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: build_ui
+        path: _output/UI
+
+    - name: Configure Environment Variables
+      shell: bash
+      run: |
+        BRANCH_NAME="${{ inputs.branch }}"
+        SAFE_BRANCH_NAME="${BRANCH_NAME//\//-}"
+        echo "FRAMEWORK=${{ inputs.framework }}" >> "$GITHUB_ENV"
+        echo "BRANCH=$BRANCH_NAME" >> "$GITHUB_ENV"
+        echo "SAFE_BRANCH=$SAFE_BRANCH_NAME" >> "$GITHUB_ENV"
+        echo "WHISPARR_MAJOR_VERSION=${{ inputs.major_version }}" >> "$GITHUB_ENV"
+        echo "WHISPARR_VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
+
+    - name: Create Packages
+      shell: bash
+      run: bash $GITHUB_ACTION_PATH/package.sh
+
+    - name: Create Windows Installer (x64)
+      if: ${{ inputs.runtime == 'win-x64' }}
+      working-directory: distribution/windows/setup
+      shell: cmd
+      run: |
+        SET RUNTIME=win-x64
+        build.bat
+
+    - name: Create Windows Installer (x86)
+      if: ${{ inputs.runtime == 'win-x86' }}
+      working-directory: distribution/windows/setup
+      shell: cmd
+      run: |
+        SET RUNTIME=win-x86
+        build.bat
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-${{ inputs.runtime }}
+        compression-level: 0
+        if-no-files-found: error
+        path: |
+          _artifacts/*.exe
+          _artifacts/*.tar.gz
+          _artifacts/*.zip

--- a/.github/actions/package/package.sh
+++ b/.github/actions/package/package.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+outputFolder=_output
+artifactsFolder=_artifacts
+uiFolder="$outputFolder/UI"
+framework="${FRAMEWORK:=net6.0}"
+
+# Sanitize BRANCH for safe file names (replace / with _)
+safeBranch="${BRANCH//\//_}"
+export SAFE_BRANCH="$safeBranch"
+
+rm -rf $artifactsFolder
+mkdir $artifactsFolder
+
+for runtime in _output/*
+do
+  name="${runtime##*/}"
+  folderName="$runtime/$framework"
+  whisparrFolder="$folderName/Whisparr"
+  archiveName="Whisparr.$safeBranch.$WHISPARR_VERSION.$name"
+
+  if [[ "$name" == 'UI' ]]; then
+    continue
+  fi
+
+  echo "Creating package for $name"
+
+  echo "Copying UI"
+  cp -r $uiFolder $whisparrFolder
+
+  echo "Setting permissions"
+  find $whisparrFolder -name "ffprobe" -exec chmod a+x {} \;
+  find $whisparrFolder -name "Whisparr" -exec chmod a+x {} \;
+  find $whisparrFolder -name "Whisparr.Update" -exec chmod a+x {} \;
+
+  if [[ "$name" == *"osx"* ]]; then
+    echo "Creating macOS package"
+
+    packageName="$name-app"
+    packageFolder="$outputFolder/$packageName"
+
+    rm -rf $packageFolder
+    mkdir $packageFolder
+
+    cp -r distribution/macOS/Whisparr.app $packageFolder
+    mkdir -p $packageFolder/Whisparr.app/Contents/MacOS
+
+    echo "Copying Binaries"
+    cp -r $whisparrFolder/* $packageFolder/Whisparr.app/Contents/MacOS
+
+    echo "Removing Update Folder"
+    rm -r $packageFolder/Whisparr.app/Contents/MacOS/Whisparr.Update
+
+    echo "Packaging macOS app Artifact"
+    (cd $packageFolder; zip -rq "../../$artifactsFolder/$archiveName-app.zip" ./Whisparr.app)
+  fi
+
+  echo "Packaging Artifact"
+  if [[ "$name" == *"linux"* ]] || [[ "$name" == *"osx"* ]] || [[ "$name" == *"freebsd"* ]]; then
+    tar -zcf "./$artifactsFolder/$archiveName.tar.gz" -C $folderName Whisparr
+  fi
+
+  if [[ "$name" == *"win"* ]]; then
+    if [ "$RUNNER_OS" = "Windows" ]
+      then
+        (cd $folderName; 7z a -tzip "../../../$artifactsFolder/$archiveName.zip" ./Whisparr)
+      else
+        (cd $folderName; zip -rq "../../../$artifactsFolder/$archiveName.zip" ./Whisparr)
+    fi
+  fi
+done

--- a/.github/actions/package/package.sh
+++ b/.github/actions/package/package.sh
@@ -17,7 +17,7 @@ do
   name="${runtime##*/}"
   folderName="$runtime/$framework"
   whisparrFolder="$folderName/Whisparr"
-  archiveName="Whisparr.$safeBranch.$WHISPARR_VERSION.$name"
+  archiveName="Whisparr.$WHISPARR_VERSION.$name"
 
   if [[ "$name" == 'UI' ]]; then
     continue

--- a/.github/actions/publish-test-artifact/action.yml
+++ b/.github/actions/publish-test-artifact/action.yml
@@ -1,0 +1,18 @@
+name: Publish Test Artifact
+description: Publishes a test artifact
+
+inputs:
+  framework:
+    description: '.net framework'
+    required: true
+  runtime:
+    description: '.net runtime'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/upload-artifact@v4
+      with:
+        name: tests-${{ inputs.runtime }}
+        path: _tests/${{ inputs.framework }}/${{ inputs.runtime }}/publish/**/*

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,0 +1,112 @@
+name: Test
+description: Runs unit/integration tests
+
+inputs:
+  use_postgres:
+    description: 'Whether postgres should be used for the database'
+  postgres-version:
+    description: 'Which postgres version should be used for the database'
+  os:
+    description: 'OS that the tests are running on'
+    required: true
+  artifact:
+    description: 'Test binary artifact'
+    required: true
+  pattern:
+    description: 'Pattern for DLLs'
+    required: true
+  filter:
+    description: 'Filter for tests'
+    required: true
+  integration_tests:
+    description: 'True if running integration tests'
+  binary_artifact:
+    description: 'Binary artifact for integration tests'
+  binary_path:
+    description: 'Path within binary artifact for integration tests'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '6.0.x'
+
+    - name: Setup Postgres
+      if: ${{ inputs.use_postgres }}
+      uses: ikalnytskyi/action-setup-postgres@v6
+      with:
+        postgres-version: ${{ inputs.postgres-version }}
+
+    - name: Setup Test Variables
+      shell: bash
+      run: |
+        echo "RESULTS_NAME=${{ inputs.integration_tests && 'integration-' || 'unit-' }}${{ inputs.artifact }}${{ inputs.use_postgres && '-postgres' || '' }}${{ inputs.use_postgres && inputs.postgres-version || '' }}" >> "$GITHUB_ENV"
+
+    - name: Setup Postgres Environment Variables
+      if: ${{ inputs.use_postgres }}
+      shell: bash
+      run: |
+        echo "Whisparr__Postgres__Host=localhost" >> "$GITHUB_ENV"
+        echo "Whisparr__Postgres__Port=5432" >> "$GITHUB_ENV"
+        echo "Whisparr__Postgres__User=postgres" >> "$GITHUB_ENV"
+        echo "Whisparr__Postgres__Password=postgres" >> "$GITHUB_ENV"
+
+    - name: Download Tests Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact }}
+        path: _tests
+
+    - name: Download Binary Artifact
+      if: ${{ inputs.integration_tests }}
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.binary_artifact }}
+        path: _output
+
+    - name: Set up binary artifact
+      if: ${{ inputs.binary_path != '' }}
+      shell: bash
+      run: |
+        mv ./_output/${{inputs.binary_path}} ./bin
+        echo "Moved Whisparr binary folder to ./bin."
+        ls -la ./bin/
+        if [ -f "./bin/Whisparr" ]; then
+          echo "./bin/Whisparr executable exists."
+        else
+          echo "ERROR: ./bin/Whisparr does not exist!" >&2
+          exit 1
+        fi
+
+    - name: Make executable
+      if: startsWith(inputs.os, 'windows') != true
+      shell: bash
+      run: chmod +x ./_tests/Whisparr.Test.Dummy && chmod +x ./_tests/ffprobe
+
+    - name: Make Whisparr binary executable and verify
+      if: ${{ inputs.integration_tests && !startsWith(inputs.os, 'windows') }}
+      shell: bash
+      run: |
+        chmod +x ./bin/Whisparr
+        chmod +x ./bin/ffprobe
+        if [ -x "./bin/Whisparr" ]; then
+          echo "./bin/Whisparr is executable."
+        else
+          echo "ERROR: ./bin/Whisparr is NOT executable!" >&2
+          exit 1
+        fi
+        ls -l ./bin/Whisparr ./bin/ffprobe
+
+    - name: Run tests
+      shell: bash
+      run: |
+        dotnet test ./_tests/Whisparr.*.Test.dll --filter "${{ inputs.filter }}" --logger "trx;LogFileName=${{ env.RESULTS_NAME }}.trx" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+
+    - name: Upload Test Results
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: results-${{ env.RESULTS_NAME }}
+        path: TestResults/*.trx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ env:
   FRAMEWORK: net6.0
   RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   WHISPARR_MAJOR_VERSION: 2
-  VERSION: 2.0.1
-  WHISPARR_ASSEMBLY_VERSION: 2.0.1.${{ github.run_number }}
+  VERSION: 2.1.0
+  WHISPARR_ASSEMBLY_VERSION: 2.1.0.${{ github.run_number }}
 
 jobs:
   prepare:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,245 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - v2-develop
+      - v2
+    paths-ignore:
+      - "src/Whisparr.Api.*/openapi.json"
+  pull_request:
+    branches:
+      - v2-develop
+      - v2
+    paths-ignore:
+      - "src/NzbDrone.Core/Localization/Core/**"
+      - "src/Whisparr.Api.*/openapi.json"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  FRAMEWORK: net6.0
+  RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  WHISPARR_MAJOR_VERSION: 2
+  VERSION: 2.0.1
+  WHISPARR_ASSEMBLY_VERSION: 2.0.1.${{ github.run_number }}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      framework: ${{ steps.variables.outputs.framework }}
+      major_version: ${{ steps.variables.outputs.major_version }}
+      version: ${{ steps.variables.outputs.version }}
+      branch: ${{ steps.variables.outputs.branch }}
+    steps:
+      - name: Setup Environment Variables
+        id: variables
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_name }}" == "v2-develop" ]]; then
+            SEMVER_LABEL="develop"
+          else
+            SEMVER_LABEL="release"
+          fi
+          echo "framework=${{ env.FRAMEWORK }}" >> "$GITHUB_OUTPUT"
+          echo "major_version=${{ env.WHISPARR_MAJOR_VERSION }}" >> "$GITHUB_OUTPUT"
+          echo "version=${{ env.VERSION }}-${SEMVER_LABEL}.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "branch=${RAW_BRANCH_NAME//\//-}" >> "$GITHUB_OUTPUT"
+
+  backend:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runtime: freebsd-x64
+            package_tests: false
+            os: ubuntu-latest
+          - runtime: linux-arm
+            package_tests: false
+            os: ubuntu-latest
+          - runtime: linux-arm64
+            package_tests: false
+            os: ubuntu-latest
+          - runtime: linux-musl-arm64
+            package_tests: false
+            os: ubuntu-latest
+          - runtime: linux-musl-x64
+            package_tests: false
+            os: ubuntu-latest
+          - runtime: linux-x64
+            package_tests: true
+            os: ubuntu-latest
+          - runtime: osx-arm64
+            package_tests: true
+            os: ubuntu-latest
+          - runtime: osx-x64
+            package_tests: false
+            os: ubuntu-latest
+          - runtime: win-x64
+            package_tests: true
+            os: ubuntu-latest
+          - runtime: win-x86
+            package_tests: false
+            os: ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          branch: ${{ needs.prepare.outputs.branch }}
+          version: ${{ needs.prepare.outputs.version }}
+          framework: ${{ needs.prepare.outputs.framework }}
+          runtime: ${{ matrix.runtime }}
+          package_tests: ${{ matrix.package_tests }}
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Yarn Install
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Build
+        run: yarn build --env production
+
+      - name: Publish UI Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_ui
+          path: _output/UI/**/*
+
+  unit_test:
+    needs: backend
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            artifact: tests-linux-x64
+            binary_artifact: build-linux-x64
+            filter: TestCategory!=ManualTest&TestCategory!=WINDOWS&TestCategory!=IntegrationTest&TestCategory!=AutomationTest
+          - os: macos-latest
+            artifact: tests-osx-arm64
+            binary_artifact: build-osx-arm64
+            filter: TestCategory!=ManualTest&TestCategory!=WINDOWS&TestCategory!=IntegrationTest&TestCategory!=AutomationTest
+          - os: windows-latest
+            artifact: tests-win-x64
+            binary_artifact: build-win-x64
+            filter: TestCategory!=ManualTest&TestCategory!=LINUX&TestCategory!=IntegrationTest&TestCategory!=AutomationTest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Test
+        uses: ./.github/actions/test
+        with:
+          os: ${{ matrix.os }}
+          artifact: ${{ matrix.artifact }}
+          pattern: Whisparr.*.Test.dll
+          filter: ${{ matrix.filter }}
+
+  unit_test_postgres:
+    needs: backend
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        postgres-version: [14, 15, 16]
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Test
+        uses: ./.github/actions/test
+        with:
+          os: ubuntu-latest
+          artifact: tests-linux-x64
+          pattern: Whisparr.*.Test.dll
+          filter: TestCategory!=ManualTest&TestCategory!=WINDOWS&TestCategory!=IntegrationTest&TestCategory!=AutomationTest
+          use_postgres: true
+          postgres-version: ${{ matrix.postgres-version }}
+
+  integration_test:
+    needs: [prepare, backend]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            artifact: tests-linux-x64
+            filter: TestCategory!=ManualTest&TestCategory!=WINDOWS&TestCategory=IntegrationTest
+            binary_artifact: build-linux-x64
+            binary_path: linux-x64/${{ needs.prepare.outputs.framework }}/Whisparr
+          - os: macos-latest
+            artifact: tests-osx-arm64
+            filter: TestCategory!=ManualTest&TestCategory!=WINDOWS&TestCategory=IntegrationTest
+            binary_artifact: build-osx-arm64
+            binary_path: osx-arm64/${{ needs.prepare.outputs.framework }}/Whisparr
+          - os: windows-latest
+            artifact: tests-win-x64
+            filter: TestCategory!=ManualTest&TestCategory!=LINUX&TestCategory=IntegrationTest
+            binary_artifact: build-win-x64
+            binary_path: win-x64/${{ needs.prepare.outputs.framework }}/Whisparr
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Test
+        uses: ./.github/actions/test
+        with:
+          os: ${{ matrix.os }}
+          artifact: ${{ matrix.artifact }}
+          pattern: Whisparr.*.Test.dll
+          filter: ${{ matrix.filter }}
+          integration_tests: true
+          binary_artifact: ${{ matrix.binary_artifact }}
+          binary_path: ${{ matrix.binary_path }}
+
+  deploy:
+    needs:
+      [
+        prepare,
+        backend,
+        frontend,
+        unit_test,
+        unit_test_postgres,
+        integration_test,
+      ]
+    secrets: inherit
+    uses: ./.github/workflows/deploy.yml
+    with:
+      framework: ${{ needs.prepare.outputs.framework }}
+      branch: ${{ needs.prepare.outputs.branch }}
+      major_version: ${{ needs.prepare.outputs.major_version }}
+      version: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,128 @@
+name: Deploy
+
+on:
+  workflow_call:
+    inputs:
+      framework:
+        description: ".net framework"
+        type: string
+        required: true
+      branch:
+        description: "Git branch used for this build"
+        type: string
+        required: true
+      major_version:
+        description: "Whisparr major version"
+        type: string
+        required: true
+      version:
+        description: "Whisparr version"
+        type: string
+        required: true
+
+jobs:
+  package:
+    strategy:
+      matrix:
+        include:
+          - runtime: freebsd-x64
+            os: ubuntu-latest
+          - runtime: linux-arm
+            os: ubuntu-latest
+          - runtime: linux-arm64
+            os: ubuntu-latest
+          - runtime: linux-musl-arm64
+            os: ubuntu-latest
+          - runtime: linux-musl-x64
+            os: ubuntu-latest
+          - runtime: linux-x64
+            os: ubuntu-latest
+          - runtime: osx-arm64
+            os: ubuntu-latest
+          - runtime: osx-x64
+            os: ubuntu-latest
+          - runtime: win-x64
+            os: windows-latest
+          - runtime: win-x86
+            os: windows-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Package
+        uses: ./.github/actions/package
+        with:
+          framework: ${{ inputs.framework }}
+          runtime: ${{ matrix.runtime }}
+          artifact: build-${{ matrix.runtime }}
+          branch: ${{ inputs.branch }}
+          major_version: ${{ inputs.major_version }}
+          version: ${{ inputs.version }}
+
+  release:
+    if: ${{ github.ref_name == 'v2-develop' || github.ref_name == 'v2' }}
+    needs: package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: _artifacts
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Get Previous Release
+        id: previous-release
+        uses: cardinalby/git-get-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          latest: true
+          prerelease: ${{ inputs.branch != 'v2' }}
+
+      - name: Enable GPG signing
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_commit_gpgsign: true
+          git_user_signingkey: true
+          git_tag_gpgsign: true
+
+      - name: Create signed tag
+        run: |
+          git tag -s v${{ inputs.version }} -m "Release v${{ inputs.version }}"
+          git push origin v${{ inputs.version }}
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Generate Commit Changelog
+        id: generate-commit-changelog
+        run: |
+          PREV_TAG="${{ steps.previous-release.outputs.tag_name }}"
+          CUR_TAG="v${{ inputs.version }}"
+          echo "## What's Changed" > changelog.md
+          git log "$PREV_TAG..$CUR_TAG" --pretty=format:"- %s (%h) - @%an" >> changelog.md
+          cat changelog.md
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: _artifacts/Whisparr.*
+          commit: ${{ github.sha }}
+          generateReleaseNotes: false
+          bodyFile: changelog.md
+          name: ${{ inputs.version }}
+          prerelease: ${{ inputs.branch != 'v2' }}
+          skipIfReleaseExists: true
+          tag: v${{ inputs.version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,11 +84,13 @@ jobs:
       - name: Get Previous Release
         id: previous-release
         uses: cardinalby/git-get-release-action@v1
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           latest: true
           prerelease: ${{ inputs.branch != 'v2' }}
+          doNotFailIfNotFound: true
 
       - name: Enable GPG signing
         uses: crazy-max/ghaction-import-gpg@v6
@@ -112,7 +114,11 @@ jobs:
           PREV_TAG="${{ steps.previous-release.outputs.tag_name }}"
           CUR_TAG="v${{ inputs.version }}"
           echo "## What's Changed" > changelog.md
-          git log "$PREV_TAG..$CUR_TAG" --pretty=format:"- %s (%h) - @%an" >> changelog.md
+          if [ -n "$PREV_TAG" ]; then
+            git log "$PREV_TAG..$CUR_TAG" --pretty=format:"- %s (%h) - @%an" >> changelog.md
+          else
+            echo "Initial release" >> changelog.md
+          fi
           cat changelog.md
 
       - name: Create release

--- a/distribution/windows/setup/whisparr.iss
+++ b/distribution/windows/setup/whisparr.iss
@@ -2,13 +2,16 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define AppName "Whisparr"
-#define AppPublisher "Team Servarr"
+#define AppPublisher "Team Whisparr"
 #define AppURL "https://whisparr.com/"
 #define ForumsURL "https://whisparr.com/discord"
 #define AppExeName "Whisparr.exe"
-#define BaseVersion GetEnv('MAJORVERSION')
-#define BuildNumber GetEnv('MINORVERSION')
-#define BuildVersion GetEnv('WHISPARRVERSION')
+#define BuildNumber "2.0"
+#define BuildNumber GetEnv('WHISPARR_VERSION')
+#define MajorVersion GetEnv('WHISPARR_MAJOR_VERSION')
+#define BranchName GetEnv('SAFE_BRANCH')
+#define Framework GetEnv('FRAMEWORK')
+#define Runtime GetEnv('RUNTIME')
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
@@ -16,7 +19,7 @@
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
 AppId={{56C1065D-3523-4025-B76D-6F73F67F7F69}
 AppName={#AppName}
-AppVersion={#BaseVersion}
+AppVersion={#MajorVersion}
 AppPublisher={#AppPublisher}
 AppPublisherURL={#AppURL}
 AppSupportURL={#ForumsURL}
@@ -25,7 +28,7 @@ DefaultDirName={commonappdata}\Whisparr
 DisableDirPage=yes
 DefaultGroupName={#AppName}
 DisableProgramGroupPage=yes
-OutputBaseFilename=Whisparr.{#BuildVersion}.{#Runtime}
+OutputBaseFilename=Whisparr.{#BranchName}.{#BuildNumber}.{#Runtime}-installer
 SolidCompression=yes
 AppCopyright=Creative Commons 3.0 License
 AllowUNCPath=False
@@ -34,7 +37,7 @@ DisableReadyPage=True
 CompressionThreads=2
 Compression=lzma2/normal
 AppContact={#ForumsURL}
-VersionInfoVersion={#BaseVersion}.{#BuildNumber}
+VersionInfoVersion={#MajorVersion}
 SetupLogging=yes
 OutputDir=output
 WizardStyle=modern
@@ -52,8 +55,8 @@ Name: "none"; Description: "Do not start automatically"; GroupDescription: "Star
 Name: "{app}"; Permissions: users-modify
 
 [Files]
-Source: "..\..\..\_artifacts\{#Runtime}\{#Framework}\Whisparr\Whisparr.exe"; DestDir: "{app}\bin"; Flags: ignoreversion
-Source: "..\..\..\_artifacts\{#Runtime}\{#Framework}\Whisparr\*"; Excludes: "Whisparr.Update"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\..\..\_output\{#Runtime}\{#Framework}\Whisparr\Whisparr.exe"; DestDir: "{app}\bin"; Flags: ignoreversion
+Source: "..\..\..\_output\{#Runtime}\{#Framework}\Whisparr\*"; Excludes: "Whisparr.Update"; DestDir: "{app}\bin"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -104,6 +104,7 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="3.0.131" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TestProject)'=='true' and '$(TargetFramework)'=='net6.0'">

--- a/src/NzbDrone.Host/Whisparr.Host.csproj
+++ b/src/NzbDrone.Host/Whisparr.Host.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.1" />
     <PackageReference Include="DryIoc.dll" Version="5.4.1" />
-    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
+    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.Update/Whisparr.Update.csproj
+++ b/src/NzbDrone.Update/Whisparr.Update.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="5.4.1" />
-    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
+    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.0" />
     <PackageReference Include="NLog" Version="4.7.14" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Summary
- Add GitHub Actions build system to replace Azure DevOps builds
- Support all platforms: win-x64, win-x86, linux-x64, linux-arm, linux-arm64, linux-musl-x64, linux-musl-arm64, osx-x64, osx-arm64, freebsd-x64
- Add unit tests, integration tests, and Postgres tests
- Add Windows installer creation with Inno Setup
- Configure for v2/v2-develop branch structure
- Downgrade DryIoc.Microsoft.DependencyInjection to 6.1.0 for .NET 6.0 compatibility
- Add GitHubActionsTestLogger for CI test output