### PR TITLE
Fix: Downloads stuck in "Importing" due to external ID parsing false positives + Notification error/Crashing

### DIFF
--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -130,14 +130,6 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Should().Be(expectedExternalId);
         }
 
-        [TestCase("FC2-PPV123.mp4", "FC2-PPV123")] // Mixed alphanumeric with digits still matches
-        [TestCase("T28-573.mp4", "T28-573")]
-        public void should_parse_external_id_with_mixed_alphanumeric(string filename, string expectedExternalId)
-        {
-            var result = Parser.Parser.ParseExternalIdFromFilename(filename);
-            result.Should().Be(expectedExternalId);
-        }
-
         [TestCase("Some Random Title.mp4")]
         [TestCase("Series.23.01.23.Title.mkv")]
         [TestCase("A-1.mp4")] // Too short - needs 2+ chars on each side

--- a/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParserFixture.cs
@@ -130,11 +130,22 @@ namespace NzbDrone.Core.Test.ParserTests
             result.Should().Be(expectedExternalId);
         }
 
+        [TestCase("FC2-PPV123.mp4", "FC2-PPV123")] // Mixed alphanumeric with digits still matches
+        [TestCase("T28-573.mp4", "T28-573")]
+        public void should_parse_external_id_with_mixed_alphanumeric(string filename, string expectedExternalId)
+        {
+            var result = Parser.Parser.ParseExternalIdFromFilename(filename);
+            result.Should().Be(expectedExternalId);
+        }
+
         [TestCase("Some Random Title.mp4")]
         [TestCase("Series.23.01.23.Title.mkv")]
         [TestCase("A-1.mp4")] // Too short - needs 2+ chars on each side
         [TestCase("ABCDEFGHIJK-12345678901")] // Too long - max 10 chars on each side
         [TestCase("123-ABC.mp4")] // First part must be letters only
+        [TestCase("Hands-On Something.mp4")] // Series name, no digits in second component
+        [TestCase("Come-In Title.mp4")] // Series name, no digits in second component
+        [TestCase("Stand-By Me.mp4")] // Series name, no digits in second component
         public void should_not_parse_external_id_from_non_matching_filename(string filename)
         {
             var result = Parser.Parser.ParseExternalIdFromFilename(filename);
@@ -152,6 +163,7 @@ namespace NzbDrone.Core.Test.ParserTests
 
         [TestCase("Some Title Without Bracket")]
         [TestCase("[SubGroup] Some Title")]
+        [TestCase("Hands-On [01+22] - Mario Gets A Very Hands-On Massage")] // Exact failing title from bug report
         public void should_not_parse_external_id_from_non_matching_title(string title)
         {
             var result = Parser.Parser.ParseExternalId(title);

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -217,7 +217,7 @@ namespace NzbDrone.Core.Notifications
             var remoteEpisode = message.Episode;
             var series = remoteEpisode?.Series;
 
-if (remoteEpisode != null && remoteEpisode.Episodes?.Any() != true)
+            if (remoteEpisode != null && remoteEpisode.Episodes?.Any() != true)
             {
                 _logger.Trace("Manual interaction required for {0}, but no episode information is available", message.TrackedDownload.DownloadItem.Title);
             }

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -217,7 +217,7 @@ namespace NzbDrone.Core.Notifications
             var remoteEpisode = message.Episode;
             var series = remoteEpisode?.Series;
 
-            if (remoteEpisode != null && (remoteEpisode.Episodes == null || !remoteEpisode.Episodes.Any()))
+if (remoteEpisode != null && remoteEpisode.Episodes?.Any() != true)
             {
                 _logger.Trace("Manual interaction required for {0}, but no episode information is available", message.TrackedDownload.DownloadItem.Title);
             }

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -217,9 +217,14 @@ namespace NzbDrone.Core.Notifications
             var remoteEpisode = message.Episode;
             var series = remoteEpisode?.Series;
 
+            if (remoteEpisode != null && (remoteEpisode.Episodes == null || !remoteEpisode.Episodes.Any()))
+            {
+                _logger.Trace("Manual interaction required for {0}, but no episode information is available", message.TrackedDownload.DownloadItem.Title);
+            }
+
             var manualInteractionMessage = new ManualInteractionRequiredMessage
             {
-                Message = remoteEpisode != null
+                Message = remoteEpisode?.Episodes?.Any() == true
                     ? GetMessage(series, remoteEpisode.Episodes, remoteEpisode.ParsedEpisodeInfo.Quality)
                     : message.TrackedDownload.DownloadItem.Title,
                 Series = series,

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -15,8 +15,10 @@ namespace NzbDrone.Core.Parser
 {
     public static class Parser
     {
-        // Common external ID pattern: 2-10 letters, dash/underscore, 2-10 alphanumeric (e.g., MIKR-058, ABC_123)
-        private const string ExternalIdBasePattern = @"[A-Z]{2,10}[-_][A-Z0-9]{2,10}";
+        // Common external ID pattern: 2-10 letters, dash/underscore, 2-10 alphanumeric with at least one digit (e.g., MIKR-058, ABC_123)
+        // The lookahead (?=[A-Z0-9]*\d) ensures the second component contains at least one digit,
+        // preventing false positives on series names like "Hands-On", "Come-In", "Stand-By"
+        private const string ExternalIdBasePattern = @"[A-Z]{2,10}[-_](?=[A-Z0-9]*\d)[A-Z0-9]{2,10}";
 
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(Parser));
 

--- a/src/NzbDrone.Core/Tv/EpisodeRepository.cs
+++ b/src/NzbDrone.Core/Tv/EpisodeRepository.cs
@@ -64,7 +64,15 @@ namespace NzbDrone.Core.Tv
             // Normalize to lowercase before querying since external IDs are stored lowercase
             externalId = externalId.ToLowerInvariant();
 
-            return Query(e => e.ExternalId == externalId).SingleOrDefault();
+            var episodes = Query(e => e.ExternalId == externalId).ToList();
+
+            if (episodes.Count > 1)
+            {
+                _logger.Warn("Multiple episodes found with external ID '{0}', skipping automatic match to require manual import", externalId);
+                return null;
+            }
+
+            return episodes.SingleOrDefault();
         }
 
         public List<Episode> GetEpisodes(int seriesId)


### PR DESCRIPTION
Downloads with titles like `Hands-On [01+22] - Mario Gets A Very Hands-On Massage` get permanently stuck in "Downloaded - Importing" with no manual import icon. The series name "Hands-On" is falsely parsed as a JAV catalog number, `FindByExternalId("hands-on")` finds multiple episodes, and `SingleOrDefault()` throws, crashing the download monitoring loop on every pass.

I went ahead and fixed `FindByExternalId` to return null when multiple episodes match the same external ID, forcing manual import instead of crashing with `InvalidOperationException`. I also tightned up the external ID regex to help prevent further bad data.

Fixed `NotificationService` crash when processing `ManualInteractionRequiredEvent` with an empty episode list

fixes: https://github.com/Whisparr/Whisparr/issues/1038