### PR TITLE
Chore: Sonarr Upstream Sync - Batch 9 (January 2024)

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -2,6 +2,8 @@ const loose = true;
 
 module.exports = {
   plugins: [
+    '@babel/plugin-transform-logical-assignment-operators',
+
     // Stage 1
     '@babel/plugin-proposal-export-default-from',
     ['@babel/plugin-transform-optional-chaining', { loose }],

--- a/frontend/src/Components/Filter/CustomFilters/CustomFiltersModalContent.js
+++ b/frontend/src/Components/Filter/CustomFilters/CustomFiltersModalContent.js
@@ -30,22 +30,24 @@ function CustomFiltersModalContent(props) {
 
       <ModalBody>
         {
-          customFilters.map((customFilter) => {
-            return (
-              <CustomFilter
-                key={customFilter.id}
-                id={customFilter.id}
-                label={customFilter.label}
-                filters={customFilter.filters}
-                selectedFilterKey={selectedFilterKey}
-                isDeleting={isDeleting}
-                deleteError={deleteError}
-                dispatchSetFilter={dispatchSetFilter}
-                dispatchDeleteCustomFilter={dispatchDeleteCustomFilter}
-                onEditPress={onEditCustomFilter}
-              />
-            );
-          })
+          customFilters
+            .sort((a, b) => a.label.localeCompare(b.label))
+            .map((customFilter) => {
+              return (
+                <CustomFilter
+                  key={customFilter.id}
+                  id={customFilter.id}
+                  label={customFilter.label}
+                  filters={customFilter.filters}
+                  selectedFilterKey={selectedFilterKey}
+                  isDeleting={isDeleting}
+                  deleteError={deleteError}
+                  dispatchSetFilter={dispatchSetFilter}
+                  dispatchDeleteCustomFilter={dispatchDeleteCustomFilter}
+                  onEditPress={onEditCustomFilter}
+                />
+              );
+            })
         }
 
         <div className={styles.addButtonContainer}>

--- a/frontend/src/Components/Menu/FilterMenuContent.js
+++ b/frontend/src/Components/Menu/FilterMenuContent.js
@@ -40,18 +40,26 @@ class FilterMenuContent extends Component {
         }
 
         {
-          customFilters.map((filter) => {
-            return (
-              <FilterMenuItem
-                key={filter.id}
-                filterKey={filter.id}
-                selectedFilterKey={selectedFilterKey}
-                onPress={onFilterSelect}
-              >
-                {filter.label}
-              </FilterMenuItem>
-            );
-          })
+          customFilters.length > 0 ?
+            <MenuItemSeparator /> :
+            null
+        }
+
+        {
+          customFilters
+            .sort((a, b) => a.label.localeCompare(b.label))
+            .map((filter) => {
+              return (
+                <FilterMenuItem
+                  key={filter.id}
+                  filterKey={filter.id}
+                  selectedFilterKey={selectedFilterKey}
+                  onPress={onFilterSelect}
+                >
+                  {filter.label}
+                </FilterMenuItem>
+              );
+            })
         }
 
         {

--- a/frontend/src/Series/Index/Posters/SeriesIndexPosters.tsx
+++ b/frontend/src/Series/Index/Posters/SeriesIndexPosters.tsx
@@ -190,11 +190,15 @@ export default function SeriesIndexPosters(props: SeriesIndexPostersProps) {
 
     if (isSmallScreen) {
       const padding = bodyPaddingSmallScreen - 5;
+      const width = window.innerWidth - padding * 2;
+      const height = window.innerHeight;
 
-      setSize({
-        width: window.innerWidth - padding * 2,
-        height: window.innerHeight,
-      });
+      if (width !== size.width || height !== size.height) {
+        setSize({
+          width,
+          height,
+        });
+      }
 
       return;
     }

--- a/frontend/src/Series/Index/Posters/SeriesIndexPosters.tsx
+++ b/frontend/src/Series/Index/Posters/SeriesIndexPosters.tsx
@@ -212,7 +212,7 @@ export default function SeriesIndexPosters(props: SeriesIndexPostersProps) {
         height: window.innerHeight,
       });
     }
-  }, [isSmallScreen, scrollerRef, bounds]);
+  }, [isSmallScreen, scrollerRef, bounds, size.width, size.height]);
 
   useEffect(() => {
     const currentScrollerRef = scrollerRef.current as HTMLElement;

--- a/frontend/src/Settings/PendingChangesModal.js
+++ b/frontend/src/Settings/PendingChangesModal.js
@@ -15,12 +15,17 @@ function PendingChangesModal(props) {
     isOpen,
     onConfirm,
     onCancel,
-    bindShortcut
+    bindShortcut,
+    unbindShortcut
   } = props;
 
   useEffect(() => {
-    bindShortcut('enter', onConfirm);
-  }, [bindShortcut, onConfirm]);
+    if (isOpen) {
+      bindShortcut('enter', onConfirm);
+
+      return () => unbindShortcut('enter', onConfirm);
+    }
+  }, [bindShortcut, unbindShortcut, isOpen, onConfirm]);
 
   return (
     <Modal
@@ -61,7 +66,8 @@ PendingChangesModal.propTypes = {
   kind: PropTypes.oneOf(kinds.all),
   onConfirm: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  bindShortcut: PropTypes.func.isRequired
+  bindShortcut: PropTypes.func.isRequired,
+  unbindShortcut: PropTypes.func.isRequired
 };
 
 PendingChangesModal.defaultProps = {

--- a/frontend/src/Store/Actions/Settings/indexers.js
+++ b/frontend/src/Store/Actions/Settings/indexers.js
@@ -143,7 +143,13 @@ export default {
       delete selectedSchema.name;
 
       selectedSchema.fields = selectedSchema.fields.map((field) => {
-        return { ...field };
+        const newField = { ...field };
+
+        if (newField.privacy === 'apiKey' || newField.privacy === 'password') {
+          newField.value = '';
+        }
+
+        return newField;
       });
 
       newState.selectedSchema = selectedSchema;

--- a/src/NzbDrone.Common.Test/DiskTests/DiskProviderFixtureBase.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskProviderFixtureBase.cs
@@ -11,6 +11,16 @@ namespace NzbDrone.Common.Test.DiskTests
         where TSubject : class, IDiskProvider
     {
         [Test]
+        public void writealltext_should_truncate_existing()
+        {
+            var file = GetTempFilePath();
+
+            Subject.WriteAllText(file, "A pretty long string");
+            Subject.WriteAllText(file, "A short string");
+            Subject.ReadAllText(file).Should().Be("A short string");
+        }
+
+        [Test]
         [Retry(5)]
         public void directory_exist_should_be_able_to_find_existing_folder()
         {

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -131,7 +131,7 @@ namespace NzbDrone.Common.Disk
             {
                 var testPath = Path.Combine(path, "whisparr_write_test.txt");
                 var testContent = $"This file was created to verify if '{path}' is writable. It should've been automatically deleted. Feel free to delete it.";
-                File.WriteAllText(testPath, testContent);
+                WriteAllText(testPath, testContent);
                 File.Delete(testPath);
                 return true;
             }
@@ -311,7 +311,16 @@ namespace NzbDrone.Common.Disk
         {
             Ensure.That(filename, () => filename).IsValidPath(PathValidationType.CurrentOs);
             RemoveReadOnly(filename);
-            File.WriteAllText(filename, contents);
+
+            // File.WriteAllText is broken on net core when writing to some CIFS mounts
+            // This workaround from https://github.com/dotnet/runtime/issues/42790#issuecomment-700362617
+            using (var fs = new FileStream(filename, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                using (var writer = new StreamWriter(fs))
+                {
+                    writer.Write(contents);
+                }
+            }
         }
 
         public void FolderSetLastWriteTime(string path, DateTime dateTime)

--- a/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/MultiLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/MultiLanguageFixture.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.CustomFormats.Specifications.LanguageSpecification
+{
+    [TestFixture]
+    public class MultiLanguageFixture : CoreTest<Core.CustomFormats.LanguageSpecification>
+    {
+        private CustomFormatInput _input;
+
+        [SetUp]
+        public void Setup()
+        {
+            _input = new CustomFormatInput
+            {
+                EpisodeInfo = Builder<ParsedEpisodeInfo>.CreateNew().Build(),
+                Series = Builder<Series>.CreateNew().With(s => s.OriginalLanguage = Language.English).Build(),
+                Size = 100.Megabytes(),
+                Languages = new List<Language>
+                {
+                    Language.English,
+                    Language.French
+                },
+                Filename = "Series.Title.S01E01"
+            };
+        }
+
+        [Test]
+        public void should_match_one_language()
+        {
+            Subject.Value = Language.French.Id;
+            Subject.Negate = false;
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_not_match_different_language()
+        {
+            Subject.Value = Language.Spanish.Id;
+            Subject.Negate = false;
+
+            Subject.IsSatisfiedBy(_input).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_not_match_negated_when_one_language_matches()
+        {
+            Subject.Value = Language.French.Id;
+            Subject.Negate = true;
+
+            Subject.IsSatisfiedBy(_input).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_not_match_negated_when_all_languages_do_not_match()
+        {
+            Subject.Value = Language.Spanish.Id;
+            Subject.Negate = true;
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/OriginalLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/OriginalLanguageFixture.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.Linq;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.CustomFormats.Specifications.LanguageSpecification
+{
+    [TestFixture]
+    public class OriginalLanguageFixture : CoreTest<Core.CustomFormats.LanguageSpecification>
+    {
+        private CustomFormatInput _input;
+
+        [SetUp]
+        public void Setup()
+        {
+            _input = new CustomFormatInput
+            {
+                EpisodeInfo = Builder<ParsedEpisodeInfo>.CreateNew().Build(),
+                Series = Builder<Series>.CreateNew().With(s => s.OriginalLanguage = Language.English).Build(),
+                Size = 100.Megabytes(),
+                Languages = new List<Language>
+                {
+                    Language.French
+                },
+                Filename = "Series.Title.S01E01"
+            };
+        }
+
+        public void GivenLanguages(params Language[] languages)
+        {
+            _input.Languages = languages.ToList();
+        }
+
+        [Test]
+        public void should_match_same_single_language()
+        {
+            GivenLanguages(Language.English);
+
+            Subject.Value = Language.Original.Id;
+            Subject.Negate = false;
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_not_match_different_single_language()
+        {
+            Subject.Value = Language.Original.Id;
+            Subject.Negate = false;
+
+            Subject.IsSatisfiedBy(_input).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_not_match_negated_same_single_language()
+        {
+            GivenLanguages(Language.English);
+
+            Subject.Value = Language.Original.Id;
+            Subject.Negate = true;
+
+            Subject.IsSatisfiedBy(_input).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_match_negated_different_single_language()
+        {
+            Subject.Value = Language.Original.Id;
+            Subject.Negate = true;
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/SingleLanguageFixture.cs
+++ b/src/NzbDrone.Core.Test/CustomFormats/Specifications/LanguageSpecification/SingleLanguageFixture.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using NUnit.Framework;
+using NzbDrone.Core.CustomFormats;
+using NzbDrone.Core.Languages;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.CustomFormats.Specifications.LanguageSpecification
+{
+    [TestFixture]
+    public class SingleLanguageFixture : CoreTest<Core.CustomFormats.LanguageSpecification>
+    {
+        private CustomFormatInput _input;
+
+        [SetUp]
+        public void Setup()
+        {
+            _input = new CustomFormatInput
+            {
+                EpisodeInfo = Builder<ParsedEpisodeInfo>.CreateNew().Build(),
+                Series = Builder<Series>.CreateNew().With(s => s.OriginalLanguage = Language.English).Build(),
+                Size = 100.Megabytes(),
+                Languages = new List<Language>
+                {
+                    Language.French
+                },
+                Filename = "Series.Title.S01E01"
+            };
+        }
+
+        [Test]
+        public void should_match_same_language()
+        {
+            Subject.Value = Language.French.Id;
+            Subject.Negate = false;
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+
+        [Test]
+        public void should_not_match_different_language()
+        {
+            Subject.Value = Language.Spanish.Id;
+            Subject.Negate = false;
+
+            Subject.IsSatisfiedBy(_input).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_not_match_negated_same_language()
+        {
+            Subject.Value = Language.French.Id;
+            Subject.Negate = true;
+
+            Subject.IsSatisfiedBy(_input).Should().BeFalse();
+        }
+
+        [Test]
+        public void should_match_negated_different_language()
+        {
+            Subject.Value = Language.Spanish.Id;
+            Subject.Negate = true;
+
+            Subject.IsSatisfiedBy(_input).Should().BeTrue();
+        }
+    }
+}

--- a/src/NzbDrone.Core.Test/IndexerTests/FileListTests/FileListFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerTests/FileListTests/FileListFixture.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Test.IndexerTests.FileListTests
 
             Mocker.GetMock<IHttpClient>()
                 .Setup(o => o.ExecuteAsync(It.Is<HttpRequest>(v => v.Method == HttpMethod.Get)))
-                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader(), recentFeed)));
+                .Returns<HttpRequest>(r => Task.FromResult(new HttpResponse(r, new HttpHeader { { "Content-Type", "application/json" } }, recentFeed)));
 
             var releases = await Subject.FetchRecent();
 

--- a/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/DiskScanServiceTests/ScanFixture.cs
@@ -186,6 +186,7 @@ namespace NzbDrone.Core.Test.MediaFiles.DiskScanServiceTests
                            Path.Combine(_series.Path, "Scenes", "file6.mkv").AsOsAgnostic(),
                            Path.Combine(_series.Path, "Shorts", "file7.mkv").AsOsAgnostic(),
                            Path.Combine(_series.Path, "Trailers", "file8.mkv").AsOsAgnostic(),
+                           Path.Combine(_series.Path, "Other", "file9.mkv").AsOsAgnostic(),
                            Path.Combine(_series.Path, "Series Title S01E01 (1080p BluRay x265 10bit Tigole).mkv").AsOsAgnostic(),
                        });
 

--- a/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
+++ b/src/NzbDrone.Core/CustomFormats/CustomFormatCalculationService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.History;
@@ -23,10 +24,12 @@ namespace NzbDrone.Core.CustomFormats
     public class CustomFormatCalculationService : ICustomFormatCalculationService
     {
         private readonly ICustomFormatService _formatService;
+        private readonly Logger _logger;
 
-        public CustomFormatCalculationService(ICustomFormatService formatService)
+        public CustomFormatCalculationService(ICustomFormatService formatService, Logger logger)
         {
             _formatService = formatService;
+            _logger = logger;
         }
 
         public List<CustomFormat> ParseCustomFormat(RemoteEpisode remoteEpisode, long size)
@@ -153,20 +156,23 @@ namespace NzbDrone.Core.CustomFormats
             return matches.OrderBy(x => x.Name).ToList();
         }
 
-        private static List<CustomFormat> ParseCustomFormat(EpisodeFile episodeFile, Series series, List<CustomFormat> allCustomFormats)
+        private List<CustomFormat> ParseCustomFormat(EpisodeFile episodeFile, Series series, List<CustomFormat> allCustomFormats)
         {
             var releaseTitle = string.Empty;
 
             if (episodeFile.SceneName.IsNotNullOrWhiteSpace())
             {
+                _logger.Trace("Using scene name for release title: {0}", episodeFile.SceneName);
                 releaseTitle = episodeFile.SceneName;
             }
             else if (episodeFile.OriginalFilePath.IsNotNullOrWhiteSpace())
             {
+                _logger.Trace("Using original file path for release title: {0}", Path.GetFileName(episodeFile.OriginalFilePath));
                 releaseTitle = Path.GetFileName(episodeFile.OriginalFilePath);
             }
             else if (episodeFile.RelativePath.IsNotNullOrWhiteSpace())
             {
+                _logger.Trace("Using relative path for release title: {0}", Path.GetFileName(episodeFile.RelativePath));
                 releaseTitle = Path.GetFileName(episodeFile.RelativePath);
             }
 

--- a/src/NzbDrone.Core/CustomFormats/Specifications/CustomFormatSpecificationBase.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/CustomFormatSpecificationBase.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.CustomFormats
 
         public abstract NzbDroneValidationResult Validate();
 
-        public bool IsSatisfiedBy(CustomFormatInput input)
+        public virtual bool IsSatisfiedBy(CustomFormatInput input)
         {
             var match = IsSatisfiedByWithoutNegate(input);
 

--- a/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/LanguageSpecification.cs
@@ -30,6 +30,16 @@ namespace NzbDrone.Core.CustomFormats
         [FieldDefinition(1, Label = "Language", Type = FieldType.Select, SelectOptions = typeof(LanguageFieldConverter))]
         public int Value { get; set; }
 
+        public override bool IsSatisfiedBy(CustomFormatInput input)
+        {
+            if (Negate)
+            {
+                return IsSatisfiedByWithNegate(input);
+            }
+
+            return IsSatisfiedByWithoutNegate(input);
+        }
+
         protected override bool IsSatisfiedByWithoutNegate(CustomFormatInput input)
         {
             var comparedLanguage = input.EpisodeInfo != null && input.Series != null && Value == Language.Original.Id && input.Series.OriginalLanguage != Language.Unknown
@@ -37,6 +47,15 @@ namespace NzbDrone.Core.CustomFormats
                 : (Language)Value;
 
             return input.Languages?.Contains(comparedLanguage) ?? false;
+        }
+
+        private bool IsSatisfiedByWithNegate(CustomFormatInput input)
+        {
+            var comparedLanguage = input.EpisodeInfo != null && input.Series != null && Value == Language.Original.Id && input.Series.OriginalLanguage != Language.Unknown
+                ? input.Series.OriginalLanguage
+                : (Language)Value;
+
+            return !input.Languages?.Contains(comparedLanguage) ?? false;
         }
 
         public override NzbDroneValidationResult Validate()

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -611,7 +611,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             }
             else if (torrent.RatioLimit == -2 && config.MaxRatioEnabled)
             {
-                if (torrent.Ratio >= config.MaxRatio)
+                if (Math.Round(torrent.Ratio, 2) >= config.MaxRatio)
                 {
                     return true;
                 }

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -132,6 +132,8 @@ namespace NzbDrone.Core.Download
                 if (series == null)
                 {
                     trackedDownload.Warn("Series title mismatch; automatic import is not possible. Check the download troubleshooting entry on the wiki for common causes.");
+                    SendManualInteractionRequiredNotification(trackedDownload);
+
                     return;
                 }
 
@@ -142,16 +144,7 @@ namespace NzbDrone.Core.Download
                 if (seriesMatchType == SeriesMatchType.Id && releaseSource != ReleaseSourceType.InteractiveSearch)
                 {
                     trackedDownload.Warn("Found matching series via grab history, but release was matched to series by ID. Automatic import is not possible. See the FAQ for details.");
-
-                    if (!trackedDownload.HasNotifiedManualInteractionRequired)
-                    {
-                        trackedDownload.HasNotifiedManualInteractionRequired = true;
-
-                        var releaseInfo = new GrabbedReleaseInfo(grabbedHistories);
-                        var manualInteractionEvent = new ManualInteractionRequiredEvent(trackedDownload, releaseInfo);
-
-                        _eventAggregator.PublishEvent(manualInteractionEvent);
-                    }
+                    SendManualInteractionRequiredNotification(trackedDownload);
 
                     return;
                 }
@@ -172,6 +165,8 @@ namespace NzbDrone.Core.Download
             if (trackedDownload.RemoteEpisode == null)
             {
                 trackedDownload.Warn("Unable to parse download, automatic import is not possible.");
+                SendManualInteractionRequiredNotification(trackedDownload);
+
                 return;
             }
 
@@ -228,6 +223,7 @@ namespace NzbDrone.Core.Download
             if (statusMessages.Any())
             {
                 trackedDownload.Warn(statusMessages.ToArray());
+                SendManualInteractionRequiredNotification(trackedDownload);
             }
         }
 
@@ -292,6 +288,21 @@ namespace NzbDrone.Core.Download
 
             _logger.Debug("Not all episodes have been imported for the release '{0}'", trackedDownload.DownloadItem.Title);
             return false;
+        }
+
+        private void SendManualInteractionRequiredNotification(TrackedDownload trackedDownload)
+        {
+            if (!trackedDownload.HasNotifiedManualInteractionRequired)
+            {
+                var grabbedHistories = _historyService.FindByDownloadId(trackedDownload.DownloadItem.DownloadId).Where(h => h.EventType == EpisodeHistoryEventType.Grabbed).ToList();
+
+                trackedDownload.HasNotifiedManualInteractionRequired = true;
+
+                var releaseInfo = grabbedHistories.Count > 0 ? new GrabbedReleaseInfo(grabbedHistories) : null;
+                var manualInteractionEvent = new ManualInteractionRequiredEvent(trackedDownload, releaseInfo);
+
+                _eventAggregator.PublishEvent(manualInteractionEvent);
+            }
         }
 
         private void SetImportItem(TrackedDownload trackedDownload)

--- a/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
+++ b/src/NzbDrone.Core/Download/ProcessDownloadDecisions.cs
@@ -196,31 +196,30 @@ namespace NzbDrone.Core.Download
         private async Task<ProcessedDecisionResult> ProcessDecisionInternal(DownloadDecision decision, int? downloadClientId = null)
         {
             var remoteEpisode = decision.RemoteEpisode;
+            var remoteIndexer = remoteEpisode.Release.Indexer;
 
             try
             {
-                _logger.Trace("Grabbing from Indexer {0} at priority {1}.", remoteEpisode.Release.Indexer, remoteEpisode.Release.IndexerPriority);
+                _logger.Trace("Grabbing release '{0}' from Indexer {1} at priority {2}.", remoteEpisode, remoteIndexer, remoteEpisode.Release.IndexerPriority);
                 await _downloadService.DownloadReport(remoteEpisode, downloadClientId);
 
                 return ProcessedDecisionResult.Grabbed;
             }
             catch (ReleaseUnavailableException)
             {
-                _logger.Warn("Failed to download release from indexer, no longer available. " + remoteEpisode);
+                _logger.Warn("Failed to download release '{0}' from Indexer {1}. Release not available", remoteEpisode, remoteIndexer);
                 return ProcessedDecisionResult.Rejected;
             }
             catch (Exception ex)
             {
                 if (ex is DownloadClientUnavailableException || ex is DownloadClientAuthenticationException)
                 {
-                    _logger.Debug(ex,
-                        "Failed to send release to download client, storing until later. " + remoteEpisode);
-
+                    _logger.Debug(ex, "Failed to send release '{0}' from Indexer {1} to download client, storing until later.", remoteEpisode, remoteIndexer);
                     return ProcessedDecisionResult.Failed;
                 }
                 else
                 {
-                    _logger.Warn(ex, "Couldn't add report to download queue. " + remoteEpisode);
+                    _logger.Warn(ex, "Couldn't add release '{0}' from Indexer {1} to download queue.", remoteEpisode, remoteIndexer);
                     return ProcessedDecisionResult.Skipped;
                 }
             }

--- a/src/NzbDrone.Core/History/HistoryRepository.cs
+++ b/src/NzbDrone.Core/History/HistoryRepository.cs
@@ -124,21 +124,19 @@ namespace NzbDrone.Core.History
 
         public PagingSpec<EpisodeHistory> GetPaged(PagingSpec<EpisodeHistory> pagingSpec, int[] languages, int[] qualities)
         {
-            pagingSpec.Records = GetPagedRecords(PagedBuilder(pagingSpec, languages, qualities), pagingSpec, PagedQuery);
+            pagingSpec.Records = GetPagedRecords(PagedBuilder(languages, qualities), pagingSpec, PagedQuery);
 
             var countTemplate = $"SELECT COUNT(*) FROM (SELECT /**select**/ FROM \"{TableMapping.Mapper.TableNameMapping(typeof(EpisodeHistory))}\" /**join**/ /**innerjoin**/ /**leftjoin**/ /**where**/ /**groupby**/ /**having**/) AS \"Inner\"";
-            pagingSpec.TotalRecords = GetPagedRecordCount(PagedBuilder(pagingSpec, languages, qualities).Select(typeof(EpisodeHistory)), pagingSpec, countTemplate);
+            pagingSpec.TotalRecords = GetPagedRecordCount(PagedBuilder(languages, qualities).Select(typeof(EpisodeHistory)), pagingSpec, countTemplate);
 
             return pagingSpec;
         }
 
-        private SqlBuilder PagedBuilder(PagingSpec<EpisodeHistory> pagingSpec, int[] languages, int[] qualities)
+        private SqlBuilder PagedBuilder(int[] languages, int[] qualities)
         {
             var builder = Builder()
                 .Join<EpisodeHistory, Series>((h, a) => h.SeriesId == a.Id)
                 .Join<EpisodeHistory, Episode>((h, a) => h.EpisodeId == a.Id);
-
-            AddFilters(builder, pagingSpec);
 
             if (languages is { Length: > 0 })
             {

--- a/src/NzbDrone.Core/Indexers/FileList/FileListParser.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListParser.cs
@@ -18,14 +18,19 @@ namespace NzbDrone.Core.Indexers.FileList
 
         public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
         {
-            var torrentInfos = new List<ReleaseInfo>();
-
             if (indexerResponse.HttpResponse.StatusCode != HttpStatusCode.OK)
             {
                 throw new IndexerException(indexerResponse,
                     "Unexpected response status {0} code from API request",
                     indexerResponse.HttpResponse.StatusCode);
             }
+
+            if (!indexerResponse.HttpResponse.Headers.ContentType.Contains(HttpAccept.Json.Value))
+            {
+                throw new IndexerException(indexerResponse, "Unexpected response header '{0}' from indexer request, expected '{1}'", indexerResponse.HttpResponse.Headers.ContentType, HttpAccept.Json.Value);
+            }
+
+            var torrentInfos = new List<ReleaseInfo>();
 
             var queryResults = JsonConvert.DeserializeObject<List<FileListTorrent>>(indexerResponse.Content);
 

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -69,7 +69,7 @@ namespace NzbDrone.Core.MediaFiles
             _logger = logger;
         }
 
-        private static readonly Regex ExcludedExtrasSubFolderRegex = new Regex(@"(?:\\|\/|^)(?:extras|extrafanart|behind the scenes|deleted scenes|featurettes|interviews|scenes|samples|shorts|trailers)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ExcludedExtrasSubFolderRegex = new Regex(@"(?:\\|\/|^)(?:extras|extrafanart|behind the scenes|deleted scenes|featurettes|interviews|other|scenes|samples|shorts|trailers)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex ExcludedSubFoldersRegex = new Regex(@"(?:\\|\/|^)(?:@eadir|\.@__thumb|plex versions|\.[^\\/]+)(?:\\|\/)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex ExcludedExtraFilesRegex = new Regex(@"(-(trailer|other|behindthescenes|deleted|featurette|interview|scene|short)\.[^.]+$)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex ExcludedFilesRegex = new Regex(@"^\._|^Thumbs\.db$", RegexOptions.Compiled | RegexOptions.IgnoreCase);

--- a/src/NzbDrone.Core/Update/InstallUpdateService.cs
+++ b/src/NzbDrone.Core/Update/InstallUpdateService.cs
@@ -107,6 +107,11 @@ namespace NzbDrone.Core.Update
 
             var updateSandboxFolder = _appFolderInfo.GetUpdateSandboxFolder();
 
+            if (_diskProvider.GetTotalSize(updateSandboxFolder) < 1.Gigabytes())
+            {
+                _logger.Warn("Temporary location '{0}' has less than 1 GB free space, Sonarr may not be able to update itself.", updateSandboxFolder);
+            }
+
             var packageDestination = Path.Combine(updateSandboxFolder, updatePackage.FileName);
 
             if (_diskProvider.FolderExists(updateSandboxFolder))

--- a/src/Whisparr.Api.V3/History/HistoryController.cs
+++ b/src/Whisparr.Api.V3/History/HistoryController.cs
@@ -62,15 +62,14 @@ namespace Whisparr.Api.V3.History
 
         [HttpGet]
         [Produces("application/json")]
-        public PagingResource<HistoryResource> GetHistory([FromQuery] PagingRequestResource paging, bool includeSeries, bool includeEpisode, int? eventType, int? episodeId, string downloadId, [FromQuery] int[] seriesIds = null, [FromQuery] int[] languages = null, [FromQuery] int[] quality = null)
+        public PagingResource<HistoryResource> GetHistory([FromQuery] PagingRequestResource paging, bool includeSeries, bool includeEpisode, [FromQuery(Name = "eventType")] int[] eventTypes, int? episodeId, string downloadId, [FromQuery] int[] seriesIds = null, [FromQuery] int[] languages = null, [FromQuery] int[] quality = null)
         {
             var pagingResource = new PagingResource<HistoryResource>(paging);
             var pagingSpec = pagingResource.MapToPagingSpec<HistoryResource, EpisodeHistory>("date", SortDirection.Descending);
 
-            if (eventType.HasValue)
+            if (eventTypes != null && eventTypes.Any())
             {
-                var filterValue = (EpisodeHistoryEventType)eventType.Value;
-                pagingSpec.FilterExpressions.Add(v => v.EventType == filterValue);
+                pagingSpec.FilterExpressions.Add(v => eventTypes.Contains((int)v.EventType));
             }
 
             if (episodeId.HasValue)


### PR DESCRIPTION
Applied Commits (15)

  - Sonarr/Sonarr@e4b5d559d - Sort Custom Filters
  - Sonarr/Sonarr@489f03441 - Fixed: Filter history by multiple event types
  - Sonarr/Sonarr@c6bb6ad87 - Round off the seeded ratio when checking for removal candidates
  - Sonarr/Sonarr@2dbf5b5a7 - Check Content-Type in FileList parser
  - Sonarr/Sonarr@ec40bc6ee - Improve Release Title Custom Format debugging
  - Sonarr/Sonarr@d336aaf3f - Fixed: Don't clone indexer API Key
  - Sonarr/Sonarr@3cf4d2907 - Transpile logical assignment operators with babel
  - Sonarr/Sonarr@c0b30a502 - Fixed: Series poster view on mobile devices
  - Sonarr/Sonarr@e66ba84fc - New: Log warning if less than 1 GB free space during update
  - Sonarr/Sonarr@d9acbf568 - Fixed: FolderWritable check for CIFS shares mounted in Unix
  - Sonarr/Sonarr@d7aea82e4 - Improve Release Grabbing & Failure Logging
  - Sonarr/Sonarr@e1c6722aa - New: Ignore 'Other' subfolder when scanning disk
  - Sonarr/Sonarr@ded7c3c6e - Only bind shortcut for pending changes confirmation when it's shown
  - Sonarr/Sonarr@42b11528b - New: Improve multi-language negate Custom Format
  - Sonarr/Sonarr@c5a724f14 - New: Send 'On Manual Interaction Required' notifications in more cases

Skipped Commits

  - Sonarr/Sonarr@0d0641819 - New: Add size to more history events (already in Whisparr)
  - Sonarr/Sonarr@fc3a2e9ab - New: Added some extra pixels to grouped calendar events (already in Whisparr)
  - Sonarr/Sonarr@3cd4c67ba - New: Add download client name to pending items (already in Whisparr)
  - Sonarr/Sonarr@8f0514a91 - Fixed: Grouped calendar events not correctly showing as downloading (already in Whisparr)
  - Sonarr/Sonarr@e17655c26 - Fixed: Notifications with only On Series Add enabled being labeled as disabled (already in Whisparr)
  - Sonarr/Sonarr@57445bbe5 - New: Added column in Queue (separate PR)
  - Sonarr/Sonarr@345854d0f - New: Optionally remove from queue by changing category (separate PR)
  - Translation updates, API docs (conflicts)