### PR TITLE
fix: undefined error on delete modal for undefined series.statistics …

### DIFF
--- a/frontend/src/Series/Index/Select/Delete/DeleteSeriesModalContent.tsx
+++ b/frontend/src/Series/Index/Select/Delete/DeleteSeriesModalContent.tsx
@@ -156,7 +156,7 @@ function DeleteSeriesModalContent(props: DeleteSeriesModalContentProps) {
 
         <ul>
           {series.map((s) => {
-            const { episodeFileCount = 0, sizeOnDisk = 0 } = s.statistics;
+            const { episodeFileCount = 0, sizeOnDisk = 0 } = s.statistics ?? {};
 
             return (
               <li key={s.title}>

--- a/frontend/src/Series/Index/Select/SeasonPass/SeasonPassSeason.tsx
+++ b/frontend/src/Series/Index/Select/SeasonPass/SeasonPassSeason.tsx
@@ -12,7 +12,7 @@ interface SeasonPassSeasonProps {
   seriesId: number;
   seasonNumber: number;
   monitored: boolean;
-  statistics: Statistics;
+  statistics?: Statistics;
   isSaving: boolean;
 }
 

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.tsx
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.tsx
@@ -324,7 +324,7 @@ function SeriesIndexRow(props: SeriesIndexRowProps) {
             return <VirtualTableRowCell key={name} className={styles[name]} />;
           }
 
-          const { episodeCount: seasonEpisodeCount = 0, episodeFileCount: seasonEpisodeFileCount = 0, totalEpisodeCount: seasonTotalEpisodeCount = 0 } = latestSeason.statistics || {};
+          const { episodeCount: seasonEpisodeCount = 0, episodeFileCount: seasonEpisodeFileCount = 0, totalEpisodeCount: seasonTotalEpisodeCount = 0 } = latestSeason.statistics ?? {};
 
           return (
             <VirtualTableRowCell key={name} className={styles[name]}>

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.tsx
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.tsx
@@ -324,7 +324,7 @@ function SeriesIndexRow(props: SeriesIndexRowProps) {
             return <VirtualTableRowCell key={name} className={styles[name]} />;
           }
 
-          const { episodeCount: seasonEpisodeCount = 0, episodeFileCount: seasonEpisodeFileCount = 0, totalEpisodeCount: seasonTotalEpisodeCount = 0 } = latestSeason.statistics || {} as Statistics;
+          const { episodeCount: seasonEpisodeCount = 0, episodeFileCount: seasonEpisodeFileCount = 0, totalEpisodeCount: seasonTotalEpisodeCount = 0 } = latestSeason.statistics || {};
 
           return (
             <VirtualTableRowCell key={name} className={styles[name]}>

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.tsx
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.tsx
@@ -324,7 +324,11 @@ function SeriesIndexRow(props: SeriesIndexRowProps) {
             return <VirtualTableRowCell key={name} className={styles[name]} />;
           }
 
-          const { episodeCount: seasonEpisodeCount = 0, episodeFileCount: seasonEpisodeFileCount = 0, totalEpisodeCount: seasonTotalEpisodeCount = 0 } = latestSeason.statistics ?? {};
+          const {
+            episodeCount: seasonEpisodeCount = 0,
+            episodeFileCount: seasonEpisodeFileCount = 0,
+            totalEpisodeCount: seasonTotalEpisodeCount = 0,
+          } = latestSeason.statistics ?? {};
 
           return (
             <VirtualTableRowCell key={name} className={styles[name]}>

--- a/frontend/src/Series/Index/Table/SeriesIndexRow.tsx
+++ b/frontend/src/Series/Index/Table/SeriesIndexRow.tsx
@@ -324,7 +324,7 @@ function SeriesIndexRow(props: SeriesIndexRowProps) {
             return <VirtualTableRowCell key={name} className={styles[name]} />;
           }
 
-          const seasonStatistics = latestSeason.statistics || {};
+          const { episodeCount: seasonEpisodeCount = 0, episodeFileCount: seasonEpisodeFileCount = 0, totalEpisodeCount: seasonTotalEpisodeCount = 0 } = latestSeason.statistics || {} as Statistics;
 
           return (
             <VirtualTableRowCell key={name} className={styles[name]}>
@@ -333,9 +333,9 @@ function SeriesIndexRow(props: SeriesIndexRowProps) {
                 seasonNumber={latestSeason.seasonNumber}
                 monitored={monitored}
                 status={status}
-                episodeCount={seasonStatistics.episodeCount}
-                episodeFileCount={seasonStatistics.episodeFileCount}
-                totalEpisodeCount={seasonStatistics.totalEpisodeCount}
+                episodeCount={seasonEpisodeCount}
+                episodeFileCount={seasonEpisodeFileCount}
+                totalEpisodeCount={seasonTotalEpisodeCount}
                 width={125}
                 detailedProgressBar={true}
                 isStandalone={true}

--- a/frontend/src/Series/Series.ts
+++ b/frontend/src/Series/Series.ts
@@ -38,7 +38,7 @@ export interface Statistics {
 export interface Season {
   monitored: boolean;
   seasonNumber: number;
-  statistics: Statistics;
+  statistics?: Statistics;
   isSaving?: boolean;
 }
 


### PR DESCRIPTION
…prop - fallback to 0 values

#### Database Migration
NO

#### Description
I was trying to delete multiple shows that got accidentally added through import list and without refreshing them to fill the statistics property this error occurred.

#### Screenshot (if UI related)
<img width="968" height="942" alt="image" src="https://github.com/user-attachments/assets/520a8f88-df67-43c3-a23a-314ba223a5c3" />
<img width="510" height="152" alt="image" src="https://github.com/user-attachments/assets/526f2484-3379-4212-b0ae-720d5f0ec37a" />
