### PR TITLE
Fix: Add OriginalFilename Check When Renaming is Disabled

### DIFF
--- a/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
+++ b/src/NzbDrone.Core.Test/OrganizerTests/FileNameBuilderTests/FileNameBuilderFixture.cs
@@ -313,7 +313,7 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _episodeFile.RelativePath = "30 Rock - S01E01 - Test";
 
             Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
-                   .Should().Be("30.Rock.S01E01.xvid-LOL");
+                   .Should().Be(Path.GetFileNameWithoutExtension(_episodeFile.RelativePath));
         }
 
         [Test]
@@ -324,10 +324,10 @@ namespace NzbDrone.Core.Test.OrganizerTests.FileNameBuilderTests
             _namingConfig.ColonReplacementFormat = ColonReplacementFormat.Smart;
 
             _episodeFile.SceneName = "30.Rock.S01E01.xvid:LOL";
-            _episodeFile.RelativePath = "30 Rock - S01E01 - Test";
+            _episodeFile.RelativePath = "30 Rock - S01E01 - Test: Colon";
 
             Subject.BuildFileName(new List<Episode> { _episode1 }, _series, _episodeFile)
-                .Should().Be("30.Rock.S01E01.xvid-LOL");
+                .Should().Be("30 Rock - S01E01 - Test - Colon");
         }
 
         [Test]

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -190,6 +190,16 @@ namespace NzbDrone.Core.Organizer
 
             if (!namingConfig.RenameEpisodes)
             {
+                // When renaming is disabled, prefer the actual filename on disk over the SceneName.
+                // SceneName comes from the download client's release title which may differ from
+                // the actual filename (e.g., missing resolution/codec info).
+                var originalFileName = GetOriginalFileName(episodeFile, true);
+
+                if (originalFileName.IsNotNullOrWhiteSpace())
+                {
+                    return CleanFileName(originalFileName) + extension;
+                }
+
                 return GetOriginalTitle(episodeFile, true) + extension;
             }
 


### PR DESCRIPTION
When renaming is disabled, `GetOriginalTitle()` prefers `episodeFile.SceneName` over the actual filename. `SceneName` is set from the download client's release title, which can differ from the actual filename specifically missing resolution and video codec (x265) info most of the time.

closes: https://github.com/Whisparr/Whisparr/issues/1070