### PR TITLE
Fix: Sonarr Series to Whisparr Site

### DIFF
--- a/frontend/src/Series/SeriesTitleLink.tsx
+++ b/frontend/src/Series/SeriesTitleLink.tsx
@@ -11,7 +11,7 @@ export default function SeriesTitleLink({
   title,
   ...linkProps
 }: SeriesTitleLinkProps) {
-  const link = `/series/${titleSlug}`;
+  const link = `/site/${titleSlug}`;
 
   return (
     <Link to={link} {...linkProps}>


### PR DESCRIPTION
During tsx conversion I forgot to swap the Sonarr verbage for "series" over to Whisparr "Site"

Fixes: https://github.com/Whisparr/Whisparr/issues/1040