### PR TITLE
Fix: Stop Cloudflare Cookie Test Expiring

### DIFF
--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -800,8 +800,13 @@ namespace NzbDrone.Common.Test.Http
             Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
             try
             {
-                // the date is bad in the below - should be 13-Jul-2026
-                var malformedCookie = @"__cfduid=d29e686a9d65800021c66faca0a29b4261436890790; expires=Mon, 13-Jul-26 16:19:50 GMT; path=/; HttpOnly";
+                // The two digit year is the malformed part: a server should send 2027, not 27. Generate the date
+                // rather than hardcoding it, otherwise the cookie eventually expires and the test starts failing
+                // on a fixed date for everyone. Format as invariant because that is what a server sends; the
+                // thread culture stays set to the test case's culture so we still cover parsing it as a client
+                // running under a non-English locale.
+                var expires = DateTime.UtcNow.AddYears(1).ToString("ddd, dd-MMM-yy HH:mm:ss 'GMT'", CultureInfo.InvariantCulture);
+                var malformedCookie = $"__cfduid=d29e686a9d65800021c66faca0a29b4261436890790; expires={expires}; path=/; HttpOnly";
                 var requestSet = new HttpRequestBuilder($"https://{_httpBinHost}/response-headers")
                     .AddQueryParam("Set-Cookie", malformedCookie)
                     .Build();


### PR DESCRIPTION
The test hardcoded a cookie expiry of 13-Jul-26. That date passed on 2026-07-13 16:19:50 GMT, so the cookie became genuinely expired, CookieContainer correctly dropped it, no Cookie header was sent on the follow up request, and the assertion failed. This reds the integration test job on every PR in the repo, on all three platforms.

Nothing was wrong with the parsing or with httpbin: the same string with the year moved forward still parses fine, in en-US, es-ES and tr-TR alike.

Generate the expiry instead of hardcoding it. It keeps the two digit year, which is the malformed part under test, and is formatted invariant because that is what a server sends, while the thread culture stays set to the test case's culture so the test still covers parsing an English date on a non-English client.

Cherrypick: https://github.com/Whisparr/Whisparr-Eros/pull/325