### PR TITLE
Fix: Imports Stalling in Queue

### DIFF
--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -181,8 +181,20 @@ namespace NzbDrone.Core.Download
                 trackedDownload.RemoteEpisode.Series,
                 trackedDownload.ImportItem);
 
-            if (VerifyImport(trackedDownload, importResults))
+            try
             {
+                if (VerifyImport(trackedDownload, importResults))
+                {
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex, "Failed to verify import for '{0}'", trackedDownload.DownloadItem.Title);
+                trackedDownload.State = TrackedDownloadState.ImportPending;
+                trackedDownload.Warn("Import verification failed for {0}, manual import may be required.", trackedDownload.DownloadItem.Title);
+                SendManualInteractionRequiredNotification(trackedDownload);
+
                 return;
             }
 
@@ -269,7 +281,7 @@ namespace NzbDrone.Core.Download
             var atLeastOneEpisodeImported = importResults.Any(c => c.Result == ImportResultType.Imported);
             var allEpisodesImportedInHistory = _trackedDownloadAlreadyImported.IsImported(trackedDownload, historyItems);
             var episodes = _episodeService.GetEpisodes(trackedDownload.RemoteEpisode.Episodes.Select(e => e.Id));
-            var files = _mediaFileService.GetFiles(episodes.Select(e => e.EpisodeFileId).Distinct());
+            var files = _mediaFileService.GetFiles(episodes.Select(e => e.EpisodeFileId).Where(id => id > 0).Distinct());
 
             if (allEpisodesImportedInHistory)
             {


### PR DESCRIPTION
Downloads could get permanently stuck in the "Importing" state when `VerifyImport` threw an exception during import processing. `VerifyImport` queries for media files using `EpisodeFileId` from all episodes, including episodes that haven't been imported yet `(EpisodeFileId = 0)`. Since ID `0` doesn't exist in the database, `BasicRepository.Get()` throws an `ApplicationException`. This exception left the download stuck in Importing state which is never retried by the processing loop.

I filtered out ID = 0 and added a try catch that will catch the exception and push to manual import required instead of stalling.

This is untested in a real case as I haven't come across this issue and don't have a good way to reproduce to to test functionality so this is logic changes only. 

Fixes: https://github.com/Whisparr/Whisparr/issues/1063