### PR TITLE
Fix: Handle null episode in manual interaction notifications

### DIFF
--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -214,6 +214,12 @@ namespace NzbDrone.Core.Notifications
 
         public void Handle(ManualInteractionRequiredEvent message)
         {
+            if (message.Episode == null)
+            {
+                _logger.Trace("Skipping manual interaction notification, episode data is not available");
+                return;
+            }
+
             var manualInteractionMessage = new ManualInteractionRequiredMessage
             {
                 Message = GetMessage(message.Episode.Series, message.Episode.Episodes, message.Episode.ParsedEpisodeInfo.Quality),

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -214,18 +214,17 @@ namespace NzbDrone.Core.Notifications
 
         public void Handle(ManualInteractionRequiredEvent message)
         {
-            if (message.Episode == null)
-            {
-                _logger.Trace("Skipping manual interaction notification, episode data is not available");
-                return;
-            }
+            var remoteEpisode = message.Episode;
+            var series = remoteEpisode?.Series;
 
             var manualInteractionMessage = new ManualInteractionRequiredMessage
             {
-                Message = GetMessage(message.Episode.Series, message.Episode.Episodes, message.Episode.ParsedEpisodeInfo.Quality),
-                Series = message.Episode.Series,
-                Quality = message.Episode.ParsedEpisodeInfo.Quality,
-                Episode = message.Episode,
+                Message = remoteEpisode != null
+                    ? GetMessage(series, remoteEpisode.Episodes, remoteEpisode.ParsedEpisodeInfo.Quality)
+                    : message.TrackedDownload.DownloadItem.Title,
+                Series = series,
+                Quality = remoteEpisode?.ParsedEpisodeInfo?.Quality,
+                Episode = remoteEpisode,
                 TrackedDownload = message.TrackedDownload,
                 DownloadClientInfo = message.TrackedDownload.DownloadItem.DownloadClientInfo,
                 DownloadId = message.TrackedDownload.DownloadItem.DownloadId,
@@ -236,7 +235,7 @@ namespace NzbDrone.Core.Notifications
             {
                 try
                 {
-                    if (!ShouldHandleSeries(notification.Definition, message.Episode.Series))
+                    if (series != null && !ShouldHandleSeries(notification.Definition, series))
                     {
                         continue;
                     }


### PR DESCRIPTION
Was getting various errors in logs like so 

```
[Error] EventAggregator: NotificationService failed while processing [ManualInteractionRequiredEvent]

  [v2.1.0.63] System.NullReferenceException: Object reference not set to an instance of an object.
     at NzbDrone.Core.Notifications.NotificationService.Handle(ManualInteractionRequiredEvent message) in ./Whisparr.Core/Notifications/NotificationService.cs:line 217
     at NzbDrone.Core.Messaging.Events.EventAggregator.PublishEvent[TEvent](TEvent event)
```

This was happening due to non matches episodes in the queue. The notification call was trying to run but the episode data was null due to no match. Now it returns early and logs to prevent the null reference