### PR TITLE
New: Make JAV Tab

### DIFF
--- a/frontend/src/AddSeries/AddNewSeries/AddNewSeriesConnector.js
+++ b/frontend/src/AddSeries/AddNewSeries/AddNewSeriesConnector.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
-import { clearAddSeries, lookupSeries } from 'Store/Actions/addSeriesActions';
+import { clearAddSeries, lookupSeries, setAddSeriesDefault } from 'Store/Actions/addSeriesActions';
 import { fetchRootFolders } from 'Store/Actions/rootFolderActions';
 import parseUrl from 'Utilities/String/parseUrl';
 import AddNewSeries from './AddNewSeries';
@@ -27,6 +27,7 @@ function createMapStateToProps() {
 const mapDispatchToProps = {
   lookupSeries,
   clearAddSeries,
+  setAddSeriesDefault,
   fetchRootFolders
 };
 
@@ -43,6 +44,10 @@ class AddNewSeriesConnector extends Component {
 
   componentDidMount() {
     this.props.fetchRootFolders();
+
+    if (this.props.defaultSeriesType) {
+      this.props.setAddSeriesDefault({ seriesType: this.props.defaultSeriesType });
+    }
   }
 
   componentWillUnmount() {
@@ -96,8 +101,10 @@ class AddNewSeriesConnector extends Component {
 
 AddNewSeriesConnector.propTypes = {
   term: PropTypes.string,
+  defaultSeriesType: PropTypes.string,
   lookupSeries: PropTypes.func.isRequired,
   clearAddSeries: PropTypes.func.isRequired,
+  setAddSeriesDefault: PropTypes.func.isRequired,
   fetchRootFolders: PropTypes.func.isRequired
 };
 

--- a/frontend/src/AddSeries/SeriesTypePopoverContent.js
+++ b/frontend/src/AddSeries/SeriesTypePopoverContent.js
@@ -7,7 +7,7 @@ function SeriesTypePopoverContent() {
   return (
     <DescriptionList>
       <DescriptionListItem
-        title={translate('Standard')}
+        title={translate('Scenes')}
         data={translate('StandardTypeDescription')}
       />
 

--- a/frontend/src/App/AppRoutes.js
+++ b/frontend/src/App/AppRoutes.js
@@ -49,7 +49,12 @@ function AppRoutes(props) {
       <Route
         exact={true}
         path="/"
-        component={SeriesIndex}
+        render={(routeProps) => (
+          <SeriesIndex
+            {...routeProps}
+            seriesType="standard"
+          />
+        )}
       />
 
       {
@@ -77,6 +82,27 @@ function AppRoutes(props) {
       <Route
         path="/add/import"
         component={ImportSeries}
+      />
+
+      <Route
+        exact={true}
+        path="/jav"
+        render={(routeProps) => (
+          <SeriesIndex
+            {...routeProps}
+            seriesType="jav"
+          />
+        )}
+      />
+
+      <Route
+        path="/jav/add/new"
+        render={(routeProps) => (
+          <AddNewSeriesConnector
+            {...routeProps}
+            defaultSeriesType="jav"
+          />
+        )}
       />
 
       <Route

--- a/frontend/src/App/State/AppState.ts
+++ b/frontend/src/App/State/AppState.ts
@@ -54,6 +54,7 @@ interface AppState {
   parse: ParseAppState;
   queue: QueueAppState;
   rootFolders: RootFolderAppState;
+  javSeriesIndex: SeriesIndexAppState;
   series: SeriesAppState;
   seriesIndex: SeriesIndexAppState;
   settings: SettingsAppState;

--- a/frontend/src/Components/Filter/Builder/SeriesTypesFilterBuilderRowValue.js
+++ b/frontend/src/Components/Filter/Builder/SeriesTypesFilterBuilderRowValue.js
@@ -6,7 +6,7 @@ const seriesTypesList = [
   {
     id: 'standard',
     get name() {
-      return translate('Standard');
+      return translate('Scenes');
     }
   },
   {

--- a/frontend/src/Components/Form/SeriesTypeSelectInput.tsx
+++ b/frontend/src/Components/Form/SeriesTypeSelectInput.tsx
@@ -21,7 +21,7 @@ interface ISeriesTypeOption {
 const seriesTypeOptions: ISeriesTypeOption[] = [
   {
     key: seriesTypes.STANDARD,
-    value: 'Standard',
+    value: 'Scenes',
     format: 'Season and episode numbers (S01E05)',
   },
   {

--- a/frontend/src/Components/Page/Sidebar/PageSidebar.js
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.js
@@ -37,6 +37,18 @@ const links = [
   },
 
   {
+    iconName: icons.SERIES_CONTINUING,
+    title: () => translate('JAV'),
+    to: '/jav',
+    children: [
+      {
+        title: () => translate('AddNew'),
+        to: '/jav/add/new'
+      }
+    ]
+  },
+
+  {
     iconName: icons.CALENDAR,
     title: () => translate('Calendar'),
     to: '/calendar'

--- a/frontend/src/Series/Index/SeriesIndex.tsx
+++ b/frontend/src/Series/Index/SeriesIndex.tsx
@@ -26,14 +26,14 @@ import SortDirection from 'Helpers/Props/SortDirection';
 import ParseToolbarButton from 'Parse/ParseToolbarButton';
 import NoSeries from 'Series/NoSeries';
 import { executeCommand } from 'Store/Actions/commandActions';
-import { fetchQueueDetails } from 'Store/Actions/queueActions';
-import { fetchSeries } from 'Store/Actions/seriesActions';
 import {
   setJavSeriesFilter,
   setJavSeriesSort,
   setJavSeriesTableOption,
   setJavSeriesView,
 } from 'Store/Actions/javSeriesIndexActions';
+import { fetchQueueDetails } from 'Store/Actions/queueActions';
+import { fetchSeries } from 'Store/Actions/seriesActions';
 import {
   setSeriesFilter,
   setSeriesSort,
@@ -126,7 +126,9 @@ function SeriesIndex(props: SeriesIndexProps) {
     sortDirection,
     view,
   }: SeriesAppState & SeriesIndexAppState & ClientSideCollectionAppState =
-    useSelector(createSeriesClientSideCollectionItemsSelector(uiSection, seriesType));
+    useSelector(
+      createSeriesClientSideCollectionItemsSelector(uiSection, seriesType)
+    );
 
   const isRssSyncExecuting = useSelector(
     createCommandExecutingSelector(RSS_SYNC)

--- a/frontend/src/Series/Index/SeriesIndex.tsx
+++ b/frontend/src/Series/Index/SeriesIndex.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
 import { SelectProvider } from 'App/SelectContext';
 import ClientSideCollectionAppState from 'App/State/ClientSideCollectionAppState';
 import SeriesAppState, { SeriesIndexAppState } from 'App/State/SeriesAppState';
@@ -20,7 +21,6 @@ import PageToolbarButton from 'Components/Page/Toolbar/PageToolbarButton';
 import PageToolbarSection from 'Components/Page/Toolbar/PageToolbarSection';
 import PageToolbarSeparator from 'Components/Page/Toolbar/PageToolbarSeparator';
 import TableOptionsModalWrapper from 'Components/Table/TableOptions/TableOptionsModalWrapper';
-import withScrollPosition from 'Components/withScrollPosition';
 import { align, icons, kinds } from 'Helpers/Props';
 import SortDirection from 'Helpers/Props/SortDirection';
 import ParseToolbarButton from 'Parse/ParseToolbarButton';
@@ -28,6 +28,12 @@ import NoSeries from 'Series/NoSeries';
 import { executeCommand } from 'Store/Actions/commandActions';
 import { fetchQueueDetails } from 'Store/Actions/queueActions';
 import { fetchSeries } from 'Store/Actions/seriesActions';
+import {
+  setJavSeriesFilter,
+  setJavSeriesSort,
+  setJavSeriesTableOption,
+  setJavSeriesView,
+} from 'Store/Actions/javSeriesIndexActions';
 import {
   setSeriesFilter,
   setSeriesSort,
@@ -69,11 +75,43 @@ function getViewComponent(view: string) {
   return SeriesIndexTable;
 }
 
-interface SeriesIndexProps {
-  initialScrollTop?: number;
+interface SeriesIndexProps extends RouteComponentProps {
+  seriesType?: string;
 }
 
-const SeriesIndex = withScrollPosition((props: SeriesIndexProps) => {
+function getActions(seriesType: string) {
+  if (seriesType === 'jav') {
+    return {
+      dispatchSetSort: setJavSeriesSort,
+      dispatchSetFilter: setJavSeriesFilter,
+      dispatchSetView: setJavSeriesView,
+      dispatchSetTableOption: setJavSeriesTableOption,
+    };
+  }
+
+  return {
+    dispatchSetSort: setSeriesSort,
+    dispatchSetFilter: setSeriesFilter,
+    dispatchSetView: setSeriesView,
+    dispatchSetTableOption: setSeriesTableOption,
+  };
+}
+
+function SeriesIndex(props: SeriesIndexProps) {
+  const seriesType = props.seriesType || 'standard';
+  const uiSection = seriesType === 'jav' ? 'javSeriesIndex' : 'seriesIndex';
+  const scrollKey = uiSection;
+
+  const initialScrollTop =
+    props.history?.action === 'POP' ? scrollPositions[scrollKey] : 0;
+
+  const {
+    dispatchSetSort,
+    dispatchSetFilter,
+    dispatchSetView,
+    dispatchSetTableOption,
+  } = getActions(seriesType);
+
   const {
     isFetching,
     isPopulated,
@@ -88,7 +126,7 @@ const SeriesIndex = withScrollPosition((props: SeriesIndexProps) => {
     sortDirection,
     view,
   }: SeriesAppState & SeriesIndexAppState & ClientSideCollectionAppState =
-    useSelector(createSeriesClientSideCollectionItemsSelector('seriesIndex'));
+    useSelector(createSeriesClientSideCollectionItemsSelector(uiSection, seriesType));
 
   const isRssSyncExecuting = useSelector(
     createCommandExecutingSelector(RSS_SYNC)
@@ -121,34 +159,34 @@ const SeriesIndex = withScrollPosition((props: SeriesIndexProps) => {
 
   const onTableOptionChange = useCallback(
     (payload: unknown) => {
-      dispatch(setSeriesTableOption(payload));
+      dispatch(dispatchSetTableOption(payload));
     },
-    [dispatch]
+    [dispatch, dispatchSetTableOption]
   );
 
   const onViewSelect = useCallback(
     (value: string) => {
-      dispatch(setSeriesView({ view: value }));
+      dispatch(dispatchSetView({ view: value }));
 
       if (scrollerRef.current) {
         scrollerRef.current.scrollTo(0, 0);
       }
     },
-    [scrollerRef, dispatch]
+    [scrollerRef, dispatch, dispatchSetView]
   );
 
   const onSortSelect = useCallback(
     (value: string) => {
-      dispatch(setSeriesSort({ sortKey: value }));
+      dispatch(dispatchSetSort({ sortKey: value }));
     },
-    [dispatch]
+    [dispatch, dispatchSetSort]
   );
 
   const onFilterSelect = useCallback(
     (value: string) => {
-      dispatch(setSeriesFilter({ selectedFilterKey: value }));
+      dispatch(dispatchSetFilter({ selectedFilterKey: value }));
     },
-    [dispatch]
+    [dispatch, dispatchSetFilter]
   );
 
   const onOptionsPress = useCallback(() => {
@@ -169,9 +207,9 @@ const SeriesIndex = withScrollPosition((props: SeriesIndexProps) => {
   const onScroll = useCallback(
     ({ scrollTop }: { scrollTop: number }) => {
       setJumpToCharacter(undefined);
-      scrollPositions.seriesIndex = scrollTop;
+      scrollPositions[scrollKey] = scrollTop;
     },
-    [setJumpToCharacter]
+    [setJumpToCharacter, scrollKey]
   );
 
   const jumpBarItems = useMemo(() => {
@@ -312,7 +350,7 @@ const SeriesIndex = withScrollPosition((props: SeriesIndexProps) => {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore
             innerClassName={styles[`${view}InnerContentBody`]}
-            initialScrollTop={props.initialScrollTop}
+            initialScrollTop={initialScrollTop}
             onScroll={onScroll}
           >
             {isFetching && !isPopulated ? <LoadingIndicator /> : null}
@@ -338,7 +376,7 @@ const SeriesIndex = withScrollPosition((props: SeriesIndexProps) => {
             ) : null}
 
             {!error && isPopulated && !items.length ? (
-              <NoSeries totalItems={totalItems} />
+              <NoSeries totalItems={totalItems} seriesType={seriesType} />
             ) : null}
           </PageContentBody>
           {isLoaded && !!jumpBarItems.order.length ? (
@@ -366,6 +404,6 @@ const SeriesIndex = withScrollPosition((props: SeriesIndexProps) => {
       </PageContent>
     </SelectProvider>
   );
-}, 'seriesIndex');
+}
 
 export default SeriesIndex;

--- a/frontend/src/Series/NoSeries.js
+++ b/frontend/src/Series/NoSeries.js
@@ -6,7 +6,9 @@ import translate from 'Utilities/String/translate';
 import styles from './NoSeries.css';
 
 function NoSeries(props) {
-  const { totalItems } = props;
+  const { totalItems, seriesType } = props;
+
+  const addNewPath = seriesType === 'jav' ? '/jav/add/new' : '/add/new';
 
   if (totalItems > 0) {
     return (
@@ -24,18 +26,21 @@ function NoSeries(props) {
         {translate('NoSitesFoundImportOrAdd')}
       </div>
 
-      <div className={styles.buttonContainer}>
-        <Button
-          to="/add/import"
-          kind={kinds.PRIMARY}
-        >
-          {translate('ImportExistingSites')}
-        </Button>
-      </div>
+      {
+        seriesType !== 'jav' &&
+          <div className={styles.buttonContainer}>
+            <Button
+              to="/add/import"
+              kind={kinds.PRIMARY}
+            >
+              {translate('ImportExistingSites')}
+            </Button>
+          </div>
+      }
 
       <div className={styles.buttonContainer}>
         <Button
-          to="/add/new"
+          to={addNewPath}
           kind={kinds.PRIMARY}
         >
           {translate('AddNewSite')}
@@ -46,7 +51,8 @@ function NoSeries(props) {
 }
 
 NoSeries.propTypes = {
-  totalItems: PropTypes.number.isRequired
+  totalItems: PropTypes.number.isRequired,
+  seriesType: PropTypes.string
 };
 
 export default NoSeries;

--- a/frontend/src/Store/Actions/index.js
+++ b/frontend/src/Store/Actions/index.js
@@ -12,6 +12,7 @@ import * as episodeSelection from './episodeSelectionActions';
 import * as history from './historyActions';
 import * as importSeries from './importSeriesActions';
 import * as interactiveImportActions from './interactiveImportActions';
+import * as javSeriesIndex from './javSeriesIndexActions';
 import * as oAuth from './oAuthActions';
 import * as organizePreview from './organizePreviewActions';
 import * as parse from './parseActions';
@@ -43,6 +44,7 @@ export default [
   history,
   importSeries,
   interactiveImportActions,
+  javSeriesIndex,
   oAuth,
   organizePreview,
   parse,

--- a/frontend/src/Store/Actions/javSeriesIndexActions.js
+++ b/frontend/src/Store/Actions/javSeriesIndexActions.js
@@ -1,0 +1,341 @@
+import moment from 'moment';
+import { createAction } from 'redux-actions';
+import { sortDirections } from 'Helpers/Props';
+import translate from 'Utilities/String/translate';
+import createHandleActions from './Creators/createHandleActions';
+import createSetClientSideCollectionFilterReducer from './Creators/Reducers/createSetClientSideCollectionFilterReducer';
+import createSetClientSideCollectionSortReducer from './Creators/Reducers/createSetClientSideCollectionSortReducer';
+import createSetTableOptionReducer from './Creators/Reducers/createSetTableOptionReducer';
+import { filterBuilderProps, filterPredicates, filters, sortPredicates } from './seriesActions';
+
+//
+// Variables
+
+export const section = 'javSeriesIndex';
+
+//
+// State
+
+export const defaultState = {
+  sortKey: 'sortTitle',
+  sortDirection: sortDirections.ASCENDING,
+  secondarySortKey: 'sortTitle',
+  secondarySortDirection: sortDirections.ASCENDING,
+  view: 'posters',
+
+  posterOptions: {
+    detailedProgressBar: false,
+    size: 'large',
+    showTitle: false,
+    showMonitored: true,
+    showQualityProfile: true,
+    showTags: false,
+    showSearchAction: false
+  },
+
+  overviewOptions: {
+    detailedProgressBar: false,
+    size: 'medium',
+    showMonitored: true,
+    showNetwork: true,
+    showQualityProfile: true,
+    showPreviousAiring: false,
+    showAdded: false,
+    showSeasonCount: true,
+    showPath: false,
+    showSizeOnDisk: false,
+    showTags: false,
+    showSearchAction: false
+  },
+
+  tableOptions: {
+    showBanners: false,
+    showSearchAction: false
+  },
+
+  columns: [
+    {
+      name: 'status',
+      columnLabel: () => translate('Status'),
+      isSortable: true,
+      isVisible: true,
+      isModifiable: false
+    },
+    {
+      name: 'sortTitle',
+      label: () => translate('SiteTitle'),
+      isSortable: true,
+      isVisible: true,
+      isModifiable: false
+    },
+    {
+      name: 'network',
+      label: () => translate('Network'),
+      isSortable: true,
+      isVisible: true
+    },
+    {
+      name: 'qualityProfileId',
+      label: () => translate('QualityProfile'),
+      isSortable: true,
+      isVisible: true
+    },
+    {
+      name: 'nextAiring',
+      label: () => translate('NextAiring'),
+      isSortable: true,
+      isVisible: true
+    },
+    {
+      name: 'previousAiring',
+      label: () => translate('PreviousAiring'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'originalLanguage',
+      label: () => translate('OriginalLanguage'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'added',
+      label: () => translate('Added'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'seasonCount',
+      label: () => translate('Seasons'),
+      isSortable: true,
+      isVisible: true
+    },
+    {
+      name: 'seasonFolder',
+      label: () => translate('SeasonFolder'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'episodeProgress',
+      label: () => translate('Episodes'),
+      isSortable: true,
+      isVisible: true
+    },
+    {
+      name: 'episodeCount',
+      label: () => translate('EpisodeCount'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'latestSeason',
+      label: () => translate('LatestSeason'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'year',
+      label: () => translate('Year'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'path',
+      label: () => translate('Path'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'sizeOnDisk',
+      label: () => translate('SizeOnDisk'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'genres',
+      label: () => translate('Genres'),
+      isSortable: false,
+      isVisible: false
+    },
+    {
+      name: 'certification',
+      label: () => translate('Certification'),
+      isSortable: false,
+      isVisible: false
+    },
+    {
+      name: 'releaseGroups',
+      label: () => translate('ReleaseGroups'),
+      isSortable: false,
+      isVisible: false
+    },
+    {
+      name: 'tags',
+      label: () => translate('Tags'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'useSceneNumbering',
+      label: () => translate('SceneNumbering'),
+      isSortable: true,
+      isVisible: false
+    },
+    {
+      name: 'actions',
+      columnLabel: () => translate('Actions'),
+      isVisible: true,
+      isModifiable: false
+    }
+  ],
+
+  sortPredicates: {
+    ...sortPredicates,
+
+    network: function(item) {
+      const network = item.network;
+
+      return network ? network.toLowerCase() : '';
+    },
+
+    nextAiring: function(item, direction) {
+      const nextAiring = item.nextAiring;
+
+      if (nextAiring) {
+        return moment(nextAiring).unix();
+      }
+
+      if (direction === sortDirections.DESCENDING) {
+        return 0;
+      }
+
+      return Number.MAX_VALUE;
+    },
+
+    previousAiring: function(item, direction) {
+      const previousAiring = item.previousAiring;
+
+      if (previousAiring) {
+        return moment(previousAiring).unix();
+      }
+
+      if (direction === sortDirections.DESCENDING) {
+        return -Number.MAX_VALUE;
+      }
+
+      return Number.MAX_VALUE;
+    },
+
+    episodeProgress: function(item) {
+      const { statistics = {} } = item;
+
+      const {
+        episodeCount = 0,
+        episodeFileCount
+      } = statistics;
+
+      const progress = episodeCount ? episodeFileCount / episodeCount * 100 : 100;
+
+      return progress + episodeCount / 1000000;
+    },
+
+    episodeCount: function(item) {
+      const { statistics = {} } = item;
+
+      return statistics.totalEpisodeCount || 0;
+    },
+
+    seasonCount: function(item) {
+      const { statistics = {} } = item;
+
+      return statistics.seasonCount;
+    },
+
+    originalLanguage: function(item) {
+      const { originalLanguage = {} } = item;
+
+      return originalLanguage.name;
+    }
+  },
+
+  selectedFilterKey: 'all',
+
+  filters,
+
+  filterPredicates,
+
+  filterBuilderProps
+};
+
+export const persistState = [
+  'javSeriesIndex.sortKey',
+  'javSeriesIndex.sortDirection',
+  'javSeriesIndex.selectedFilterKey',
+  'javSeriesIndex.customFilters',
+  'javSeriesIndex.view',
+  'javSeriesIndex.columns',
+  'javSeriesIndex.posterOptions',
+  'javSeriesIndex.overviewOptions',
+  'javSeriesIndex.tableOptions'
+];
+
+//
+// Actions Types
+
+export const SET_JAV_SERIES_SORT = 'javSeriesIndex/setJavSeriesSort';
+export const SET_JAV_SERIES_FILTER = 'javSeriesIndex/setJavSeriesFilter';
+export const SET_JAV_SERIES_VIEW = 'javSeriesIndex/setJavSeriesView';
+export const SET_JAV_SERIES_TABLE_OPTION = 'javSeriesIndex/setJavSeriesTableOption';
+export const SET_JAV_SERIES_POSTER_OPTION = 'javSeriesIndex/setJavSeriesPosterOption';
+export const SET_JAV_SERIES_OVERVIEW_OPTION = 'javSeriesIndex/setJavSeriesOverviewOption';
+
+//
+// Action Creators
+
+export const setJavSeriesSort = createAction(SET_JAV_SERIES_SORT);
+export const setJavSeriesFilter = createAction(SET_JAV_SERIES_FILTER);
+export const setJavSeriesView = createAction(SET_JAV_SERIES_VIEW);
+export const setJavSeriesTableOption = createAction(SET_JAV_SERIES_TABLE_OPTION);
+export const setJavSeriesPosterOption = createAction(SET_JAV_SERIES_POSTER_OPTION);
+export const setJavSeriesOverviewOption = createAction(SET_JAV_SERIES_OVERVIEW_OPTION);
+
+//
+// Reducers
+
+export const reducers = createHandleActions({
+
+  [SET_JAV_SERIES_SORT]: createSetClientSideCollectionSortReducer(section),
+  [SET_JAV_SERIES_FILTER]: createSetClientSideCollectionFilterReducer(section),
+
+  [SET_JAV_SERIES_VIEW]: function(state, { payload }) {
+    return Object.assign({}, state, { view: payload.view });
+  },
+
+  [SET_JAV_SERIES_TABLE_OPTION]: createSetTableOptionReducer(section),
+
+  [SET_JAV_SERIES_POSTER_OPTION]: function(state, { payload }) {
+    const posterOptions = state.posterOptions;
+
+    return {
+      ...state,
+      posterOptions: {
+        ...posterOptions,
+        ...payload
+      }
+    };
+  },
+
+  [SET_JAV_SERIES_OVERVIEW_OPTION]: function(state, { payload }) {
+    const overviewOptions = state.overviewOptions;
+
+    return {
+      ...state,
+      overviewOptions: {
+        ...overviewOptions,
+        ...payload
+      }
+    };
+  }
+
+}, defaultState, section);

--- a/frontend/src/Store/Selectors/createClientSideCollectionSelector.js
+++ b/frontend/src/Store/Selectors/createClientSideCollectionSelector.js
@@ -119,7 +119,7 @@ export function createCustomFiltersSelector(type, alternateType) {
   );
 }
 
-function createClientSideCollectionSelector(section, uiSection) {
+function createClientSideCollectionSelector(section, uiSection, preFilter) {
   return createSelector(
     (state) => _.get(state, section),
     (state) => _.get(state, uiSection),
@@ -127,7 +127,8 @@ function createClientSideCollectionSelector(section, uiSection) {
     (sectionState, uiSectionState = {}, customFilters) => {
       const state = Object.assign({}, sectionState, uiSectionState, { customFilters });
 
-      const filtered = filter(state.items, state);
+      const items = preFilter ? state.items.filter(preFilter) : state.items;
+      const filtered = filter(items, state);
       const sorted = sort(filtered, state);
 
       return {
@@ -135,7 +136,7 @@ function createClientSideCollectionSelector(section, uiSection) {
         ...uiSectionState,
         customFilters,
         items: sorted,
-        totalItems: state.items.length
+        totalItems: items.length
       };
     }
   );

--- a/frontend/src/Store/Selectors/createSeriesClientSideCollectionItemsSelector.js
+++ b/frontend/src/Store/Selectors/createSeriesClientSideCollectionItemsSelector.js
@@ -2,9 +2,11 @@ import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect'
 import hasDifferentItemsOrOrder from 'Utilities/Object/hasDifferentItemsOrOrder';
 import createClientSideCollectionSelector from './createClientSideCollectionSelector';
 
-function createUnoptimizedSelector(uiSection) {
+function createUnoptimizedSelector(uiSection, seriesType) {
+  const preFilter = seriesType ? (item) => item.seriesType === seriesType : undefined;
+
   return createSelector(
-    createClientSideCollectionSelector('series', uiSection),
+    createClientSideCollectionSelector('series', uiSection, preFilter),
     (series) => {
       const items = series.items.map((s) => {
         const {
@@ -35,9 +37,9 @@ const createSeriesEqualSelector = createSelectorCreator(
   seriesListEqual
 );
 
-function createSeriesClientSideCollectionItemsSelector(uiSection) {
+function createSeriesClientSideCollectionItemsSelector(uiSection, seriesType) {
   return createSeriesEqualSelector(
-    createUnoptimizedSelector(uiSection),
+    createUnoptimizedSelector(uiSection, seriesType),
     (series) => series
   );
 }

--- a/frontend/src/Store/scrollPositions.ts
+++ b/frontend/src/Store/scrollPositions.ts
@@ -1,4 +1,5 @@
 const scrollPositions: Record<string, number> = {
+  javSeriesIndex: 0,
   seriesIndex: 0,
 };
 

--- a/frontend/src/Utilities/Series/seriesTypeOptions.js
+++ b/frontend/src/Utilities/Series/seriesTypeOptions.js
@@ -4,7 +4,7 @@ const seriesTypeOptions = [
   {
     key: 'standard',
     get value() {
-      return translate('Standard');
+      return translate('Scenes');
     }
   },
   {

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1617,6 +1617,8 @@
   "SslCertPath": "SSL Cert Path",
   "SslCertPathHelpText": "Path to pfx file",
   "SslPort": "SSL Port",
+  "Scenes": "Scenes",
+  "SceneEpisodeFormat": "Scene Episode Format",
   "Standard": "Standard",
   "StandardEpisodeFormat": "Standard Episode Format",
   "StandardTypeDescription": "Episodes released with SxxEyy pattern",

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/EpisodeResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/EpisodeResource.cs
@@ -17,6 +17,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public string Overview { get; set; }
         public string Image { get; set; }
         public int? Duration { get; set; }
+        public string Type { get; set; }
         public List<ActorResource> Credits { get; set; }
     }
 }

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/ShowResource.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/Resource/ShowResource.cs
@@ -7,6 +7,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public ShowResource()
         {
             Genres = new List<string>();
+            Types = new List<string>();
             Images = new List<ImageResource>();
             Years = new List<int>();
             Episodes = new List<EpisodeResource>();
@@ -27,6 +28,7 @@ namespace NzbDrone.Core.MetadataSource.SkyHook.Resource
         public string Network { get; set; }
         public string OriginalLanguage { get; set; }
         public List<string> Genres { get; set; }
+        public List<string> Types { get; set; }
 
         public string ContentRating { get; set; }
 

--- a/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/SkyHook/SkyHookProxy.cs
@@ -200,6 +200,11 @@ namespace NzbDrone.Core.MetadataSource.SkyHook
             series.Images = show.Images.Select(MapImage).ToList();
             series.Monitored = true;
 
+            if (show.Types != null && show.Types.Any(t => t.Equals("JAV", StringComparison.OrdinalIgnoreCase)))
+            {
+                series.SeriesType = SeriesTypes.Jav;
+            }
+
             return series;
         }
 


### PR DESCRIPTION
This is a weird one that I've been thinking about for a while. Currently all sites, JAV and "regular" get clustered into one large page and makes it difficult to parse without using tags, filtering, and all that other jazz. This breaks it out based on Series.Type. When you select the JAV series type it will move that site to the JAV tab and opposite for Scenes. All currently existing sites with the type will automatically move to the appropriate page. 

The only things that I see currently being an issue are import lists and library import. Currently both of those default to "scenes" so they will go there first and you will need to manually modify the series type to be JAV. That is an issue I beleive is better tackled in a separate PR as this one is already quite large.

Will be requesting testing before having this merged
UI: 
<img width="213" height="374" alt="62635507b5c3f3b00c68714b9095c0e5" src="https://github.com/user-attachments/assets/7e3f87dc-caa6-46ec-b9cb-70f81b9fef90" />
