### PR TITLE
Chore: Sonarr Upstream Sync - Batch 12 (April 2024)

### DIFF
--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportRow.tsx
@@ -122,7 +122,8 @@ function InteractiveImportRow(props: InteractiveImportRowProps) {
         seasonNumber != null &&
         episodes.length &&
         quality &&
-        languages
+        languages &&
+        size > 0
       ) {
         onSelectedChange({
           id,

--- a/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.js
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.js
@@ -150,6 +150,11 @@ class EditCustomFormatModalContent extends Component {
                   </Form>
 
                   <FieldSet legend={translate('Conditions')}>
+                    <Alert kind={kinds.INFO}>
+                      <div>
+                        {translate('CustomFormatsSettingsTriggerInfo')}
+                      </div>
+                    </Alert>
                     <div className={styles.customFormats}>
                       {
                         specifications.map((tag) => {

--- a/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.js
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/EditCustomFormatModalContent.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import Alert from 'Components/Alert';
 import Card from 'Components/Card';
 import FieldSet from 'Components/FieldSet';
 import Form from 'Components/Form/Form';

--- a/frontend/src/Store/Actions/Creators/createTestProviderHandler.js
+++ b/frontend/src/Store/Actions/Creators/createTestProviderHandler.js
@@ -1,8 +1,11 @@
+import $ from 'jquery';
+import _ from 'lodash';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
 import getProviderState from 'Utilities/State/getProviderState';
 import { set } from '../baseActions';
 
 const abortCurrentRequests = {};
+let lastTestData = null;
 
 export function createCancelTestProviderHandler(section) {
   return function(getState, payload, dispatch) {
@@ -17,10 +20,25 @@ function createTestProviderHandler(section, url) {
   return function(getState, payload, dispatch) {
     dispatch(set({ section, isTesting: true }));
 
-    const testData = getProviderState(payload, getState, section);
+    const {
+      queryParams = {},
+      ...otherPayload
+    } = payload;
+
+    const testData = getProviderState({ ...otherPayload }, getState, section);
+    const params = { ...queryParams };
+
+    // If the user is re-testing the same provider without changes
+    // force it to be tested.
+
+    if (_.isEqual(testData, lastTestData)) {
+      params.forceTest = true;
+    }
+
+    lastTestData = testData;
 
     const ajaxOptions = {
-      url: `${url}/test`,
+      url: `${url}/test?${$.param(params, true)}`,
       method: 'POST',
       contentType: 'application/json',
       dataType: 'json',
@@ -32,6 +50,8 @@ function createTestProviderHandler(section, url) {
     abortCurrentRequests[section] = abortRequest;
 
     request.done((data) => {
+      lastTestData = null;
+
       dispatch(set({
         section,
         isTesting: false,

--- a/src/NzbDrone.Common.Test/PathExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/PathExtensionFixture.cs
@@ -3,6 +3,7 @@ using System.IO;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Test.Common;
@@ -34,7 +35,7 @@ namespace NzbDrone.Common.Test
         [TestCase(@"\\Testserver\\Test\", @"\\Testserver\Test")]
         [TestCase(@"\\Testserver\Test\file.ext", @"\\Testserver\Test\file.ext")]
         [TestCase(@"\\Testserver\Test\file.ext\\", @"\\Testserver\Test\file.ext")]
-        [TestCase(@"\\Testserver\Test\file.ext   \\", @"\\Testserver\Test\file.ext")]
+        [TestCase(@"\\Testserver\Test\file.ext   ", @"\\Testserver\Test\file.ext")]
         [TestCase(@"//CAPITAL//lower// ", @"\\CAPITAL\lower")]
         public void Clean_Path_Windows(string dirty, string clean)
         {
@@ -334,6 +335,31 @@ namespace NzbDrone.Common.Test
             result[1].Should().Be(@"Test");
             result[2].Should().Be(@"TV");
             result[3].Should().Be(@"Series Title");
+        }
+
+        [TestCase(@"C:\Test\")]
+        [TestCase(@"C:\Test")]
+        [TestCase(@"C:\Test\TV\")]
+        [TestCase(@"C:\Test\TV")]
+        public void IsPathValid_should_be_true(string path)
+        {
+            path.AsOsAgnostic().IsPathValid(PathValidationType.CurrentOs).Should().BeTrue();
+        }
+
+        [TestCase(@"C:\Test \")]
+        [TestCase(@"C:\Test ")]
+        [TestCase(@"C:\ Test\")]
+        [TestCase(@"C:\ Test")]
+        [TestCase(@"C:\Test \TV")]
+        [TestCase(@"C:\ Test\TV")]
+        [TestCase(@"C:\Test \TV\")]
+        [TestCase(@"C:\ Test\TV\")]
+        [TestCase(@" C:\Test\TV\")]
+        [TestCase(@" C:\Test\TV")]
+
+        public void IsPathValid_should_be_false(string path)
+        {
+            path.AsOsAgnostic().IsPathValid(PathValidationType.CurrentOs).Should().BeFalse();
         }
     }
 }

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -29,6 +29,12 @@ namespace NzbDrone.Common.Extensions
 
         public static string CleanFilePath(this string path)
         {
+            if (path.IsNotNullOrWhiteSpace())
+            {
+                // Trim trailing spaces before checking if the path is valid so validation doesn't fail for something we can fix.
+                path = path.TrimEnd(' ');
+            }
+
             Ensure.That(path, () => path).IsNotNullOrWhiteSpace();
             Ensure.That(path, () => path).IsValidPath(PathValidationType.AnyOs);
 
@@ -37,10 +43,10 @@ namespace NzbDrone.Common.Extensions
             // UNC
             if (!info.FullName.Contains('/') && info.FullName.StartsWith(@"\\"))
             {
-                return info.FullName.TrimEnd('/', '\\', ' ');
+                return info.FullName.TrimEnd('/', '\\');
             }
 
-            return info.FullName.TrimEnd('/').Trim('\\', ' ');
+            return info.FullName.TrimEnd('/').Trim('\\');
         }
 
         public static bool PathNotEquals(this string firstPath, string secondPath, StringComparison? comparison = null)
@@ -152,6 +158,23 @@ namespace NzbDrone.Common.Extensions
             if (string.IsNullOrWhiteSpace(path) || path.ContainsInvalidPathChars())
             {
                 return false;
+            }
+
+            if (path.Trim() != path)
+            {
+                return false;
+            }
+
+            var directoryInfo = new DirectoryInfo(path);
+
+            while (directoryInfo != null)
+            {
+                if (directoryInfo.Name.Trim() != directoryInfo.Name)
+                {
+                    return false;
+                }
+
+                directoryInfo = directoryInfo.Parent;
             }
 
             if (validationType == PathValidationType.AnyOs)
@@ -289,6 +312,11 @@ namespace NzbDrone.Common.Extensions
             }
 
             return processName;
+        }
+
+        public static string CleanPath(this string path)
+        {
+            return Path.Join(path.Split(Path.DirectorySeparatorChar).Select(s => s.Trim()).ToArray());
         }
 
         public static string GetAppDataPath(this IAppFolderInfo appFolderInfo)

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -40,9 +40,6 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("SomeShow.S20E13.1080p.Blu-Ray.DTS-ES.5.1.x264-ROUGH [PublicHD]", "ROUGH")]
         [TestCase("SomeShow S01E168 1080p WEB-DL AAC 2.0 x264-Erai-raws", "Erai-raws")]
         [TestCase("The.Good.Series.S05E03.Series.of.Intelligence.1080p.10bit.AMZN.WEB-DL.DDP5.1.HEVC-Vyndros", "Vyndros")]
-        [TestCase("[Tenrai-Sensei] Series [BD][1080p][HEVC 10bit x265][Dual Audio]", "Tenrai-Sensei")]
-        [TestCase("[Erai-raws] Series - 0955 ~ 1005 [1080p]", "Erai-raws")]
-        [TestCase("[Exiled-Destiny] Series Title", "Exiled-Destiny")]
         [TestCase("Series.Title.S01E09.1080p.DSNP.WEB-DL.DDP2.0.H.264-VARYG", "VARYG")]
 
         // [TestCase("", "")]
@@ -91,14 +88,6 @@ namespace NzbDrone.Core.Test.ParserTests
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
         }
 
-        [Test]
-        public void should_not_include_extension_in_release_group()
-        {
-            const string path = @"C:\Test\Doctor.Series.2005.s01e01.internal.bdrip.x264-archivist.mkv";
-
-            Parser.Parser.ParsePath(path).ReleaseGroup.Should().Be("archivist");
-        }
-
         [TestCase("Series.Title.S02E04.720p.WEBRip.x264-SKGTV English", "SKGTV")]
         [TestCase("Series.Title.S02E04.720p.WEBRip.x264-SKGTV_English", "SKGTV")]
         [TestCase("Series.Title.S02E04.720p.WEBRip.x264-SKGTV.English", "SKGTV")]
@@ -140,23 +129,5 @@ namespace NzbDrone.Core.Test.ParserTests
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
         }
 
-        [TestCase("[FFF] Series Title!! - S01E11 - Someday, With Sonarr", "FFF")]
-        [TestCase("[HorribleSubs] Series Title!! - S01E12 - Sonarr Going Well!!", "HorribleSubs")]
-        [TestCase("[Anime-Koi] Series Title - S01E06 - Guys From Sonarr", "Anime-Koi")]
-        [TestCase("[Anime-Koi] Series Title - S01E07 - A High-Grade Sonarr", "Anime-Koi")]
-        [TestCase("[Anime-Koi] Series Title 2 - 01 [h264-720p][28D54E2C]", "Anime-Koi")]
-
-        // [TestCase("Tokyo.Ghoul.02x01.013.HDTV-720p-Anime-Koi", "Anime-Koi")]
-        // [TestCase("", "")]
-        public void should_parse_anime_release_groups(string title, string expected)
-        {
-            Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
-        }
-
-        [TestCase("Terrible.Anime.Title.001.DBOX.480p.x264-iKaos [v3] [6AFFEF6B]")]
-        public void should_not_parse_anime_hash_as_release_group(string title)
-        {
-            Parser.Parser.ParseReleaseGroup(title).Should().BeNull();
-        }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -40,6 +40,9 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("SomeShow.S20E13.1080p.Blu-Ray.DTS-ES.5.1.x264-ROUGH [PublicHD]", "ROUGH")]
         [TestCase("SomeShow S01E168 1080p WEB-DL AAC 2.0 x264-Erai-raws", "Erai-raws")]
         [TestCase("The.Good.Series.S05E03.Series.of.Intelligence.1080p.10bit.AMZN.WEB-DL.DDP5.1.HEVC-Vyndros", "Vyndros")]
+        [TestCase("[Tenrai-Sensei] Series [BD][1080p][HEVC 10bit x265][Dual Audio]", "Tenrai-Sensei")]
+        [TestCase("[Erai-raws] Series - 0955 ~ 1005 [1080p]", "Erai-raws")]
+        [TestCase("[Exiled-Destiny] Series Title", "Exiled-Destiny")]
         [TestCase("Series.Title.S01E09.1080p.DSNP.WEB-DL.DDP2.0.H.264-VARYG", "VARYG")]
 
         // [TestCase("", "")]
@@ -81,6 +84,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series Title - S01E01 - Girls Gone Wild Exposed (720p x265 EDGE2020).mkv", "EDGE2020")]
         [TestCase("Series.Title.S01E02.1080p.BluRay.Remux.AVC.FLAC.2.0-E.N.D", "E.N.D")]
         [TestCase("Show Name (2016) Season 1 S01 (1080p AMZN WEB-DL x265 HEVC 10bit EAC3 5 1 RZeroX) QxR", "RZeroX")]
+        [TestCase("Series Title S01 1080p Blu-ray Remux AVC FLAC 2.0 - KRaLiMaRKo", "KRaLiMaRKo")]
+        [TestCase("Series Title S01 1080p Blu-ray Remux AVC DTS-HD MA 2.0 - BluDragon", "BluDragon")]
         public void should_parse_exception_release_group(string title, string expected)
         {
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
@@ -89,7 +94,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [Test]
         public void should_not_include_extension_in_release_group()
         {
-            const string path = @"C:\Test\Doctor.Series.2005.22.12.24.internal.bdrip.x264-archivist.mkv";
+            const string path = @"C:\Test\Doctor.Series.2005.s01e01.internal.bdrip.x264-archivist.mkv";
 
             Parser.Parser.ParsePath(path).ReleaseGroup.Should().Be("archivist");
         }
@@ -118,14 +123,14 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series.Title.S08E05.The.Forgotten.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb-Rakuv", "NTb")]
         [TestCase("The.Series.S30E01.Devs.Not.Dead.1080p.AMZN.WEB-DL.DDP5.1.H264-QOQ-Rakuv02", "QOQ")]
         [TestCase("Lie.To.Developers.S01E13.720p.BluRay.x264-SiNNERS-Rakuvfinhel", "SiNNERS")]
-        [TestCase("Who.is.Whisparr.S01E01.INTERNAL.720p.HDTV.x264-aAF-RakuvUS-Obfuscated", "aAF")]
+        [TestCase("Who.is.Sonarr.S01E01.INTERNAL.720p.HDTV.x264-aAF-RakuvUS-Obfuscated", "aAF")]
         [TestCase("Deadly.Development.S01E10.Sink.With.Code.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTG-WhiteRev", "NTG")]
-        [TestCase("The.Whisparr.Series.S09E12.Developers.REPACK.1080p.AMZN.WEB-DL.DD.5.1.H.264-CasStudio-BUYMORE", "CasStudio")]
+        [TestCase("The.Sonarr.Series.S09E12.Developers.REPACK.1080p.AMZN.WEB-DL.DD.5.1.H.264-CasStudio-BUYMORE", "CasStudio")]
         [TestCase("2.Tired.Developers.S02E24.1080p.AMZN.WEBRip.DD5.1.x264-CasStudio-AsRequested", "CasStudio")]
         [TestCase("Series.S04E11.Lines.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb-AlternativeToRequested", "NTb")]
         [TestCase("Series.S16E04.Third.Wheel.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb-GEROV", "NTb")]
         [TestCase("Series.and.Title.S10E06.Dev.n.Play.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTb-Z0iDS3N", "NTb")]
-        [TestCase("Absolute.Series.S02E06.The.House.of.Whisparr.DVDRip.x264-MaG-Chamele0n", "MaG")]
+        [TestCase("Absolute.Series.S02E06.The.House.of.Sonarr.DVDRip.x264-MaG-Chamele0n", "MaG")]
         [TestCase("The.Series.Title.S08E08.1080p.BluRay.x264-ROVERS-4P", "ROVERS")]
         [TestCase("Series.Title.S01E02.720p.BluRay.X264-REWARD-4Planet", "REWARD")]
         [TestCase("Series.S01E01.Rites.of.Passage.1080p.BluRay.x264-DON-AlteZachen", "DON")]
@@ -135,26 +140,21 @@ namespace NzbDrone.Core.Test.ParserTests
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
         }
 
-        [TestCase("Terrible.Anime.Title.001.DBOX.480p.x264-iKaos [v3] [6AFFEF6B]")]
-        public void should_not_parse_anime_hash_as_release_group(string title)
-        {
-            Parser.Parser.ParseReleaseGroup(title).Should().BeNull();
-        }
+        [TestCase("[FFF] Series Title!! - S01E11 - Someday, With Sonarr", "FFF")]
+        [TestCase("[HorribleSubs] Series Title!! - S01E12 - Sonarr Going Well!!", "HorribleSubs")]
+        [TestCase("[Anime-Koi] Series Title - S01E06 - Guys From Sonarr", "Anime-Koi")]
+        [TestCase("[Anime-Koi] Series Title - S01E07 - A High-Grade Sonarr", "Anime-Koi")]
+        [TestCase("[Anime-Koi] Series Title 2 - 01 [h264-720p][28D54E2C]", "Anime-Koi")]
 
-        [TestCase("Lubed.25.06.24.Tess.Thompson.XXX.1080p.HEVC.x265.PRT", "PRT")]
-        [TestCase("Series.Title.S01E01.720p.WEB.H264.WRB", "WRB")]
-        [TestCase("Series.Title.S01E01.720p.WEB.H264.KTR", "KTR")]
-        [TestCase("Some.Series.23.05.15.Title.1080p.WEB.x265.ABC", "ABC")]
-        public void should_parse_period_prefixed_release_group(string title, string expected)
+        // [TestCase("Tokyo.Ghoul.02x01.013.HDTV-720p-Anime-Koi", "Anime-Koi")]
+        // [TestCase("", "")]
+        public void should_parse_anime_release_groups(string title, string expected)
         {
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
         }
 
-        [TestCase("Series.Title.S01E01.720p.WEB.x264")]
-        [TestCase("Series.Title.S01E01.720p.WEB.hevc")]
-        [TestCase("Series.Title.S01E01.720p.WEB.English")]
-        [TestCase("Series.Title.S01E01.720p.WEB.dvdrip")]
-        public void should_not_parse_codec_or_language_as_period_release_group(string title)
+        [TestCase("Terrible.Anime.Title.001.DBOX.480p.x264-iKaos [v3] [6AFFEF6B]")]
+        public void should_not_parse_anime_hash_as_release_group(string title)
         {
             Parser.Parser.ParseReleaseGroup(title).Should().BeNull();
         }

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -128,6 +128,5 @@ namespace NzbDrone.Core.Test.ParserTests
         {
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);
         }
-
     }
 }

--- a/src/NzbDrone.Core/Datastore/CorruptDatabaseException.cs
+++ b/src/NzbDrone.Core/Datastore/CorruptDatabaseException.cs
@@ -3,7 +3,7 @@ using NzbDrone.Common.Exceptions;
 
 namespace NzbDrone.Core.Datastore
 {
-    public class CorruptDatabaseException : NzbDroneException
+    public class CorruptDatabaseException : SonarrStartupException
     {
         public CorruptDatabaseException(string message, params object[] args)
             : base(message, args)
@@ -16,12 +16,12 @@ namespace NzbDrone.Core.Datastore
         }
 
         public CorruptDatabaseException(string message, Exception innerException, params object[] args)
-            : base(message, innerException, args)
+            : base(innerException, message, args)
         {
         }
 
         public CorruptDatabaseException(string message, Exception innerException)
-            : base(message, innerException)
+            : base(innerException, message)
         {
         }
     }

--- a/src/NzbDrone.Core/Datastore/CorruptDatabaseException.cs
+++ b/src/NzbDrone.Core/Datastore/CorruptDatabaseException.cs
@@ -3,7 +3,7 @@ using NzbDrone.Common.Exceptions;
 
 namespace NzbDrone.Core.Datastore
 {
-    public class CorruptDatabaseException : SonarrStartupException
+    public class CorruptDatabaseException : WhisparrStartupException
     {
         public CorruptDatabaseException(string message, params object[] args)
             : base(message, args)

--- a/src/NzbDrone.Core/Download/DownloadClientBase.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientBase.cs
@@ -32,6 +32,7 @@ namespace NzbDrone.Core.Download
                 {
                     { Result.HasHttpServerError: true } => PredicateResult.True(),
                     { Result.StatusCode: HttpStatusCode.RequestTimeout } => PredicateResult.True(),
+                    { Exception: HttpException { Response.HasHttpServerError: true } } => PredicateResult.True(),
                     _ => PredicateResult.False()
                 },
                 Delay = TimeSpan.FromSeconds(3),

--- a/src/NzbDrone.Core/Extras/ExistingExtraFileService.cs
+++ b/src/NzbDrone.Core/Extras/ExistingExtraFileService.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Extras
 {
     public interface IExistingExtraFiles
     {
-        List<string> ImportExtraFiles(Series series, List<string> possibleExtraFiles);
+        List<string> ImportExtraFiles(Series series, List<string> possibleExtraFiles, bool keepExistingEntries);
     }
 
     public class ExistingExtraFileService : IExistingExtraFiles, IHandle<SeriesScannedEvent>
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Extras
             _logger = logger;
         }
 
-        public List<string> ImportExtraFiles(Series series, List<string> possibleExtraFiles)
+        public List<string> ImportExtraFiles(Series series, List<string> possibleExtraFiles, bool keepExistingEntries)
         {
             _logger.Debug("Looking for existing extra files in {0}", series.Path);
 
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Extras
 
             foreach (var existingExtraFileImporter in _existingExtraFileImporters)
             {
-                var imported = existingExtraFileImporter.ProcessFiles(series, possibleExtraFiles, importedFiles);
+                var imported = existingExtraFileImporter.ProcessFiles(series, possibleExtraFiles, importedFiles, keepExistingEntries);
 
                 importedFiles.AddRange(imported.Select(f => Path.Combine(series.Path, f.RelativePath)));
             }
@@ -45,7 +45,7 @@ namespace NzbDrone.Core.Extras
         {
             var series = message.Series;
             var possibleExtraFiles = message.PossibleExtraFiles;
-            var importedFiles = ImportExtraFiles(series, possibleExtraFiles);
+            var importedFiles = ImportExtraFiles(series, possibleExtraFiles, false);
 
             _logger.Info("Found {0} possible extra files, imported {1} files.", possibleExtraFiles.Count, importedFiles.Count);
         }

--- a/src/NzbDrone.Core/Extras/IImportExistingExtraFiles.cs
+++ b/src/NzbDrone.Core/Extras/IImportExistingExtraFiles.cs
@@ -7,6 +7,6 @@ namespace NzbDrone.Core.Extras
     public interface IImportExistingExtraFiles
     {
         int Order { get; }
-        IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles);
+        IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles, bool keepExistingEntries);
     }
 }

--- a/src/NzbDrone.Core/Extras/ImportExistingExtraFilesBase.cs
+++ b/src/NzbDrone.Core/Extras/ImportExistingExtraFilesBase.cs
@@ -19,10 +19,15 @@ namespace NzbDrone.Core.Extras
         }
 
         public abstract int Order { get; }
-        public abstract IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles);
+        public abstract IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles, bool keepExistingEntries);
 
-        public virtual ImportExistingExtraFileFilterResult<TExtraFile> FilterAndClean(Series series, List<string> filesOnDisk, List<string> importedFiles)
+        public virtual ImportExistingExtraFileFilterResult<TExtraFile> FilterAndClean(Series series, List<string> filesOnDisk, List<string> importedFiles, bool keepExistingEntries)
         {
+            if (keepExistingEntries)
+            {
+                return Filter(series, filesOnDisk, importedFiles, new List<TExtraFile>());
+            }
+
             var seriesFiles = _extraFileService.GetFilesBySeries(series.Id);
 
             Clean(series, filesOnDisk, importedFiles, seriesFiles);

--- a/src/NzbDrone.Core/Extras/ImportExistingExtraFilesBase.cs
+++ b/src/NzbDrone.Core/Extras/ImportExistingExtraFilesBase.cs
@@ -23,12 +23,16 @@ namespace NzbDrone.Core.Extras
 
         public virtual ImportExistingExtraFileFilterResult<TExtraFile> FilterAndClean(Series series, List<string> filesOnDisk, List<string> importedFiles, bool keepExistingEntries)
         {
+            var seriesFiles = _extraFileService.GetFilesBySeries(series.Id);
+
             if (keepExistingEntries)
             {
+                var incompleteImports = seriesFiles.IntersectBy(f => Path.Combine(series.Path, f.RelativePath), filesOnDisk, i => i, PathEqualityComparer.Instance).Select(f => f.Id);
+
+                _extraFileService.DeleteMany(incompleteImports);
+
                 return Filter(series, filesOnDisk, importedFiles, new List<TExtraFile>());
             }
-
-            var seriesFiles = _extraFileService.GetFilesBySeries(series.Id);
 
             Clean(series, filesOnDisk, importedFiles, seriesFiles);
 

--- a/src/NzbDrone.Core/Extras/Metadata/ExistingMetadataImporter.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/ExistingMetadataImporter.cs
@@ -33,12 +33,12 @@ namespace NzbDrone.Core.Extras.Metadata
 
         public override int Order => 0;
 
-        public override IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles)
+        public override IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles, bool keepExistingEntries)
         {
             _logger.Debug("Looking for existing metadata in {0}", series.Path);
 
             var metadataFiles = new List<MetadataFile>();
-            var filterResult = FilterAndClean(series, filesOnDisk, importedFiles);
+            var filterResult = FilterAndClean(series, filesOnDisk, importedFiles, keepExistingEntries);
 
             foreach (var possibleMetadataFile in filterResult.FilesOnDisk)
             {

--- a/src/NzbDrone.Core/Extras/Others/ExistingOtherExtraImporter.cs
+++ b/src/NzbDrone.Core/Extras/Others/ExistingOtherExtraImporter.cs
@@ -28,12 +28,12 @@ namespace NzbDrone.Core.Extras.Others
 
         public override int Order => 2;
 
-        public override IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles)
+        public override IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles, bool keepExistingEntries)
         {
             _logger.Debug("Looking for existing extra files in {0}", series.Path);
 
             var extraFiles = new List<OtherExtraFile>();
-            var filterResult = FilterAndClean(series, filesOnDisk, importedFiles);
+            var filterResult = FilterAndClean(series, filesOnDisk, importedFiles, keepExistingEntries);
 
             foreach (var possibleExtraFile in filterResult.FilesOnDisk)
             {

--- a/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
+++ b/src/NzbDrone.Core/Extras/Subtitles/ExistingSubtitleImporter.cs
@@ -29,12 +29,12 @@ namespace NzbDrone.Core.Extras.Subtitles
 
         public override int Order => 1;
 
-        public override IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles)
+        public override IEnumerable<ExtraFile> ProcessFiles(Series series, List<string> filesOnDisk, List<string> importedFiles, bool keepExistingEntries)
         {
             _logger.Debug("Looking for existing subtitle files in {0}", series.Path);
 
             var subtitleFiles = new List<SubtitleFile>();
-            var filterResult = FilterAndClean(series, filesOnDisk, importedFiles);
+            var filterResult = FilterAndClean(series, filesOnDisk, importedFiles, keepExistingEntries);
 
             foreach (var possibleSubtitleFile in filterResult.FilesOnDisk)
             {

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -260,6 +260,7 @@
   "CustomFormats": "Custom Formats",
   "CustomFormatsLoadError": "Unable to load Custom Formats",
   "CustomFormatsSettings": "Custom Formats Settings",
+  "CustomFormatsSettingsTriggerInfo": "A Custom Format will be applied to a release or file when it matches at least one of each of the different condition types chosen.",
   "CustomFormatsSettingsSummary": "Custom Formats and Settings",
   "CustomFormatsSpecificationFlag": "Flag",
   "Cutoff": "Cutoff",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -345,7 +345,7 @@
   "DeleteTag": "DeleteTag",
   "DeleteTagMessageText": "Are you sure you want to delete the tag '{label}'?",
   "Deleted": "Deleted",
-  "DeletedReasonManual": "File was deleted by via UI",
+  "DeletedReasonManual": "File was deleted using {appName}, either manually or by another tool through the API",
   "DeletedReasonMissingFromDisk": "Whisparr was unable to find the file on disk so the file was unlinked from the episode in the database",
   "DeletedReasonUpgrade": "File was deleted to import an upgrade",
   "DeletedSiteDescription": "Site was deleted from TheTPDB",

--- a/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DiskScanService.cs
@@ -174,10 +174,16 @@ namespace NzbDrone.Core.MediaFiles
             fileInfoStopwatch.Stop();
             _logger.Trace("Reprocessing existing files complete for: {0} [{1}]", series, decisionsStopwatch.Elapsed);
 
-            var filesOnDisk = GetNonVideoFiles(series.Path);
-            var possibleExtraFiles = FilterPaths(series.Path, filesOnDisk);
-
             RemoveEmptySeriesFolder(series.Path);
+
+            var possibleExtraFiles = new List<string>();
+
+            if (_diskProvider.FolderExists(series.Path))
+            {
+                var extraFiles = GetNonVideoFiles(series.Path);
+                possibleExtraFiles = FilterPaths(series.Path, extraFiles);
+            }
+
             CompletedScanning(series, possibleExtraFiles);
         }
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
@@ -123,6 +123,11 @@ namespace NzbDrone.Core.MediaFiles
 
             episodeFile.RelativePath = series.Path.GetRelativePath(destinationFilePath);
 
+            if (localEpisode is not null)
+            {
+                localEpisode.FileNameBeforeRename = episodeFile.RelativePath;
+            }
+
             if (localEpisode is not null && _scriptImportDecider.TryImport(episodeFilePath, destinationFilePath, localEpisode, episodeFile, mode) is var scriptImportDecision && scriptImportDecision != ScriptImportDecision.DeferMove)
             {
                 if (scriptImportDecision == ScriptImportDecision.RenameRequested)

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportApprovedEpisodes.cs
@@ -155,7 +155,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
                     {
                         if (localEpisode.ScriptImported)
                         {
-                            _existingExtraFiles.ImportExtraFiles(localEpisode.Series, localEpisode.PossibleExtraFiles);
+                            _existingExtraFiles.ImportExtraFiles(localEpisode.Series, localEpisode.PossibleExtraFiles, true);
 
                             if (localEpisode.FileRenamedAfterScriptImport)
                             {

--- a/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/NtfyProxy.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Net;
-
 using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Extensions;
@@ -112,18 +111,18 @@ namespace NzbDrone.Core.Notifications.Ntfy
         {
             try
             {
-                requestBuilder.Headers.Add("X-Title", title);
-                requestBuilder.Headers.Add("X-Message", message);
-                requestBuilder.Headers.Add("X-Priority", settings.Priority.ToString());
+                requestBuilder.AddQueryParam("title", title);
+                requestBuilder.AddQueryParam("message", message);
+                requestBuilder.AddQueryParam("priority", settings.Priority.ToString());
 
                 if (settings.Tags.Any())
                 {
-                    requestBuilder.Headers.Add("X-Tags", settings.Tags.Join(","));
+                    requestBuilder.AddQueryParam("tags", settings.Tags.Join(","));
                 }
 
                 if (!settings.ClickUrl.IsNullOrWhiteSpace())
                 {
-                    requestBuilder.Headers.Add("X-Click", settings.ClickUrl);
+                    requestBuilder.AddQueryParam("click", settings.ClickUrl);
                 }
 
                 if (!settings.AccessToken.IsNullOrWhiteSpace())

--- a/src/NzbDrone.Core/Notifications/Telegram/TelegramProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/TelegramProxy.cs
@@ -50,10 +50,11 @@ namespace NzbDrone.Core.Notifications.Telegram
         {
             try
             {
+                const string brandedTitle = "Whisparr - Test Notification";
                 const string title = "Test Notification";
                 const string body = "This is a test message from Whisparr";
 
-                SendNotification(title, body, settings);
+                SendNotification(settings.IncludeAppNameInTitle ? brandedTitle : title, body, settings);
             }
             catch (Exception ex)
             {

--- a/src/NzbDrone.Core/Notifications/Telegram/TelegramSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/TelegramSettings.cs
@@ -32,6 +32,9 @@ namespace NzbDrone.Core.Notifications.Telegram
         [FieldDefinition(3, Label = "Send Silently", Type = FieldType.Checkbox, HelpText = "Sends the message silently. Users will receive a notification with no sound")]
         public bool SendSilently { get; set; }
 
+        [FieldDefinition(4, Label = "Include {appName} in Title", Type = FieldType.Checkbox, HelpText = "Optionally prefix message title with {appName} to differentiate notifications from different applications")]
+        public bool IncludeAppNameInTitle { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));

--- a/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
+++ b/src/NzbDrone.Core/Parser/Model/LocalEpisode.cs
@@ -42,6 +42,7 @@ namespace NzbDrone.Core.Parser.Model
         public int CustomFormatScore { get; set; }
         public GrabbedReleaseInfo Release { get; set; }
         public bool ScriptImported { get; set; }
+        public string FileNameBeforeRename { get; set; }
         public bool FileRenamedAfterScriptImport { get; set; }
         public bool ShouldImportExtras { get; set; }
         public List<string> PossibleExtraFiles { get; set; }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -231,7 +231,7 @@ namespace NzbDrone.Core.Parser
 
         // Handle Exception Release Groups that don't follow -RlsGrp; Manual List
         // name only...be very careful with this last; high chance of false positives
-        private static readonly Regex ExceptionReleaseGroupRegexExact = new Regex(@"(?<releasegroup>(?:D\-Z0N3|Fight-BB|VARYG|E\.N\.D)\b)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex ExceptionReleaseGroupRegexExact = new Regex(@"(?<releasegroup>(?:D\-Z0N3|Fight-BB|VARYG|E\.N\.D|KRaLiMaRKo|BluDragon)\b)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         // groups whose releases end with RlsGroup) or RlsGroup]
         private static readonly Regex ExceptionReleaseGroupRegex = new Regex(@"(?<releasegroup>(Silence|afm72|Panda|Ghost|MONOLITH|Tigole|Joy|ImE|UTR|t3nzin|Anime Time|Project Angel|Hakata Ramen|HONE|Vyndros|SEV|Garshasp|Kappa|Natty|RCVR|SAMPA|YOGI|r00t|EDGE2020|RZeroX)(?=\]|\)))", RegexOptions.IgnoreCase | RegexOptions.Compiled);

--- a/src/NzbDrone.Mono/Disk/FindDriveType.cs
+++ b/src/NzbDrone.Mono/Disk/FindDriveType.cs
@@ -6,15 +6,16 @@ namespace NzbDrone.Mono.Disk
 {
     public static class FindDriveType
     {
-        private static readonly Dictionary<string, DriveType> DriveTypeMap = new Dictionary<string, DriveType>
-                                                                                  {
-                                                                                      { "afpfs", DriveType.Network },
-                                                                                      { "apfs", DriveType.Fixed },
-                                                                                      { "fuse.mergerfs", DriveType.Fixed },
-                                                                                      { "fuse.glusterfs", DriveType.Network },
-                                                                                      { "nullfs", DriveType.Fixed },
-                                                                                      { "zfs", DriveType.Fixed }
-                                                                                  };
+        private static readonly Dictionary<string, DriveType> DriveTypeMap = new ()
+        {
+            { "afpfs", DriveType.Network },
+            { "apfs", DriveType.Fixed },
+            { "fuse.mergerfs", DriveType.Fixed },
+            { "fuse.shfs", DriveType.Fixed },
+            { "fuse.glusterfs", DriveType.Network },
+            { "nullfs", DriveType.Fixed },
+            { "zfs", DriveType.Fixed }
+        };
 
         public static DriveType Find(string driveFormat)
         {

--- a/src/NzbDrone.Windows/Disk/DiskProvider.cs
+++ b/src/NzbDrone.Windows/Disk/DiskProvider.cs
@@ -170,6 +170,11 @@ namespace NzbDrone.Windows.Disk
         {
             try
             {
+                if (source.Length > 256 && !source.StartsWith(@"\\?\"))
+                {
+                    source = @"\\?\" + source;
+                }
+
                 return CreateHardLink(destination, source, IntPtr.Zero);
             }
             catch (Exception ex)

--- a/src/Whisparr.Api.V3/ProviderControllerBase.cs
+++ b/src/Whisparr.Api.V3/ProviderControllerBase.cs
@@ -205,10 +205,10 @@ namespace Whisparr.Api.V3
         [SkipValidation(true, false)]
         [HttpPost("test")]
         [Consumes("application/json")]
-        public object Test([FromBody] TProviderResource providerResource)
+        public object Test([FromBody] TProviderResource providerResource, [FromQuery] bool forceTest = false)
         {
             var existingDefinition = providerResource.Id > 0 ? _providerFactory.Find(providerResource.Id) : null;
-            var providerDefinition = GetDefinition(providerResource, existingDefinition, true, true, true);
+            var providerDefinition = GetDefinition(providerResource, existingDefinition, true, !forceTest, true);
 
             Test(providerDefinition, true);
 

--- a/src/Whisparr.Api.V3/Series/SeriesController.cs
+++ b/src/Whisparr.Api.V3/Series/SeriesController.cs
@@ -88,8 +88,6 @@ namespace Whisparr.Api.V3.Series
                          .When(s => s.Path.IsNullOrWhiteSpace());
             PostValidator.RuleFor(s => s.Title).NotEmpty();
             PostValidator.RuleFor(s => s.TvdbId).GreaterThan(0).SetValidator(seriesExistsValidator);
-
-            PutValidator.RuleFor(s => s.Path).IsValidPath();
         }
 
         [HttpGet]


### PR DESCRIPTION
Cherry-picked commits from Sonarr v5-develop for April 2024.

  Applied Commits (16)

  Sonarr/Sonarr@6003ca169 - Fixed: Deleted episodes not being unmonitored when series folder has been deleted
  Sonarr/Sonarr@0a7f3a12c - Do not remove all extras when script importing
  Sonarr/Sonarr@7776ec995 - Reimport files imported prematurely during script import
  Sonarr/Sonarr@238ba85f0 - New: Informational text on Custom Formats modal
  Sonarr/Sonarr@e672996db - Improve text for file deleted through UI/API
  Sonarr/Sonarr@a169ebff2 - Fixed: Sending ntfy.sh notifications with unicode characters
  Sonarr/Sonarr@37863a8de - New: Option to prefix app name on Telegram notification titles
  Sonarr/Sonarr@fc06e5135 - Fixed: Renaming episodes for a series
  Sonarr/Sonarr@1aef91041 - New: Detect shfs mounts in disk space
  Sonarr/Sonarr@e96625446 - Fixed: Re-testing edited providers will forcibly test them
  Sonarr/Sonarr@a97fbcc40 - Fixed: Improve paths longer than 256 on Windows failing to hardlink
  Sonarr/Sonarr@316b5cbf7 - New: Validate that folders in paths don't start or end with a space
  Sonarr/Sonarr@1df7cdc65 - New: Add KRaLiMaRKo and BluDragon to release group parsing exceptions
  Sonarr/Sonarr@973810104 - Treat CorruptDatabaseException as a startup failure
  Sonarr/Sonarr@04bd535cf - New: Don't initially select 0 byte files in Interactive Import
  Sonarr/Sonarr@efb3fa93e - Fixed: Retrying download for pushed releases

  Skipped Commits

  Sonarr/Sonarr@60ee7cc71 - BHD RSS key cleansing (BHD doesn't support XXX)
  Sonarr/Sonarr@0937ee6fe - Path parsing fix (complex parser conflicts)
  Sonarr/Sonarr@2ef46e5b9 - Subtitle copy regex (language parser conflicts)
  Sonarr/Sonarr@af5a681ab - Pre-rename episodefile fix (modify/delete conflicts)
  Sonarr/Sonarr@7fc3bebc9 - Truncation tokens footnote (separate PR)
  Sonarr/Sonarr@74cdf01e4 - Set Release Type in Manual Import (7 conflicts)
  Sonarr/Sonarr@f4c19a384 - Auto tag based on tags present/absent (multiple conflicts)
  Sonarr/Sonarr@1fcd2b492 - Custom Formats enumeration (FileNameBuilder diverged)
  Sonarr/Sonarr@476e7a7b9 - Release Type in Manage Episodes (tied to Release Type feature)
  Sonarr/Sonarr@d051dac12 - Environment Variables for config.xml (complex conflicts)
  Sonarr/Sonarr@c81ae6546 - Limit titles in task name (file deleted in Whisparr)