### PR TITLE
Fix WHISPARR__AUTH__APIKEY environment variable not being honored

### DIFF
--- a/src/NzbDrone.Common.Test/ConfigFileProviderTest.cs
+++ b/src/NzbDrone.Common.Test/ConfigFileProviderTest.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using FluentAssertions;
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Options;
 using NzbDrone.Core.Authentication;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Test.Common;
@@ -196,6 +198,42 @@ namespace NzbDrone.Common.Test
             _configFileContents = "{ \"key\": \"value\" }";
 
             Assert.Throws<InvalidConfigFileException>(() => Subject.GetValue("key", "value"));
+        }
+
+        [Test]
+        public void ApiKey_should_use_auth_options_when_provided()
+        {
+            var authOptions = new AuthOptions { ApiKey = "test-api-key-from-env" };
+            Mocker.SetConstant<IOptions<AuthOptions>>(Options.Create(authOptions));
+
+            var result = Subject.ApiKey;
+
+            result.Should().Be("test-api-key-from-env");
+        }
+
+        [Test]
+        public void ApiKey_should_fallback_to_generated_when_auth_options_null()
+        {
+            var authOptions = new AuthOptions { ApiKey = null };
+            Mocker.SetConstant<IOptions<AuthOptions>>(Options.Create(authOptions));
+
+            var result = Subject.ApiKey;
+
+            result.Should().NotBeNullOrWhiteSpace();
+            result.Should().HaveLength(32); // Generated API keys are 32 chars (GUID without dashes)
+        }
+
+        [Test]
+        public void ApiKey_should_fallback_to_config_file_when_auth_options_null()
+        {
+            var authOptions = new AuthOptions { ApiKey = null };
+            Mocker.SetConstant<IOptions<AuthOptions>>(Options.Create(authOptions));
+
+            _configFileContents = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Config><ApiKey>config-file-api-key</ApiKey></Config>";
+
+            var result = Subject.ApiKey;
+
+            result.Should().Be("config-file-api-key");
         }
     }
 }

--- a/src/NzbDrone.Common/Options/AuthOptions.cs
+++ b/src/NzbDrone.Common/Options/AuthOptions.cs
@@ -1,0 +1,8 @@
+namespace NzbDrone.Common.Options;
+
+public class AuthOptions
+{
+    public string ApiKey { get; set; }
+    public string Method { get; set; }
+    public string Required { get; set; }
+}

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -16,6 +16,7 @@ using NzbDrone.Core.Datastore;
 using NzbDrone.Core.Lifecycle;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Common.Options;
 using NzbDrone.Core.Update;
 
 namespace NzbDrone.Core.Configuration
@@ -72,6 +73,7 @@ namespace NzbDrone.Core.Configuration
         private readonly IDiskProvider _diskProvider;
         private readonly ICached<string> _cache;
         private readonly PostgresOptions _postgresOptions;
+        private readonly AuthOptions _authOptions;
 
         private readonly string _configFile;
         private static readonly Regex HiddenCharacterRegex = new Regex("[^a-z0-9]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -82,13 +84,15 @@ namespace NzbDrone.Core.Configuration
                                   ICacheManager cacheManager,
                                   IEventAggregator eventAggregator,
                                   IDiskProvider diskProvider,
-                                  IOptions<PostgresOptions> postgresOptions)
+                                  IOptions<PostgresOptions> postgresOptions,
+                                  IOptions<AuthOptions> authOptions)
         {
             _cache = cacheManager.GetCache<string>(GetType());
             _eventAggregator = eventAggregator;
             _diskProvider = diskProvider;
             _configFile = appFolderInfo.GetConfigPath();
             _postgresOptions = postgresOptions.Value;
+            _authOptions = authOptions.Value;
         }
 
         public string WhisparrMetadata
@@ -198,7 +202,7 @@ namespace NzbDrone.Core.Configuration
         {
             get
             {
-                var apiKey = GetValue("ApiKey", GenerateApiKey());
+                var apiKey = _authOptions?.ApiKey ?? GetValue("ApiKey", GenerateApiKey());
 
                 if (apiKey.IsNullOrWhiteSpace())
                 {

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -24,6 +24,7 @@ using NzbDrone.Common.Instrumentation;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Datastore.Extensions;
+using AuthOptions = NzbDrone.Common.Options.AuthOptions;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 using PostgresOptions = NzbDrone.Core.Datastore.PostgresOptions;
 
@@ -98,6 +99,7 @@ namespace NzbDrone.Host
                             .ConfigureServices(services =>
                             {
                                 services.Configure<PostgresOptions>(config.GetSection("Whisparr:Postgres"));
+                                services.Configure<AuthOptions>(config.GetSection("Whisparr:Auth"));
                             }).Build();
 
                         break;
@@ -156,6 +158,7 @@ namespace NzbDrone.Host
                 .ConfigureServices(services =>
                 {
                     services.Configure<PostgresOptions>(config.GetSection("Whisparr:Postgres"));
+                    services.Configure<AuthOptions>(config.GetSection("Whisparr:Auth"));
                 })
                 .ConfigureWebHost(builder =>
                 {


### PR DESCRIPTION
  ## Description

  Fix `WHISPARR__AUTH__APIKEY` environment variable not being honored.

  Add `AuthOptions` class and wire it up following the existing `PostgresOptions` pattern to enable environment variable configuration for API key.

  Fixes #992

  ## Changes

  - Add `AuthOptions.cs` with `ApiKey` property
  - Register `AuthOptions` in `Bootstrap.cs` via `services.Configure`
  - Inject `IOptions<AuthOptions>` into `ConfigFileProvider`
  - Check `_authOptions?.ApiKey` before falling back to `config.xml`
  - Add 3 unit tests for the new functionality

  ## How Has This Been Tested?

  Unit tests added:
  - `ApiKey_should_use_auth_options_when_provided`
  - `ApiKey_should_fallback_to_generated_when_auth_options_null`
  - `ApiKey_should_fallback_to_config_file_when_auth_options_null`