### PR TITLE
Fix: Fix Scene History

### DIFF
--- a/frontend/src/Episode/History/EpisodeHistoryRow.css
+++ b/frontend/src/Episode/History/EpisodeHistoryRow.css
@@ -4,3 +4,9 @@
 
   width: 65px;
 }
+
+.customFormatScore {
+  composes: cell from '~Components/Table/Cells/TableRowCell.css';
+
+  width: 55px;
+}

--- a/frontend/src/Episode/History/EpisodeHistoryRow.css.d.ts
+++ b/frontend/src/Episode/History/EpisodeHistoryRow.css.d.ts
@@ -2,6 +2,7 @@
 // Please do not change this file!
 interface CssExports {
   'actions': string;
+  'customFormatScore': string;
   'details': string;
 }
 export const cssExports: CssExports;

--- a/frontend/src/Episode/History/EpisodeHistoryRow.js
+++ b/frontend/src/Episode/History/EpisodeHistoryRow.js
@@ -102,14 +102,6 @@ class EpisodeHistoryRow extends Component {
           />
         </TableRowCell>
 
-        <TableRowCell>
-          <EpisodeFormats formats={customFormats} />
-        </TableRowCell>
-
-        <TableRowCell>
-          {formatCustomFormatScore(customFormatScore, customFormats.length)}
-        </TableRowCell>
-
         <RelativeDateCell
           date={date}
           includeSeconds={true}


### PR DESCRIPTION
At some point extra table cell rows were created causing most of them to shift over out of alignment. 

Closes: https://github.com/Whisparr/Whisparr/issues/1089

Fixed UI: 
<img width="868" height="296" alt="image" src="https://github.com/user-attachments/assets/7a8850e3-16d2-4b42-8e50-6e2e177fa27e" />
