### PR TITLE
Fix: Manual Import Null Fix

### DIFF
--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/GetSceneNameFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeImport/GetSceneNameFixture.cs
@@ -165,6 +165,23 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeImport
                                .BeNull();
         }
 
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void should_fall_back_to_file_name_when_download_client_item_has_no_release_title(string releaseTitle)
+        {
+            _localEpisode.DownloadClientEpisodeInfo = new ParsedEpisodeInfo
+                                                      {
+                                                          ReleaseTitle = releaseTitle
+                                                      };
+
+            _localEpisode.Path = Path.Combine(@"C:\Test\Unsorted TV", _seasonName, _episodeName + ".mkv")
+                                     .AsOsAgnostic();
+
+            SceneNameCalculator.GetSceneName(_localEpisode).Should()
+                               .Be(_episodeName);
+        }
+
         [TestCase(".mkv")]
         [TestCase(".par2")]
         [TestCase(".nzb")]

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -114,6 +114,7 @@ namespace NzbDrone.Core.Download
                             Episodes = new List<Episode> { externalIdEpisode },
                             ParsedEpisodeInfo = new ParsedEpisodeInfo
                             {
+                                ReleaseTitle = trackedDownload.DownloadItem.Title,
                                 Quality = new QualityModel(),
                                 Languages = LanguageParser.ParseLanguages(trackedDownload.DownloadItem.Title),
                                 ExternalId = externalIdEpisode.ExternalId

--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
@@ -165,7 +165,11 @@ namespace NzbDrone.Core.Download.TrackedDownloads
                                 Series = series,
                                 Episodes = episodes,
                                 Languages = firstHistoryItem.Languages,
-                                ParsedEpisodeInfo = parsedEpisodeInfo ?? new ParsedEpisodeInfo { Quality = firstHistoryItem.Quality },
+                                ParsedEpisodeInfo = parsedEpisodeInfo ?? new ParsedEpisodeInfo
+                                {
+                                    ReleaseTitle = firstHistoryItem.SourceTitle ?? trackedDownload.DownloadItem.Title,
+                                    Quality = firstHistoryItem.Quality
+                                },
                                 ShouldOverride = true
                             };
                         }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/SceneNameCalculator.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/SceneNameCalculator.cs
@@ -12,7 +12,9 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
             var otherVideoFiles = localEpisode.OtherVideoFiles;
             var downloadClientInfo = localEpisode.DownloadClientEpisodeInfo;
 
-            if (!otherVideoFiles && downloadClientInfo != null)
+            // The release title can be missing when the download was matched by external ID or
+            // recreated from history, in which case fall back to the file/folder name below
+            if (!otherVideoFiles && downloadClientInfo != null && downloadClientInfo.ReleaseTitle.IsNotNullOrWhiteSpace())
             {
                 return Parser.Parser.RemoveFileExtension(downloadClientInfo.ReleaseTitle);
             }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -670,6 +670,11 @@ namespace NzbDrone.Core.Parser
 
         public static string RemoveFileExtension(string title)
         {
+            if (title.IsNullOrWhiteSpace())
+            {
+                return title;
+            }
+
             title = FileExtensionRegex.Replace(title, m =>
             {
                 var extension = m.Value.ToLower();


### PR DESCRIPTION
Manual imports of downloads that were force-grabbed or matched by external ID would fail with `System.ArgumentNullException: Value cannot be null. (Parameter 'input')` in `Parser.RemoveFileExtension`.

Both of those code paths construct a `ParsedEpisodeInfo` by hand when the release title can't be parsed, and neither set `ReleaseTitle. SceneNameCalculator.GetSceneName` then passed that null straight into a regex, throwing before the aggregation loop's error handling could catch it and killing the whole `ManualImport` command.

This sets `ReleaseTitle` from the grab history / download client title in both places, and guards `GetSceneName` so a missing title falls back to the file and folder name logic instead of throwing. Also makes `RemoveFileExtension` return null or empty input unchanged, since it's called from several other places with unvalidated titles. Adds a regression test to `GetSceneNameFixture`.

This may fix https://github.com/Whisparr/Whisparr/issues/1108 as well