### PR TITLE
Chore: Revert #777 #780 and #781

### DIFF
--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
@@ -232,7 +232,7 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
         }
 
         [Test]
-        public async Task scene_seasonsearch_should_search_each_episode_individually()
+        public async Task scene_seasonsearch()
         {
             WithEpisodes();
 
@@ -240,14 +240,14 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             await Subject.SeasonSearch(_xemSeries.Id, 1, false, false, true, false);
 
-            // Season 1 has 2 episodes, each searched individually
-            var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
+            var criteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
 
-            criteria.Count.Should().Be(2);
+            criteria.Count.Should().Be(1);
+            criteria[0].Year.Should().Be(1);
         }
 
         [Test]
-        public async Task scene_seasonsearch_should_search_all_episodes_in_season()
+        public async Task scene_seasonsearch_should_search_multiple_seasons()
         {
             WithEpisodes();
 
@@ -255,14 +255,14 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             await Subject.SeasonSearch(_xemSeries.Id, 2, false, false, true, false);
 
-            // Season 2 has 4 episodes, each searched individually
-            var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
+            var criteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
 
-            criteria.Count.Should().Be(4);
+            criteria.Count.Should().Be(1);
+            criteria[0].Year.Should().Be(2);
         }
 
         [Test]
-        public async Task scene_seasonsearch_should_search_episodes_without_scene_numbers()
+        public async Task scene_seasonsearch_should_use_seasonnumber_if_no_scene_number_is_available()
         {
             WithEpisodes();
 
@@ -270,10 +270,10 @@ namespace NzbDrone.Core.Test.IndexerSearchTests
 
             await Subject.SeasonSearch(_xemSeries.Id, 7, false, false, true, false);
 
-            // Season 7 has 2 episodes, each searched individually
-            var criteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
+            var criteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
 
-            criteria.Count.Should().Be(2);
+            criteria.Count.Should().Be(1);
+            criteria[0].Year.Should().Be(7);
         }
     }
 }

--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
@@ -71,19 +71,27 @@ namespace NzbDrone.Core.IndexerSearch
         public async Task<List<DownloadDecision>> SeasonSearch(int seriesId, int seasonNumber, List<Episode> episodes, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch)
         {
             var series = _seriesService.GetSeries(seriesId);
+
             var downloadDecisions = new List<DownloadDecision>();
 
-            _logger.ProgressInfo("Searching for {0} episodes in {1}", episodes.Count, series.Title);
-
-            // Search each episode individually - XXX content doesn't have traditional seasons
-            var searchedCount = 0;
-
-            foreach (var episode in episodes)
+            if (episodes.Count == 1)
             {
-                searchedCount++;
-                _logger.ProgressInfo("Searching for {0} - {1} [{2}/{3}]", series.Title, episode.Title, searchedCount, episodes.Count);
+                var searchSpec = Get<SingleEpisodeSearchCriteria>(series, episodes, monitoredOnly, userInvokedSearch, interactiveSearch);
+                var episode = episodes.First();
+                searchSpec.ReleaseDate = DateOnly.Parse(episode.AirDate);
+                searchSpec.Performer = episode.Actors.Select(p => p.Name).FirstOrDefault();
+                searchSpec.EpisodeTitle = episode.Title;
+                searchSpec.ExternalId = episode.ExternalId;
 
-                var decisions = await SearchSingle(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch);
+                var decisions = await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
+                downloadDecisions.AddRange(decisions);
+            }
+            else
+            {
+                var searchSpec = Get<SeasonSearchCriteria>(series, episodes, monitoredOnly, userInvokedSearch, interactiveSearch);
+                searchSpec.Year = seasonNumber;
+
+                var decisions = await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
                 downloadDecisions.AddRange(decisions);
             }
 

--- a/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
+++ b/src/NzbDrone.Core/IndexerSearch/SeasonSearchService.cs
@@ -1,9 +1,7 @@
-using System.Linq;
 using NLog;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Messaging.Commands;
-using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.IndexerSearch
 {
@@ -11,44 +9,23 @@ namespace NzbDrone.Core.IndexerSearch
     {
         private readonly ISearchForReleases _releaseSearchService;
         private readonly IProcessDownloadDecisions _processDownloadDecisions;
-        private readonly IEpisodeService _episodeService;
         private readonly Logger _logger;
 
         public SeasonSearchService(ISearchForReleases releaseSearchService,
                                    IProcessDownloadDecisions processDownloadDecisions,
-                                   IEpisodeService episodeService,
                                    Logger logger)
         {
             _releaseSearchService = releaseSearchService;
             _processDownloadDecisions = processDownloadDecisions;
-            _episodeService = episodeService;
             _logger = logger;
         }
 
         public void Execute(SeasonSearchCommand message)
         {
-            var episodes = _episodeService.GetEpisodesBySeason(message.SeriesId, message.SeasonNumber);
+            var decisions = _releaseSearchService.SeasonSearch(message.SeriesId, message.SeasonNumber, false, true, message.Trigger == CommandTrigger.Manual, false).GetAwaiter().GetResult();
+            var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
 
-            // Filter to only missing (no file) and monitored episodes
-            episodes = episodes.Where(e => !e.HasFile && e.Monitored).ToList();
-
-            if (!episodes.Any())
-            {
-                _logger.ProgressInfo("No missing monitored episodes found for this season.");
-                return;
-            }
-
-            var totalGrabbed = 0;
-
-            foreach (var episode in episodes)
-            {
-                var decisions = _releaseSearchService.EpisodeSearch(episode, message.Trigger == CommandTrigger.Manual, false).GetAwaiter().GetResult();
-                var processed = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
-
-                totalGrabbed += processed.Grabbed.Count;
-            }
-
-            _logger.ProgressInfo("Season search completed. {0} reports downloaded.", totalGrabbed);
+            _logger.ProgressInfo("Season search completed. {0} reports downloaded.", processed.Grabbed.Count);
         }
     }
 }


### PR DESCRIPTION
Discussion was brought up on discord [here](https://discord.com/channels/957516730727563285/957516731654488087/1479526409587265709) requesting to return the functionality of the season search. Initially I thought the user just wanted to click a lot of times for each of their episode but after further looking they want the backfill capability. This is a valid request and lowers API calls so I will move these features to a separate button for people who want to mass download a year without having to click every episode.