### PR TITLE
Fix: Replace SonarrBranding with Whisparr Across UI Links

### DIFF
--- a/frontend/src/Components/FileBrowser/FileBrowserModalContent.tsx
+++ b/frontend/src/Components/FileBrowser/FileBrowserModalContent.tsx
@@ -147,7 +147,7 @@ function FileBrowserModalContent(props: FileBrowserModalContentProps) {
           <Alert className={styles.mappedDrivesWarning} kind={kinds.WARNING}>
             <InlineMarkdown
               data={translate('MappedNetworkDrivesWindowsService', {
-                url: 'https://wiki.servarr.com/sonarr/faq#why-cant-sonarr-see-my-files-on-a-remote-server',
+                url: 'https://wiki.servarr.com/whisparr/faq#why-can-whisparr-not-see-my-files-on-a-remote-server',
               })}
             />
           </Alert>

--- a/frontend/src/FirstRun/AuthenticationRequiredModalContent.tsx
+++ b/frontend/src/FirstRun/AuthenticationRequiredModalContent.tsx
@@ -105,7 +105,6 @@ export default function AuthenticationRequiredModalContent() {
                     ? translate('AuthenticationMethodHelpTextWarning')
                     : undefined
                 }
-                helpLink="https://wiki.servarr.com/sonarr/faq#forced-authentication"
                 onChange={onInputChange}
                 {...authenticationMethod}
               />

--- a/frontend/src/System/Status/MoreInfo/MoreInfo.tsx
+++ b/frontend/src/System/Status/MoreInfo/MoreInfo.tsx
@@ -14,62 +14,38 @@ function MoreInfo() {
           {translate('HomePage')}
         </DescriptionListItemTitle>
         <DescriptionListItemDescription>
-          <Link to="https://sonarr.tv/">sonarr.tv</Link>
+          <Link to="https://whisparr.com/">whisparr.com</Link>
         </DescriptionListItemDescription>
 
         <DescriptionListItemTitle>{translate('Wiki')}</DescriptionListItemTitle>
         <DescriptionListItemDescription>
-          <Link to="https://wiki.servarr.com/sonarr">
-            wiki.servarr.com/sonarr
+          <Link to="https://wiki.servarr.com/whisparr">
+            wiki.servarr.com/whisparr
           </Link>
-        </DescriptionListItemDescription>
-
-        <DescriptionListItemTitle>
-          {translate('Forums')}
-        </DescriptionListItemTitle>
-        <DescriptionListItemDescription>
-          <Link to="https://forums.sonarr.tv/">forums.sonarr.tv</Link>
-        </DescriptionListItemDescription>
-
-        <DescriptionListItemTitle>
-          {translate('Twitter')}
-        </DescriptionListItemTitle>
-        <DescriptionListItemDescription>
-          <Link to="https://twitter.com/sonarrtv">@sonarrtv</Link>
         </DescriptionListItemDescription>
 
         <DescriptionListItemTitle>
           {translate('Discord')}
         </DescriptionListItemTitle>
         <DescriptionListItemDescription>
-          <Link to="https://discord.sonarr.tv/">discord.sonarr.tv</Link>
-        </DescriptionListItemDescription>
-
-        <DescriptionListItemTitle>{translate('IRC')}</DescriptionListItemTitle>
-        <DescriptionListItemDescription>
-          <Link to="irc://irc.libera.chat/#sonarr">
-            {translate('IRCLinkText')}
-          </Link>
-        </DescriptionListItemDescription>
-        <DescriptionListItemDescription>
-          <Link to="https://web.libera.chat/?channels=#sonarr">
-            {translate('LiberaWebchat')}
-          </Link>
+          <Link to="https://whisparr.com/discord">whisparr.com/discord</Link>
         </DescriptionListItemDescription>
 
         <DescriptionListItemTitle>
           {translate('Donations')}
         </DescriptionListItemTitle>
         <DescriptionListItemDescription>
-          <Link to="https://sonarr.tv/donate">sonarr.tv/donate</Link>
+          <Link to="https://opencollective.com/whisparr">
+            opencollective.com/whisparr
+          </Link>
         </DescriptionListItemDescription>
 
         <DescriptionListItemTitle>
           {translate('Source')}
         </DescriptionListItemTitle>
         <DescriptionListItemDescription>
-          <Link to="https://github.com/Sonarr/Sonarr/">
-            github.com/Sonarr/Sonarr
+          <Link to="https://github.com/Whisparr/Whisparr/">
+            github.com/Whisparr/Whisparr
           </Link>
         </DescriptionListItemDescription>
 
@@ -77,11 +53,8 @@ function MoreInfo() {
           {translate('FeatureRequests')}
         </DescriptionListItemTitle>
         <DescriptionListItemDescription>
-          <Link to="https://forums.sonarr.tv/">forums.sonarr.tv</Link>
-        </DescriptionListItemDescription>
-        <DescriptionListItemDescription>
-          <Link to="https://github.com/Sonarr/Sonarr/issues">
-            github.com/Sonarr/Sonarr/issues
+          <Link to="https://github.com/Whisparr/Whisparr/issues">
+            github.com/Whisparr/Whisparr/issues
           </Link>
         </DescriptionListItemDescription>
       </DescriptionList>


### PR DESCRIPTION
#### Database Migration
NO

#### Description
update system info links from Sonarr to Whisparr in the System status page, file browser modal.
Also removed reference to sonarr wiki for authentication. I couldn't find a whisparr equivalent.

let me know if this is fine or if some changes are needed

#### Screenshot (if UI related)
<img width="606" height="283" alt="image" src="https://github.com/user-attachments/assets/a7262937-429a-4b6f-8454-4111bcb34e9e" />
<img width="905" height="863" alt="Screenshot From 2026-06-08 19-29-02" src="https://github.com/user-attachments/assets/4078c8b1-b7be-40ec-9adb-5652089d4e07" />

