### PR TITLE
Chore: Bump dessant/support-requests from v4 to v5

### DIFF
--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -10,7 +10,7 @@ jobs:
   support:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/support-requests@v4
+      - uses: dessant/support-requests@v5
         with:
           github-token: ${{ github.token }}
           support-label: 'Type: Support'


### PR DESCRIPTION
#### Database Migration
NO

#### Description
The `Support requests` workflow has been failing on every issue event:

```
ValidationError: "github-token" length must be less than or equal to 100 characters long
```

`dessant/support-requests@v4` validates `github-token` against a schema capped at 100 characters. GitHub has since lengthened the auto-provisioned `${{ github.token }}`, so the built-in token no longer passes validation and the job fails before doing any work.

Upstream fixed the schema in [v5.0.1](https://github.com/dessant/support-requests/blob/main/CHANGELOG.md#501-2026-05-23) ("update github-token validation schema"); latest is v5.0.2. Bumping the pin to `@v5` restores the workflow and also clears the Node 20 deprecation warning, since v5.0.0 moved the action to Node 24.

Example failing run: https://github.com/Whisparr/Whisparr/actions/runs/29766212703

`dessant/lock-threads@v6` and `dessant/label-actions@v3` were checked and are unaffected — the `v6` tag already resolves to a release carrying the same fix, and label-actions v3 predates the capped schema.

#### Screenshot (if UI related)
N/A

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* N/A
