### PR TITLE
Fix: Refactor Folder Parsing

### DIFF
--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -37,6 +37,7 @@ namespace NzbDrone.Core.Download
         private readonly IEpisodeService _episodeService;
         private readonly ITrackedDownloadAlreadyImported _trackedDownloadAlreadyImported;
         private readonly IMediaFileService _mediaFileService;
+        private readonly IExternalIdMatchService _externalIdMatchService;
         private readonly Logger _logger;
 
         public CompletedDownloadService(IEventAggregator eventAggregator,
@@ -48,6 +49,7 @@ namespace NzbDrone.Core.Download
                                         IEpisodeService episodeService,
                                         ITrackedDownloadAlreadyImported trackedDownloadAlreadyImported,
                                         IMediaFileService mediaFileService,
+                                        IExternalIdMatchService externalIdMatchService,
                                         Logger logger)
         {
             _eventAggregator = eventAggregator;
@@ -59,6 +61,7 @@ namespace NzbDrone.Core.Download
             _episodeService = episodeService;
             _trackedDownloadAlreadyImported = trackedDownloadAlreadyImported;
             _mediaFileService = mediaFileService;
+            _externalIdMatchService = externalIdMatchService;
             _logger = logger;
         }
 
@@ -77,27 +80,23 @@ namespace NzbDrone.Core.Download
                 return;
             }
 
-            var grabbedHistories = _historyService.FindByDownloadId(trackedDownload.DownloadItem.DownloadId).Where(h => h.EventType == EpisodeHistoryEventType.Grabbed).ToList();
-            var historyItem = grabbedHistories.MaxBy(h => h.Date);
-
-            if (historyItem == null && trackedDownload.DownloadItem.Category.IsNullOrWhiteSpace())
-            {
-                trackedDownload.Warn("Download wasn't grabbed by Whisparr and not in a category, Skipping.");
-                return;
-            }
-
             if (!ValidatePath(trackedDownload))
             {
                 return;
             }
+
+            var grabbedHistories = _historyService.FindByDownloadId(trackedDownload.DownloadItem.DownloadId).Where(h => h.EventType == EpisodeHistoryEventType.Grabbed).ToList();
+            var historyItem = grabbedHistories.MaxBy(h => h.Date);
 
             var series = _parsingService.GetSeries(trackedDownload.DownloadItem.Title);
             Episode externalIdEpisode = null;
 
             if (series == null)
             {
-                // Try to find series by external ID from download title (e.g., MIKR-058)
-                externalIdEpisode = GetEpisodeByExternalId(trackedDownload.DownloadItem.Title);
+                // Try to find series by external ID from download title (e.g., MIKR-058), then fall back
+                // to scanning files inside the output path (e.g., release folder "abc123" containing miaa-254.mp4)
+                externalIdEpisode = _externalIdMatchService.FindEpisode(trackedDownload.DownloadItem.Title)
+                    ?? _externalIdMatchService.FindEpisodeInFolder(trackedDownload.ImportItem.OutputPath.FullPath);
 
                 if (externalIdEpisode != null)
                 {
@@ -123,6 +122,13 @@ namespace NzbDrone.Core.Download
                         };
                     }
                 }
+            }
+
+            // Safety gate: only block if we couldn't identify the series AND the download wasn't grabbed by us / categorised
+            if (series == null && historyItem == null && trackedDownload.DownloadItem.Category.IsNullOrWhiteSpace())
+            {
+                trackedDownload.Warn("Download wasn't grabbed by Whisparr and not in a category, Skipping.");
+                return;
             }
 
             if (series == null)
@@ -352,30 +358,6 @@ namespace NzbDrone.Core.Download
             }
 
             return true;
-        }
-
-        private Episode GetEpisodeByExternalId(string title)
-        {
-            var externalId = Parser.Parser.ParseExternalIdFromFilename(title);
-
-            if (externalId.IsNullOrWhiteSpace())
-            {
-                return null;
-            }
-
-            _logger.Debug("Attempting to find episode by external ID: {0}", externalId);
-
-            var episode = _episodeService.FindByExternalId(externalId);
-
-            if (episode == null)
-            {
-                _logger.Debug("No episode found with external ID: {0}", externalId);
-                return null;
-            }
-
-            _logger.Debug("Found episode '{0}' via external ID: {1}", episode.Title, externalId);
-
-            return episode;
         }
     }
 }

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -124,8 +124,9 @@ namespace NzbDrone.Core.Download
                 }
             }
 
-            // Safety gate: only block if we couldn't identify the series AND the download wasn't grabbed by us / categorised
-            if (series == null && historyItem == null && trackedDownload.DownloadItem.Category.IsNullOrWhiteSpace())
+            // Safety gate: require a grab history, a category, or a confident external-ID match.
+            // A title-only series match isn't trusted here since the title can resemble any series.
+            if (historyItem == null && trackedDownload.DownloadItem.Category.IsNullOrWhiteSpace() && externalIdEpisode == null)
             {
                 trackedDownload.Warn("Download wasn't grabbed by Whisparr and not in a category, Skipping.");
                 return;

--- a/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/DownloadedEpisodesImportService.cs
@@ -27,8 +27,8 @@ namespace NzbDrone.Core.MediaFiles
         private readonly IDiskProvider _diskProvider;
         private readonly IDiskScanService _diskScanService;
         private readonly ISeriesService _seriesService;
-        private readonly IEpisodeService _episodeService;
         private readonly IParsingService _parsingService;
+        private readonly IExternalIdMatchService _externalIdMatchService;
         private readonly IMakeImportDecision _importDecisionMaker;
         private readonly IImportApprovedEpisodes _importApprovedEpisodes;
         private readonly IDetectSample _detectSample;
@@ -38,8 +38,8 @@ namespace NzbDrone.Core.MediaFiles
         public DownloadedEpisodesImportService(IDiskProvider diskProvider,
                                                IDiskScanService diskScanService,
                                                ISeriesService seriesService,
-                                               IEpisodeService episodeService,
                                                IParsingService parsingService,
+                                               IExternalIdMatchService externalIdMatchService,
                                                IMakeImportDecision importDecisionMaker,
                                                IImportApprovedEpisodes importApprovedEpisodes,
                                                IDetectSample detectSample,
@@ -49,8 +49,8 @@ namespace NzbDrone.Core.MediaFiles
             _diskProvider = diskProvider;
             _diskScanService = diskScanService;
             _seriesService = seriesService;
-            _episodeService = episodeService;
             _parsingService = parsingService;
+            _externalIdMatchService = externalIdMatchService;
             _importDecisionMaker = importDecisionMaker;
             _importApprovedEpisodes = importApprovedEpisodes;
             _detectSample = detectSample;
@@ -159,7 +159,8 @@ namespace NzbDrone.Core.MediaFiles
         private List<ImportResult> ProcessFolder(DirectoryInfo directoryInfo, ImportMode importMode, DownloadClientItem downloadClientItem)
         {
             var cleanedUpName = GetCleanedUpFolderName(directoryInfo.Name);
-            var series = _parsingService.GetSeries(cleanedUpName);
+            var series = _parsingService.GetSeries(cleanedUpName)
+                ?? _externalIdMatchService.FindSeriesInFolder(directoryInfo.FullName);
 
             if (series == null)
             {
@@ -235,13 +236,8 @@ namespace NzbDrone.Core.MediaFiles
 
         private List<ImportResult> ProcessFile(FileInfo fileInfo, ImportMode importMode, DownloadClientItem downloadClientItem)
         {
-            var series = _parsingService.GetSeries(Path.GetFileNameWithoutExtension(fileInfo.Name));
-
-            if (series == null)
-            {
-                // Try to find series by external ID from filename (e.g., MIKR-058.mp4)
-                series = GetSeriesByExternalId(fileInfo.Name);
-            }
+            var series = _parsingService.GetSeries(Path.GetFileNameWithoutExtension(fileInfo.Name))
+                ?? _externalIdMatchService.FindSeries(fileInfo.Name);
 
             if (series == null)
             {
@@ -254,35 +250,6 @@ namespace NzbDrone.Core.MediaFiles
             }
 
             return ProcessFile(fileInfo, importMode, series, downloadClientItem);
-        }
-
-        private Series GetSeriesByExternalId(string filename)
-        {
-            var externalId = Parser.Parser.ParseExternalIdFromFilename(filename);
-
-            if (externalId.IsNullOrWhiteSpace())
-            {
-                return null;
-            }
-
-            _logger.Debug("Attempting to find series by external ID: {0}", externalId);
-
-            var episode = _episodeService.FindByExternalId(externalId);
-
-            if (episode == null)
-            {
-                _logger.Debug("No episode found with external ID: {0}", externalId);
-                return null;
-            }
-
-            var series = _seriesService.GetSeries(episode.SeriesId);
-
-            if (series != null)
-            {
-                _logger.Debug("Found series '{0}' via external ID: {1}", series.Title, externalId);
-            }
-
-            return series;
         }
 
         private List<ImportResult> ProcessFile(FileInfo fileInfo, ImportMode importMode, Series series, DownloadClientItem downloadClientItem)

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Manual/ManualImportService.cs
@@ -36,6 +36,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
         private readonly IMakeImportDecision _importDecisionMaker;
         private readonly ISeriesService _seriesService;
         private readonly IEpisodeService _episodeService;
+        private readonly IExternalIdMatchService _externalIdMatchService;
         private readonly IImportApprovedEpisodes _importApprovedEpisodes;
         private readonly IAggregationService _aggregationService;
         private readonly ITrackedDownloadService _trackedDownloadService;
@@ -51,6 +52,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                                    IMakeImportDecision importDecisionMaker,
                                    ISeriesService seriesService,
                                    IEpisodeService episodeService,
+                                   IExternalIdMatchService externalIdMatchService,
                                    IAggregationService aggregationService,
                                    IImportApprovedEpisodes importApprovedEpisodes,
                                    ITrackedDownloadService trackedDownloadService,
@@ -66,6 +68,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
             _importDecisionMaker = importDecisionMaker;
             _seriesService = seriesService;
             _episodeService = episodeService;
+            _externalIdMatchService = externalIdMatchService;
             _aggregationService = aggregationService;
             _importApprovedEpisodes = importApprovedEpisodes;
             _trackedDownloadService = trackedDownloadService;
@@ -266,6 +269,11 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
             if (series == null)
             {
+                series = _externalIdMatchService.FindSeriesInFolder(baseFolder);
+            }
+
+            if (series == null)
+            {
                 // Filter paths based on the rootFolder, so files in subfolders that should be ignored are ignored.
                 // It will lead to some extra directories being checked for files, but it saves the processing of them and is cleaner than
                 // teaching FilterPaths to know whether it's processing a file or a folder and changing it's filtering based on that.
@@ -308,7 +316,7 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
 
                 if (series == null)
                 {
-                    _parsingService.GetSeries(relativeFile.Split('\\', '/')[0]);
+                    series = _parsingService.GetSeries(relativeFile.Split('\\', '/')[0]);
                 }
 
                 if (series == null)
@@ -329,6 +337,11 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Manual
                     {
                         series = _seriesService.FindByTitle(relativeParseInfo.SeriesTitle);
                     }
+                }
+
+                if (series == null)
+                {
+                    series = _externalIdMatchService.FindSeries(Path.GetFileName(file));
                 }
 
                 if (series == null)

--- a/src/NzbDrone.Core/Parser/ExternalIdMatchService.cs
+++ b/src/NzbDrone.Core/Parser/ExternalIdMatchService.cs
@@ -1,0 +1,93 @@
+using System.IO;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Parser
+{
+    public interface IExternalIdMatchService
+    {
+        Episode FindEpisode(string filename);
+        Episode FindEpisodeInFolder(string folder);
+        Series FindSeries(string filename);
+        Series FindSeriesInFolder(string folder);
+    }
+
+    public class ExternalIdMatchService : IExternalIdMatchService
+    {
+        private readonly IEpisodeService _episodeService;
+        private readonly ISeriesService _seriesService;
+        private readonly IDiskScanService _diskScanService;
+        private readonly Logger _logger;
+
+        public ExternalIdMatchService(IEpisodeService episodeService,
+                                      ISeriesService seriesService,
+                                      IDiskScanService diskScanService,
+                                      Logger logger)
+        {
+            _episodeService = episodeService;
+            _seriesService = seriesService;
+            _diskScanService = diskScanService;
+            _logger = logger;
+        }
+
+        public Episode FindEpisode(string filename)
+        {
+            var externalId = Parser.ParseExternalIdFromFilename(filename);
+
+            if (externalId.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            _logger.Debug("Attempting to find episode by external ID: {0}", externalId);
+
+            var episode = _episodeService.FindByExternalId(externalId);
+
+            if (episode == null)
+            {
+                _logger.Debug("No episode found with external ID: {0}", externalId);
+                return null;
+            }
+
+            _logger.Debug("Found episode '{0}' via external ID: {1}", episode.Title, externalId);
+
+            return episode;
+        }
+
+        public Episode FindEpisodeInFolder(string folder)
+        {
+            if (folder.IsNullOrWhiteSpace() || !Directory.Exists(folder))
+            {
+                return null;
+            }
+
+            foreach (var videoFile in _diskScanService.GetVideoFiles(folder))
+            {
+                var episode = FindEpisode(Path.GetFileName(videoFile));
+
+                if (episode != null)
+                {
+                    return episode;
+                }
+            }
+
+            return null;
+        }
+
+        public Series FindSeries(string filename)
+        {
+            var episode = FindEpisode(filename);
+
+            return episode == null ? null : _seriesService.GetSeries(episode.SeriesId);
+        }
+
+        public Series FindSeriesInFolder(string folder)
+        {
+            var episode = FindEpisodeInFolder(folder);
+
+            return episode == null ? null : _seriesService.GetSeries(episode.SeriesId);
+        }
+    }
+}


### PR DESCRIPTION
Quite frankly, I find this fix to be blegh. The issue was that the folder parsing was failing and wasn't able to get a site so failed the whole match. This new way makes it so that if folder check fails, it attempts to parse the file and pull site data up the tree. I think I need to sit down and rethink how the JAV stuff works for now as I seem to be band aiding a lot. 

Tested with a few files and it fixed the issue the person reported. 

closes: https://github.com/Whisparr/Whisparr/issues/1081