### PR TITLE
Fixed: Fix import errors for v2 in case of unexpected file names for downloaded files

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateEpisodesFixture.cs
@@ -1,9 +1,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
+using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Download;
+using NzbDrone.Core.Download.TrackedDownloads;
+using NzbDrone.Core.History;
 using NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
@@ -157,6 +161,107 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport.Aggregation.Aggregators
 
             Mocker.GetMock<IParsingService>()
                   .Verify(v => v.GetEpisodes(specialEpisodeInfo, _series, localEpisode.SceneSource, null), Times.Once());
+        }
+
+        [Test]
+        public void should_match_episode_via_grab_history_when_filename_unparseable()
+        {
+            const int episodeId = 1695;
+            var episode = Builder<Episode>.CreateNew()
+                .With(e => e.Id = episodeId)
+                .With(e => e.SeriesId = _series.Id)
+                .Build();
+
+            var downloadItem = Builder<DownloadClientItem>.CreateNew()
+                .With(d => d.DownloadId = "a1b2c3d4e5f6789012345678901234567890abcd")
+                .With(d => d.Title = "TestStudio-Test Performer-720p.mp4")
+                .Build();
+
+            var localEpisode = new LocalEpisode
+            {
+                Path = @"C:\Test\Downloads\TestStudio-Test Performer-720p.mp4".AsOsAgnostic(),
+                Series = _series,
+                DownloadItem = downloadItem,
+                SceneSource = true
+            };
+
+            Mocker.GetMock<IHistoryService>()
+                .Setup(s => s.FindByDownloadId(downloadItem.DownloadId))
+                .Returns(new List<EpisodeHistory>
+                {
+                    new EpisodeHistory
+                    {
+                        EpisodeId = episodeId,
+                        SeriesId = _series.Id,
+                        EventType = EpisodeHistoryEventType.Grabbed,
+                        SourceTitle = "[TestStudio] Test Performer (Test Episode) [2017-06-30, 720p]"
+                    }
+                });
+
+            Mocker.GetMock<IEpisodeService>()
+                .Setup(s => s.GetEpisodes(It.Is<IEnumerable<int>>(ids => ids.Contains(episodeId))))
+                .Returns(new List<Episode> { episode });
+
+            Subject.Aggregate(localEpisode, downloadItem);
+
+            localEpisode.Episodes.Should().HaveCount(1);
+            localEpisode.Episodes.First().Id.Should().Be(episodeId);
+            Mocker.GetMock<IParsingService>()
+                .Verify(v => v.GetEpisodes(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<Series>(), It.IsAny<bool>(), null), Times.Never());
+        }
+
+        [Test]
+        public void should_not_match_via_grab_history_when_no_grab_history()
+        {
+            var downloadItem = Builder<DownloadClientItem>.CreateNew()
+                .With(d => d.DownloadId = "abc123")
+                .With(d => d.Title = "TestStudio-Test Performer-720p.mp4")
+                .Build();
+
+            var localEpisode = new LocalEpisode
+            {
+                Path = @"C:\Test\Downloads\TestStudio-Test Performer-720p.mp4".AsOsAgnostic(),
+                Series = _series,
+                DownloadItem = downloadItem,
+                SceneSource = true
+            };
+
+            Mocker.GetMock<IHistoryService>()
+                .Setup(s => s.FindByDownloadId(downloadItem.DownloadId))
+                .Returns(new List<EpisodeHistory>());
+
+            Subject.Aggregate(localEpisode, downloadItem);
+
+            localEpisode.Episodes.Should().BeEmpty();
+        }
+
+        [Test]
+        public void should_not_use_grab_history_when_filename_parses()
+        {
+            var fileEpisodeInfo = Parser.Parser.ParseTitle("Series.Title.23.01.15");
+            var parsedEpisodes = Builder<Episode>.CreateListOfSize(1).BuildList();
+
+            var downloadItem = Builder<DownloadClientItem>.CreateNew()
+                .With(d => d.DownloadId = "abc123")
+                .Build();
+
+            var localEpisode = new LocalEpisode
+            {
+                FileEpisodeInfo = fileEpisodeInfo,
+                Path = @"C:\Test\Unsorted TV\Series.Title.23.01.15\Series.Title.23.01.15.mkv".AsOsAgnostic(),
+                Series = _series,
+                DownloadItem = downloadItem
+            };
+
+            Mocker.GetMock<IParsingService>()
+                .Setup(s => s.GetEpisodes(fileEpisodeInfo, _series, localEpisode.SceneSource, null))
+                .Returns(parsedEpisodes);
+
+            Subject.Aggregate(localEpisode, downloadItem);
+
+            localEpisode.Episodes.Should().BeEquivalentTo(parsedEpisodes);
+            Mocker.GetMock<IHistoryService>()
+                .Verify(v => v.FindByDownloadId(It.IsAny<string>()), Times.Never());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateEpisodesFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateEpisodesFixture.cs
@@ -6,7 +6,6 @@ using Moq;
 using NUnit.Framework;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Download;
-using NzbDrone.Core.Download.TrackedDownloads;
 using NzbDrone.Core.History;
 using NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators;
 using NzbDrone.Core.Parser;

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -280,11 +280,11 @@ namespace NzbDrone.Core.Download
 
             var atLeastOneEpisodeImported = importResults.Any(c => c.Result == ImportResultType.Imported);
             var allEpisodesImportedInHistory = _trackedDownloadAlreadyImported.IsImported(trackedDownload, historyItems);
-            var episodes = _episodeService.GetEpisodes(trackedDownload.RemoteEpisode.Episodes.Select(e => e.Id));
-            var files = _mediaFileService.GetFiles(episodes.Select(e => e.EpisodeFileId).Where(id => id > 0).Distinct());
 
             if (allEpisodesImportedInHistory)
             {
+                var episodes = _episodeService.GetEpisodes(trackedDownload.RemoteEpisode.Episodes.Select(e => e.Id));
+                var files = _mediaFileService.GetFiles(episodes.Select(e => e.EpisodeFileId).Where(id => id > 0).Distinct());
                 // Log different error messages depending on the circumstances, but treat both as fully imported, because that's the reality.
                 // The second message shouldn't be logged in most cases, but continued reporting would indicate an ongoing issue.
 

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -285,6 +285,7 @@ namespace NzbDrone.Core.Download
             {
                 var episodes = _episodeService.GetEpisodes(trackedDownload.RemoteEpisode.Episodes.Select(e => e.Id));
                 var files = _mediaFileService.GetFiles(episodes.Select(e => e.EpisodeFileId).Where(id => id > 0).Distinct());
+
                 // Log different error messages depending on the circumstances, but treat both as fully imported, because that's the reality.
                 // The second message shouldn't be logged in most cases, but continued reporting would indicate an ongoing issue.
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateEpisodes.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/Aggregation/Aggregators/AggregateEpisodes.cs
@@ -5,6 +5,7 @@ using NLog;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Download;
 using NzbDrone.Core.Download.TrackedDownloads;
+using NzbDrone.Core.History;
 using NzbDrone.Core.Parser;
 using NzbDrone.Core.Parser.Model;
 using NzbDrone.Core.Qualities;
@@ -17,13 +18,15 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
         private readonly IParsingService _parsingService;
         private readonly IEpisodeService _episodeService;
         private readonly ITrackedDownloadService _trackedDownloadService;
+        private readonly IHistoryService _historyService;
         private readonly Logger _logger;
 
-        public AggregateEpisodes(IParsingService parsingService, IEpisodeService episodeService, ITrackedDownloadService trackedDownloadService, Logger logger)
+        public AggregateEpisodes(IParsingService parsingService, IEpisodeService episodeService, ITrackedDownloadService trackedDownloadService, IHistoryService historyService, Logger logger)
         {
             _parsingService = parsingService;
             _episodeService = episodeService;
             _trackedDownloadService = trackedDownloadService;
+            _historyService = historyService;
             _logger = logger;
         }
 
@@ -101,6 +104,12 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
                 if (episodes != null && episodes.Any())
                 {
                     return episodes;
+                }
+
+                var grabbedEpisodes = TryMatchByGrabHistory(localEpisode);
+                if (grabbedEpisodes != null && grabbedEpisodes.Any())
+                {
+                    return grabbedEpisodes;
                 }
 
                 return new List<Episode>();
@@ -189,6 +198,50 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport.Aggregation.Aggregators
             }
 
             return null;
+        }
+
+        private List<Episode> TryMatchByGrabHistory(LocalEpisode localEpisode)
+        {
+            if (localEpisode.DownloadItem?.DownloadId.IsNullOrWhiteSpace() ?? true)
+            {
+                return null;
+            }
+
+            var grabbedHistories = _historyService.FindByDownloadId(localEpisode.DownloadItem.DownloadId)
+                .Where(h => h.EventType == EpisodeHistoryEventType.Grabbed)
+                .ToList();
+
+            if (grabbedHistories.Empty())
+            {
+                return null;
+            }
+
+            var episodeIds = grabbedHistories.Select(h => h.EpisodeId).Distinct().ToList();
+            var episodes = _episodeService.GetEpisodes(episodeIds);
+
+            if (localEpisode.Series != null)
+            {
+                episodes = episodes.Where(e => e.SeriesId == localEpisode.Series.Id).ToList();
+            }
+
+            if (episodes.Empty())
+            {
+                return null;
+            }
+
+            _logger.Debug("Matched file to {0} episode(s) via grab history: {1}", episodes.Count, string.Join(", ", episodeIds));
+
+            if (localEpisode.FileEpisodeInfo == null)
+            {
+                var trackedDownload = _trackedDownloadService.Find(localEpisode.DownloadItem.DownloadId);
+
+                if (trackedDownload?.RemoteEpisode?.ParsedEpisodeInfo != null)
+                {
+                    localEpisode.FileEpisodeInfo = trackedDownload.RemoteEpisode.ParsedEpisodeInfo;
+                }
+            }
+
+            return episodes;
         }
 
         private bool PreferOtherEpisodeInfo(ParsedEpisodeInfo fileEpisodeInfo, ParsedEpisodeInfo otherEpisodeInfo)


### PR DESCRIPTION
### Disclaimer

This is my first contribution.

Changes are generated by Cursor. Let me know if something feels off and I'll push requested updates.

#### Database Migration
NO

#### Summary
Fix completed-download import failures when the torrent filename cannot be parsed but the grab history already knows which episode was downloaded.

#### Problem
When a download client saves a file under a sanitized/non-whisparr parser supported name (e.g. TestStudio-Test Performer-720p.mp4), Whisparr fails to parse season/episode from the filename even though the original release title was valid at grab time. Import then fails with [Permanent] Invalid season or episode.

The queue/tracked download still has the correct episode from the grab, but episode aggregation only tried filename parsing and external ID matching.

#### Solution
Add a grab-history fallback in AggregateEpisodes: when parsing and external ID matching fail, look up EpisodeHistory grab events by DownloadId and resolve episodes from stored EpisodeIds.

Populate FileEpisodeInfo from the tracked download when available, so downstream aggregators have parsed metadata.

Move GetEpisodes/GetFiles in CompletedDownloadService.VerifyImport inside the allEpisodesImportedInHistory block to avoid a misleading query when no episodes were imported.

#### Sample logs during error state
```
2026-06-29 21:56:09.5|Trace|Http|Res: 9 [GET] /api/v3/command: 200.OK (52 ms)
2026-06-29 21:56:09.5|Debug|Api|[GET] /api/v3/command: 200.OK (52 ms)
2026-06-29 21:56:09.6|Debug|DetectSample|[/data/qbittorrent/complete/TestStudio-Test Performer-720p.mp4] does not appear to be a sample. Runtime 00:19:55.1160000 seconds is more than minimum of 300 seconds
2026-06-29 21:56:09.6|Debug|Parser|Parsing string 'TestStudio-Test Performer-720p.mp4'
2026-06-29 21:56:09.6|Debug|Parser|Unable to parse TestStudio-Test Performer-720p.mp4
2026-06-29 21:56:09.6|Debug|Parser|Attempting to parse episode info using combined directory and file names. complete
2026-06-29 21:56:09.6|Debug|Parser|Parsing string 'complete TestStudio-Test Performer-720p.mp4'
2026-06-29 21:56:09.6|Debug|Parser|Unable to parse complete TestStudio-Test Performer-720p.mp4
2026-06-29 21:56:09.6|Debug|Parser|Attempting to parse episode info using directory name. complete
2026-06-29 21:56:09.6|Debug|Parser|Parsing string 'complete.mp4'
2026-06-29 21:56:09.6|Debug|Parser|Unable to parse complete.mp4
2026-06-29 21:56:09.7|Debug|VideoFileInfoReader|Getting media info from /data/qbittorrent/complete/TestStudio-Test Performer-720p.mp4
2026-06-29 21:56:09.7|Trace|AggregateLanguage|Considering Languages English (MediaInfo) from MediaInfo
2026-06-29 21:56:09.7|Debug|AggregateLanguage|Selected languages: English
2026-06-29 21:56:09.7|Trace|AugmentQualityFromMediaInfo|Resolution 1280x720 considered 720p
2026-06-29 21:56:09.8|Trace|AggregateQuality|Considering Source Unknown (Default) Resolution 720 (MediaInfo) Revision  from MediaInfo
2026-06-29 21:56:09.8|Debug|QualityParser|Trying to parse quality for '[TestStudio] Test Performer (Test Scene name) [2009-06-30, 720p]'
2026-06-29 21:56:09.8|Trace|AggregateQuality|Considering Source Web (Fallback) Resolution 720 (Tag) Revision v1 from ReleaseName
2026-06-29 21:56:09.8|Trace|AggregateQuality|Selected Source Web (Fallback) Resolution 720 (MediaInfo) Revision v1
2026-06-29 21:56:09.8|Debug|AggregateQuality|Using quality: WEBDL-720p v1
2026-06-29 21:56:09.8|Debug|ImportDecisionMaker|File rejected for the following reasons: [Permanent] Invalid season or episode
2026-06-29 21:56:09.8|Trace|TrackedDownloadAlreadyImported|Checking if all episodes for 'TestStudio-Test Performer-720p.mp4' have been imported
2026-06-29 21:56:09.8|Trace|TrackedDownloadAlreadyImported|Last event for episode: [1695]2009-06-30 Test Scene name is: Grabbed
2026-06-29 21:56:09.8|Trace|TrackedDownloadAlreadyImported|All episodes for 'TestStudio-Test Performer-720p.mp4' have been imported: False
2026-06-29 21:56:09.8|Debug|DownloadProcessingService|Failed to process download: TestStudio-Test Performer-720p.mp4

[v2.2.0.108] System.ApplicationException: Expected query to return 1 rows but returned 0
   at NzbDrone.Core.Datastore.BasicRepository`1.Get(IEnumerable`1 ids) in ./Whisparr.Core/Datastore/BasicRepository.cs:line 121
   at NzbDrone.Core.MediaFiles.MediaFileService.GetFiles(IEnumerable`1 ids) in ./Whisparr.Core/MediaFiles/MediaFileService.cs:line 81
   at NzbDrone.Core.Download.CompletedDownloadService.VerifyImport(TrackedDownload trackedDownload, List`1 importResults) in ./Whisparr.Core/Download/CompletedDownloadService.cs:line 272
   at NzbDrone.Core.Download.CompletedDownloadService.Import(TrackedDownload trackedDownload) in ./Whisparr.Core/Download/CompletedDownloadService.cs:line 184
   at NzbDrone.Core.Download.DownloadProcessingService.Execute(ProcessMonitoredDownloadsCommand message) in ./Whisparr.Core/Download/DownloadProcessingService.cs:line 64

```

#### Testing

I've tested the fix on the affected demo scene. Import works okay with the fix.