### PR TITLE
Fix: Add Windows.exe to Releases

### DIFF
--- a/distribution/windows/setup/whisparr.iss
+++ b/distribution/windows/setup/whisparr.iss
@@ -39,7 +39,7 @@ Compression=lzma2/normal
 AppContact={#ForumsURL}
 VersionInfoVersion={#MajorVersion}
 SetupLogging=yes
-OutputDir=output
+OutputDir=..\..\..\_artifacts
 WizardStyle=modern
 
 [Languages]


### PR DESCRIPTION
I forgot to copy the artifacts for windows .exe version so it was never building.