### PR TITLE
Fix: Duplicated Release Year in Download Notifications

### DIFF
--- a/src/NzbDrone.Core.Test/NotificationTests/NotificationServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/NotificationServiceFixture.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.Events;
+using NzbDrone.Core.Notifications;
+using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Test.Framework;
+using NzbDrone.Core.Tv;
+
+namespace NzbDrone.Core.Test.NotificationTests
+{
+    [TestFixture]
+    public class NotificationServiceFixture : CoreTest<NotificationService>
+    {
+        private DownloadMessage _downloadMessage;
+
+        [SetUp]
+        public void Setup()
+        {
+            var notificationDefinition = new NotificationDefinition
+            {
+                Id = 1,
+                Name = "Test Notification"
+            };
+
+            var notification = new Mock<INotification>();
+            notification.SetupGet(v => v.Definition).Returns(notificationDefinition);
+            notification.Setup(v => v.OnDownload(It.IsAny<DownloadMessage>()))
+                        .Callback<DownloadMessage>(v => _downloadMessage = v);
+
+            Mocker.GetMock<INotificationFactory>()
+                  .Setup(v => v.OnDownloadEnabled(true))
+                  .Returns(new List<INotification> { notification.Object });
+        }
+
+        [Test]
+        public void should_not_prefix_release_date_with_release_year_in_download_message()
+        {
+            var series = new Series { Title = "Private" };
+            var episodes = new List<Episode>
+            {
+                new Episode
+                {
+                    SeasonNumber = 2026,
+                    AirDate = "2026-06-26",
+                    Title = "Sherezade Lapiedra Has A Threesome With Her Boyfriend And A Nosey Neighbour"
+                }
+            };
+
+            Subject.Handle(new EpisodeImportedEvent(
+                new LocalEpisode
+                {
+                    Series = series,
+                    Episodes = episodes,
+                    Quality = new QualityModel(Quality.WEBDL1080p)
+                },
+                new EpisodeFile(),
+                new List<EpisodeFile>(),
+                true,
+                null));
+
+            _downloadMessage.Message.Should().Be("Private - 2026-06-26 - Sherezade Lapiedra Has A Threesome With Her Boyfriend And A Nosey Neighbour [WEBDL-1080p]");
+        }
+
+        [Test]
+        public void should_separate_multiple_release_dates_in_download_message()
+        {
+            var series = new Series { Title = "Private" };
+            var episodes = new List<Episode>
+            {
+                new Episode
+                {
+                    SeasonNumber = 2026,
+                    AirDate = "2026-06-26",
+                    Title = "First Scene"
+                },
+                new Episode
+                {
+                    SeasonNumber = 2026,
+                    AirDate = "2026-06-27",
+                    Title = "Second Scene"
+                }
+            };
+
+            Subject.Handle(new EpisodeImportedEvent(
+                new LocalEpisode
+                {
+                    Series = series,
+                    Episodes = episodes,
+                    Quality = new QualityModel(Quality.WEBDL1080p)
+                },
+                new EpisodeFile(),
+                new List<EpisodeFile>(),
+                true,
+                null));
+
+            _downloadMessage.Message.Should().Be("Private - 2026-06-26 + 2026-06-27 - First Scene + Second Scene [WEBDL-1080p]");
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -51,14 +51,13 @@ namespace NzbDrone.Core.Notifications
                 qualityString += " Proper";
             }
 
-            var episodeNumbers = string.Concat(episodes.Select(e => e.AirDate));
+            var releaseDates = string.Join(" + ", episodes.Select(e => e.AirDate));
 
             var episodeTitles = string.Join(" + ", episodes.Select(e => e.Title));
 
-            return string.Format("{0} - {1}{2} - {3} [{4}]",
+            return string.Format("{0} - {1} - {2} [{3}]",
                                     series.Title,
-                                    episodes.First().SeasonNumber,
-                                    episodeNumbers,
+                                    releaseDates,
                                     episodeTitles,
                                     qualityString);
         }


### PR DESCRIPTION
## Summary

- Fixes Whisparr download notification messages that duplicated the release year, e.g. `20262026-06-26`.
- Builds the message from episode release dates directly instead of prefixing `SeasonNumber`, which Whisparr maps to the release year.
- Separates multiple release dates with ` + `, matching the existing episode-title delimiter.
- Adds regression coverage for single-date and multi-date download notifications.

## Root cause

`SkyHookProxy` maps `episode.SeasonNumber` to `oracleEpisode.Year`, while `episode.AirDate` already contains the full release date. `NotificationService.GetMessage()` formatted messages as `{SeasonNumber}{AirDate}`, so 2026 + 2026-06-26 became `20262026-06-26`.

## Test plan

- [x] `git diff --check`
- [x] `/tmp/dotnet-whisparr/dotnet test src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj --filter NotificationServiceFixture /p:RunAnalyzers=false`

Note: a plain `dotnet test` build currently hits existing repository-wide StyleCop SA1200 analyzer errors in `NzbDrone.Common`; the focused regression tests pass with analyzers disabled.
