### PR TITLE
Chore: Sonarr Upstream Sync - Deferred Blockers

### DIFF
--- a/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
+++ b/src/NzbDrone.Core.Test/NotificationTests/NotificationBaseFixture.cs
@@ -5,7 +5,6 @@ using FluentValidation.Results;
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Notifications;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Tv;
 using NzbDrone.Core.Validation;
 using NzbDrone.Test.Common;
@@ -15,9 +14,9 @@ namespace NzbDrone.Core.Test.NotificationTests
     [TestFixture]
     public class NotificationBaseFixture : TestBase
     {
-        private class TestSetting : IProviderConfig
+        private class TestSetting : NotificationSettingsBase<TestSetting>
         {
-            public NzbDroneValidationResult Validate()
+            public override NzbDroneValidationResult Validate()
             {
                 return new NzbDroneValidationResult();
             }

--- a/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
+++ b/src/NzbDrone.Core/Blocklisting/BlocklistService.cs
@@ -15,6 +15,7 @@ namespace NzbDrone.Core.Blocklisting
     public interface IBlocklistService
     {
         bool Blocklisted(int seriesId, ReleaseInfo release);
+        bool BlocklistedTorrentHash(int seriesId, string hash);
         PagingSpec<Blocklist> Paged(PagingSpec<Blocklist> pagingSpec);
         void Block(RemoteEpisode remoteEpisode, string message);
         void Delete(int id);
@@ -59,6 +60,12 @@ namespace NzbDrone.Core.Blocklisting
 
             return blocklistedByTitle.Where(b => b.Protocol == DownloadProtocol.Usenet)
                                      .Any(b => SameNzb(b, release));
+        }
+
+        public bool BlocklistedTorrentHash(int seriesId, string hash)
+        {
+            return _blocklistRepository.BlocklistedByTorrentInfoHash(seriesId, hash).Any(b =>
+                b.TorrentInfoHash.Equals(hash, StringComparison.InvariantCultureIgnoreCase));
         }
 
         public PagingSpec<Blocklist> Paged(PagingSpec<Blocklist> pagingSpec)

--- a/src/NzbDrone.Core/Download/Clients/Aria2/Aria2.cs
+++ b/src/NzbDrone.Core/Download/Clients/Aria2/Aria2.cs
@@ -7,6 +7,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.Parser.Model;
@@ -27,8 +28,9 @@ namespace NzbDrone.Core.Download.Clients.Aria2
                         IConfigService configService,
                         IDiskProvider diskProvider,
                         IRemotePathMappingService remotePathMappingService,
+                        IBlocklistService blocklistService,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Aria2/Aria2Settings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Aria2/Aria2Settings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.Aria2
@@ -13,9 +12,9 @@ namespace NzbDrone.Core.Download.Clients.Aria2
         }
     }
 
-    public class Aria2Settings : IProviderConfig
+    public class Aria2Settings : DownloadClientSettingsBase<Aria2Settings>
     {
-        private static readonly Aria2SettingsValidator Validator = new Aria2SettingsValidator();
+        private static readonly Aria2SettingsValidator Validator = new ();
 
         public Aria2Settings()
         {
@@ -41,7 +40,7 @@ namespace NzbDrone.Core.Download.Clients.Aria2
         [FieldDefinition(4, Label = "Secret token", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string SecretToken { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
                 return new NzbDroneValidationResult(Validator.Validate(this));
             }

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackhole.cs
@@ -7,6 +7,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.Organizer;
@@ -29,8 +30,9 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
                                 IConfigService configService,
                                 IDiskProvider diskProvider,
                                 IRemotePathMappingService remotePathMappingService,
+                                IBlocklistService blocklistService,
                                 Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _scanWatchFolder = scanWatchFolder;
 

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackholeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackholeSettings.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using FluentValidation;
 using Newtonsoft.Json;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
 
@@ -18,7 +17,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         }
     }
 
-    public class TorrentBlackholeSettings : IProviderConfig
+    public class TorrentBlackholeSettings : DownloadClientSettingsBase<TorrentBlackholeSettings>
     {
         public TorrentBlackholeSettings()
         {
@@ -26,7 +25,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
             ReadOnly = true;
         }
 
-        private static readonly TorrentBlackholeSettingsValidator Validator = new TorrentBlackholeSettingsValidator();
+        private static readonly TorrentBlackholeSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "Torrent Folder", Type = FieldType.Path, HelpText = "Folder in which Whisparr will store the .torrent file")]
         public string TorrentFolder { get; set; }
@@ -47,7 +46,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         [FieldDefinition(4, Label = "Read Only", Type = FieldType.Checkbox, HelpText = "Instead of moving files this will instruct Whisparr to Copy or Hardlink (depending on settings/system configuration)")]
         public bool ReadOnly { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackholeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackholeSettings.cs
@@ -1,6 +1,5 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
 
@@ -15,9 +14,9 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         }
     }
 
-    public class UsenetBlackholeSettings : IProviderConfig
+    public class UsenetBlackholeSettings : DownloadClientSettingsBase<UsenetBlackholeSettings>
     {
-        private static readonly UsenetBlackholeSettingsValidator Validator = new UsenetBlackholeSettingsValidator();
+        private static readonly UsenetBlackholeSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "Nzb Folder", Type = FieldType.Path, HelpText = "Folder in which Whisparr will store the .nzb file")]
         public string NzbFolder { get; set; }
@@ -25,7 +24,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
         [FieldDefinition(1, Label = "Watch Folder", Type = FieldType.Path, HelpText = "Folder from which Whisparr should import completed downloads")]
         public string WatchFolder { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -7,6 +7,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.Parser.Model;
@@ -25,8 +26,9 @@ namespace NzbDrone.Core.Download.Clients.Deluge
                       IConfigService configService,
                       IDiskProvider diskProvider,
                       IRemotePathMappingService remotePathMappingService,
+                      IBlocklistService blocklistService,
                       Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.Deluge
@@ -17,9 +16,9 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         }
     }
 
-    public class DelugeSettings : IProviderConfig
+    public class DelugeSettings : DownloadClientSettingsBase<DelugeSettings>
     {
-        private static readonly DelugeSettingsValidator Validator = new DelugeSettingsValidator();
+        private static readonly DelugeSettingsValidator Validator = new ();
 
         public DelugeSettings()
         {
@@ -65,7 +64,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         [FieldDefinition(11, Label = "DownloadClientDelugeSettingsDirectoryCompleted", Type = FieldType.Textbox, Advanced = true, HelpText = "DownloadClientDelugeSettingsDirectoryCompletedHelpText")]
         public string CompletedDirectory { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/DownloadClientSettingsBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadClientSettingsBase.cs
@@ -1,0 +1,30 @@
+using System;
+using Equ;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.Download.Clients
+{
+    public abstract class DownloadClientSettingsBase<TSettings> : IProviderConfig, IEquatable<TSettings>
+        where TSettings : DownloadClientSettingsBase<TSettings>
+    {
+        private static readonly MemberwiseEqualityComparer<TSettings> Comparer = MemberwiseEqualityComparer<TSettings>.ByProperties;
+
+        public abstract NzbDroneValidationResult Validate();
+
+        public bool Equals(TSettings other)
+        {
+            return Comparer.Equals(this as TSettings, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as TSettings);
+        }
+
+        public override int GetHashCode()
+        {
+            return Comparer.GetHashCode(this as TSettings);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationSettings.cs
@@ -1,8 +1,7 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.DownloadStation
@@ -26,9 +25,9 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
         }
     }
 
-    public class DownloadStationSettings : IProviderConfig
+    public class DownloadStationSettings : DownloadClientSettingsBase<DownloadStationSettings>
     {
-        private static readonly DownloadStationSettingsValidator Validator = new DownloadStationSettingsValidator();
+        private static readonly DownloadStationSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
         public string Host { get; set; }
@@ -57,7 +56,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
             this.Port = 5000;
         }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/TorrentDownloadStation.cs
@@ -8,6 +8,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.DownloadStation.Proxies;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
@@ -36,8 +37,9 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
                                       IConfigService configService,
                                       IDiskProvider diskProvider,
                                       IRemotePathMappingService remotePathMappingService,
+                                      IBlocklistService blocklistService,
                                       Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _dsInfoProxy = dsInfoProxy;
             _dsTaskProxySelector = dsTaskProxySelector;

--- a/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/Flood.cs
@@ -7,6 +7,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.Flood.Models;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
@@ -28,8 +29,9 @@ namespace NzbDrone.Core.Download.Clients.Flood
                         IConfigService configService,
                         IDiskProvider diskProvider,
                         IRemotePathMappingService remotePathMappingService,
+                        IBlocklistService blocklistService,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _proxy = proxy;
             _downloadSeedConfigProvider = downloadSeedConfigProvider;

--- a/src/NzbDrone.Core/Download/Clients/Flood/FloodSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/FloodSettings.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Download.Clients.Flood.Models;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.Flood
@@ -17,9 +16,9 @@ namespace NzbDrone.Core.Download.Clients.Flood
         }
     }
 
-    public class FloodSettings : IProviderConfig
+    public class FloodSettings : DownloadClientSettingsBase<FloodSettings>
     {
-        private static readonly FloodSettingsValidator Validator = new FloodSettingsValidator();
+        private static readonly FloodSettingsValidator Validator = new ();
 
         public FloodSettings()
         {
@@ -67,7 +66,7 @@ namespace NzbDrone.Core.Download.Clients.Flood
         [FieldDefinition(10, Label = "Start on Add", Type = FieldType.Checkbox)]
         public bool StartOnAdd { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/FreeboxDownload/FreeboxDownloadSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/FreeboxDownload/FreeboxDownloadSettings.cs
@@ -2,7 +2,6 @@ using System.Text.RegularExpressions;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
 
@@ -34,9 +33,9 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
         }
     }
 
-    public class FreeboxDownloadSettings : IProviderConfig
+    public class FreeboxDownloadSettings : DownloadClientSettingsBase<FreeboxDownloadSettings>
     {
-        private static readonly FreeboxDownloadSettingsValidator Validator = new FreeboxDownloadSettingsValidator();
+        private static readonly FreeboxDownloadSettingsValidator Validator = new ();
 
         public FreeboxDownloadSettings()
         {
@@ -79,7 +78,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
         [FieldDefinition(10, Label = "Add Paused", Type = FieldType.Checkbox)]
         public bool AddPaused { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/FreeboxDownload/TorrentFreeboxDownload.cs
+++ b/src/NzbDrone.Core/Download/Clients/FreeboxDownload/TorrentFreeboxDownload.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentValidation.Results;
@@ -6,6 +6,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.FreeboxDownload.Responses;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
@@ -24,8 +25,9 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
             IConfigService configService,
             IDiskProvider diskProvider,
             IRemotePathMappingService remotePathMappingService,
+            IBlocklistService blocklistService,
             Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/Hadouken.cs
@@ -5,6 +5,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.Hadouken.Models;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
@@ -24,8 +25,9 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
                         IConfigService configService,
                         IDiskProvider diskProvider,
                         IRemotePathMappingService remotePathMappingService,
+                        IBlocklistService blocklistService,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenSettings.cs
@@ -1,7 +1,6 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.Hadouken
@@ -22,9 +21,9 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
         }
     }
 
-    public class HadoukenSettings : IProviderConfig
+    public class HadoukenSettings : DownloadClientSettingsBase<HadoukenSettings>
     {
-        private static readonly HadoukenSettingsValidator Validator = new HadoukenSettingsValidator();
+        private static readonly HadoukenSettingsValidator Validator = new ();
 
         public HadoukenSettings()
         {
@@ -54,7 +53,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
         [FieldDefinition(6, Label = "Category", Type = FieldType.Textbox)]
         public string Category { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexProxy.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexProxy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net;
 using Newtonsoft.Json;

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexSettings.cs
@@ -1,7 +1,6 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.NzbVortex
@@ -23,9 +22,9 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
         }
     }
 
-    public class NzbVortexSettings : IProviderConfig
+    public class NzbVortexSettings : DownloadClientSettingsBase<NzbVortexSettings>
     {
-        private static readonly NzbVortexSettingsValidator Validator = new NzbVortexSettingsValidator();
+        private static readonly NzbVortexSettingsValidator Validator = new ();
 
         public NzbVortexSettings()
         {
@@ -57,7 +56,7 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
         [FieldDefinition(6, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(NzbVortexPriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
         public int OlderTvPriority { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetSettings.cs
@@ -1,7 +1,6 @@
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.Nzbget
@@ -21,9 +20,9 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
         }
     }
 
-    public class NzbgetSettings : IProviderConfig
+    public class NzbgetSettings : DownloadClientSettingsBase<NzbgetSettings>
     {
-        private static readonly NzbgetSettingsValidator Validator = new NzbgetSettingsValidator();
+        private static readonly NzbgetSettingsValidator Validator = new ();
 
         public NzbgetSettings()
         {
@@ -64,7 +63,7 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
         [FieldDefinition(9, Label = "Add Paused", Type = FieldType.Checkbox, HelpText = "This option requires at least NzbGet version 16.0")]
         public bool AddPaused { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/PneumaticSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/PneumaticSettings.cs
@@ -1,6 +1,5 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
 
@@ -15,9 +14,9 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
         }
     }
 
-    public class PneumaticSettings : IProviderConfig
+    public class PneumaticSettings : DownloadClientSettingsBase<PneumaticSettings>
     {
-        private static readonly PneumaticSettingsValidator Validator = new PneumaticSettingsValidator();
+        private static readonly PneumaticSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "Nzb Folder", Type = FieldType.Path, HelpText = "This folder will need to be reachable from XBMC")]
         public string NzbFolder { get; set; }
@@ -25,7 +24,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
         [FieldDefinition(1, Label = "Strm Folder", Type = FieldType.Path, HelpText = ".strm files in this folder will be import by drone")]
         public string StrmFolder { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrent.cs
@@ -8,6 +8,7 @@ using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.Parser.Model;
@@ -34,8 +35,9 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
                            IDiskProvider diskProvider,
                            IRemotePathMappingService remotePathMappingService,
                            ICacheManager cacheManager,
+                           IBlocklistService blocklistService,
                            Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _proxySelector = proxySelector;
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -1,7 +1,6 @@
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.QBittorrent
@@ -26,9 +25,9 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         }
     }
 
-    public class QBittorrentSettings : IProviderConfig
+    public class QBittorrentSettings : DownloadClientSettingsBase<QBittorrentSettings>
     {
-        private static readonly QBittorrentSettingsValidator Validator = new QBittorrentSettingsValidator();
+        private static readonly QBittorrentSettingsValidator Validator = new ();
 
         public QBittorrentSettings()
         {
@@ -82,7 +81,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         [FieldDefinition(14, Label = "DownloadClientQbittorrentSettingsContentLayout", Type = FieldType.Select, SelectOptions = typeof(QBittorrentContentLayout), HelpText = "DownloadClientQbittorrentSettingsContentLayoutHelpText")]
         public int ContentLayout { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdSettings.cs
@@ -1,7 +1,6 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.Sabnzbd
@@ -32,9 +31,9 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
         }
     }
 
-    public class SabnzbdSettings : IProviderConfig
+    public class SabnzbdSettings : DownloadClientSettingsBase<SabnzbdSettings>
     {
-        private static readonly SabnzbdSettingsValidator Validator = new SabnzbdSettingsValidator();
+        private static readonly SabnzbdSettingsValidator Validator = new ();
 
         public SabnzbdSettings()
         {
@@ -75,7 +74,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
         [FieldDefinition(9, Label = "Older Priority", Type = FieldType.Select, SelectOptions = typeof(SabnzbdPriority), HelpText = "Priority to use when grabbing episodes that aired over 14 days ago")]
         public int OlderTvPriority { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/TorrentSeedConfiguration.cs
+++ b/src/NzbDrone.Core/Download/Clients/TorrentSeedConfiguration.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 
 namespace NzbDrone.Core.Download.Clients
 {
     public class TorrentSeedConfiguration
     {
-        public static TorrentSeedConfiguration DefaultConfiguration = new TorrentSeedConfiguration();
+        public static TorrentSeedConfiguration DefaultConfiguration = new ();
 
         public double? Ratio { get; set; }
         public TimeSpan? SeedTime { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/Transmission.cs
@@ -6,6 +6,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.RemotePathMappings;
@@ -23,8 +24,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                             IConfigService configService,
                             IDiskProvider diskProvider,
                             IRemotePathMappingService remotePathMappingService,
+                            IBlocklistService blocklistService,
                             Logger logger)
-            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
         }
 

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -7,6 +7,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.Parser.Model;
@@ -27,8 +28,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
             IConfigService configService,
             IDiskProvider diskProvider,
             IRemotePathMappingService remotePathMappingService,
+            IBlocklistService blocklistService,
             Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _proxy = proxy;
         }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
@@ -3,7 +3,6 @@ using System.Text.RegularExpressions;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.Transmission
@@ -25,9 +24,9 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         }
     }
 
-    public class TransmissionSettings : IProviderConfig
+    public class TransmissionSettings : DownloadClientSettingsBase<TransmissionSettings>
     {
-        private static readonly TransmissionSettingsValidator Validator = new TransmissionSettingsValidator();
+        private static readonly TransmissionSettingsValidator Validator = new ();
 
         // This constructor is used when creating a new instance, such as the user adding a new Transmission client.
         public TransmissionSettings()
@@ -86,7 +85,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
         [FieldDefinition(11, Label = "Add Paused", Type = FieldType.Checkbox)]
         public bool AddPaused { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
+++ b/src/NzbDrone.Core/Download/Clients/Vuze/Vuze.cs
@@ -2,6 +2,7 @@ using FluentValidation.Results;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.Transmission;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
@@ -22,8 +23,9 @@ namespace NzbDrone.Core.Download.Clients.Vuze
                     IConfigService configService,
                     IDiskProvider diskProvider,
                     IRemotePathMappingService remotePathMappingService,
+                    IBlocklistService blocklistService,
                     Logger logger)
-            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(proxy, torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
         }
 

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrent.cs
@@ -8,6 +8,7 @@ using NzbDrone.Common.Disk;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Download.Clients.rTorrent;
 using NzbDrone.Core.Exceptions;
@@ -34,8 +35,9 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
                         IRemotePathMappingService remotePathMappingService,
                         IDownloadSeedConfigProvider downloadSeedConfigProvider,
                         IRTorrentDirectoryValidator rTorrentDirectoryValidator,
+                        IBlocklistService blocklistService,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _proxy = proxy;
             _rTorrentDirectoryValidator = rTorrentDirectoryValidator;

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.RTorrent
@@ -17,9 +16,9 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
         }
     }
 
-    public class RTorrentSettings : IProviderConfig
+    public class RTorrentSettings : DownloadClientSettingsBase<RTorrentSettings>
     {
-        private static readonly RTorrentSettingsValidator Validator = new RTorrentSettingsValidator();
+        private static readonly RTorrentSettingsValidator Validator = new ();
 
         public RTorrentSettings()
         {
@@ -67,7 +66,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
         [FieldDefinition(11, Label = "Add Stopped", Type = FieldType.Checkbox, HelpText = "Enabling will add torrents and magnets to rTorrent in a stopped state. This may break magnet files.")]
         public bool AddStopped { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -8,6 +8,7 @@ using NzbDrone.Common.Cache;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.MediaFiles.TorrentInfo;
 using NzbDrone.Core.Parser.Model;
@@ -28,8 +29,9 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
                         IConfigService configService,
                         IDiskProvider diskProvider,
                         IRemotePathMappingService remotePathMappingService,
+                        IBlocklistService blocklistService,
                         Logger logger)
-            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, logger)
+            : base(torrentFileInfoReader, httpClient, configService, diskProvider, remotePathMappingService, blocklistService, logger)
         {
             _proxy = proxy;
 

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
@@ -1,7 +1,6 @@
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Download.Clients.UTorrent
@@ -17,9 +16,9 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
         }
     }
 
-    public class UTorrentSettings : IProviderConfig
+    public class UTorrentSettings : DownloadClientSettingsBase<UTorrentSettings>
     {
-        private static readonly UTorrentSettingsValidator Validator = new UTorrentSettingsValidator();
+        private static readonly UTorrentSettingsValidator Validator = new ();
 
         public UTorrentSettings()
         {
@@ -61,7 +60,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
         [FieldDefinition(10, Label = "Initial State", Type = FieldType.Select, SelectOptions = typeof(UTorrentState), HelpText = "Initial state for torrents added to uTorrent")]
         public int IntialState { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Download/DownloadClientDefinition.cs
+++ b/src/NzbDrone.Core/Download/DownloadClientDefinition.cs
@@ -1,14 +1,35 @@
-﻿using NzbDrone.Core.Indexers;
+using System;
+using Equ;
+using NzbDrone.Core.Indexers;
 using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.Download
 {
-    public class DownloadClientDefinition : ProviderDefinition
+    public class DownloadClientDefinition : ProviderDefinition, IEquatable<DownloadClientDefinition>
     {
+        private static readonly MemberwiseEqualityComparer<DownloadClientDefinition> Comparer = MemberwiseEqualityComparer<DownloadClientDefinition>.ByProperties;
+
+        [MemberwiseEqualityIgnore]
         public DownloadProtocol Protocol { get; set; }
+
         public int Priority { get; set; } = 1;
 
         public bool RemoveCompletedDownloads { get; set; } = true;
         public bool RemoveFailedDownloads { get; set; } = true;
+
+        public bool Equals(DownloadClientDefinition other)
+        {
+            return Comparer.Equals(this, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as DownloadClientDefinition);
+        }
+
+        public override int GetHashCode()
+        {
+            return Comparer.GetHashCode(this);
+        }
     }
 }

--- a/src/NzbDrone.Core/Download/DownloadService.cs
+++ b/src/NzbDrone.Core/Download/DownloadService.cs
@@ -104,6 +104,11 @@ namespace NzbDrone.Core.Download
                 _logger.Trace("Release {0} no longer available on indexer.", remoteEpisode);
                 throw;
             }
+            catch (ReleaseBlockedException)
+            {
+                _logger.Trace("Release {0} previously added to blocklist, not sending to download client again.", remoteEpisode);
+                throw;
+            }
             catch (DownloadClientRejectedReleaseException)
             {
                 _logger.Trace("Release {0} rejected by download client, possible duplicate.", remoteEpisode);
@@ -128,7 +133,7 @@ namespace NzbDrone.Core.Download
             episodeGrabbedEvent.DownloadClientId = downloadClient.Definition.Id;
             episodeGrabbedEvent.DownloadClientName = downloadClient.Definition.Name;
 
-            if (!string.IsNullOrWhiteSpace(downloadClientId))
+            if (downloadClientId.IsNotNullOrWhiteSpace())
             {
                 episodeGrabbedEvent.DownloadId = downloadClientId;
             }

--- a/src/NzbDrone.Core/Download/TorrentClientBase.cs
+++ b/src/NzbDrone.Core/Download/TorrentClientBase.cs
@@ -6,6 +6,7 @@ using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Http;
+using NzbDrone.Core.Blocklisting;
 using NzbDrone.Core.Configuration;
 using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.Indexers;
@@ -21,17 +22,20 @@ namespace NzbDrone.Core.Download
         where TSettings : IProviderConfig, new()
     {
         protected readonly IHttpClient _httpClient;
+        private readonly IBlocklistService _blocklistService;
         protected readonly ITorrentFileInfoReader _torrentFileInfoReader;
 
         protected TorrentClientBase(ITorrentFileInfoReader torrentFileInfoReader,
-                                    IHttpClient httpClient,
-                                    IConfigService configService,
-                                    IDiskProvider diskProvider,
-                                    IRemotePathMappingService remotePathMappingService,
-                                    Logger logger)
+            IHttpClient httpClient,
+            IConfigService configService,
+            IDiskProvider diskProvider,
+            IRemotePathMappingService remotePathMappingService,
+            IBlocklistService blocklistService,
+            Logger logger)
             : base(configService, diskProvider, remotePathMappingService, logger)
         {
             _httpClient = httpClient;
+            _blocklistService = blocklistService;
             _torrentFileInfoReader = torrentFileInfoReader;
         }
 
@@ -86,7 +90,7 @@ namespace NzbDrone.Core.Download
                 {
                     try
                     {
-                        return DownloadFromMagnetUrl(remoteEpisode, magnetUrl);
+                        return DownloadFromMagnetUrl(remoteEpisode, indexer, magnetUrl);
                     }
                     catch (NotSupportedException ex)
                     {
@@ -100,7 +104,7 @@ namespace NzbDrone.Core.Download
                 {
                     try
                     {
-                        return DownloadFromMagnetUrl(remoteEpisode, magnetUrl);
+                        return DownloadFromMagnetUrl(remoteEpisode, indexer, magnetUrl);
                     }
                     catch (NotSupportedException ex)
                     {
@@ -149,7 +153,7 @@ namespace NzbDrone.Core.Download
                     {
                         if (locationHeader.StartsWith("magnet:"))
                         {
-                            return DownloadFromMagnetUrl(remoteEpisode, locationHeader);
+                            return DownloadFromMagnetUrl(remoteEpisode, indexer, locationHeader);
                         }
 
                         request.Url += new HttpUri(locationHeader);
@@ -192,6 +196,9 @@ namespace NzbDrone.Core.Download
 
             var filename = string.Format("{0}.torrent", FileNameBuilder.CleanFileName(remoteEpisode.Release.Title));
             var hash = _torrentFileInfoReader.GetHashFromTorrentFile(torrentFile);
+
+            EnsureReleaseIsNotBlocklisted(remoteEpisode, indexer, hash);
+
             var actualHash = AddFromTorrentFile(remoteEpisode, hash, filename, torrentFile);
 
             if (actualHash.IsNotNullOrWhiteSpace() && hash != actualHash)
@@ -205,7 +212,7 @@ namespace NzbDrone.Core.Download
             return actualHash;
         }
 
-        private string DownloadFromMagnetUrl(RemoteEpisode remoteEpisode, string magnetUrl)
+        private string DownloadFromMagnetUrl(RemoteEpisode remoteEpisode, IIndexer indexer, string magnetUrl)
         {
             string hash = null;
             string actualHash = null;
@@ -223,6 +230,8 @@ namespace NzbDrone.Core.Download
 
             if (hash != null)
             {
+                EnsureReleaseIsNotBlocklisted(remoteEpisode, indexer, hash);
+
                 actualHash = AddFromMagnetLink(remoteEpisode, hash, magnetUrl);
             }
 
@@ -235,6 +244,31 @@ namespace NzbDrone.Core.Download
             }
 
             return actualHash;
+        }
+
+        private void EnsureReleaseIsNotBlocklisted(RemoteEpisode remoteEpisode, IIndexer indexer, string hash)
+        {
+            var indexerSettings = indexer?.Definition?.Settings as ITorrentIndexerSettings;
+            var torrentInfo = remoteEpisode.Release as TorrentInfo;
+            var torrentInfoHash = torrentInfo?.InfoHash;
+
+            // If the release didn't come from an interactive search,
+            // the hash wasn't known during processing and the
+            // indexer is configured to reject blocklisted releases
+            // during grab check if it's already been blocklisted.
+
+            if (torrentInfo != null && torrentInfoHash.IsNullOrWhiteSpace())
+            {
+                // If the hash isn't known from parsing we set it here so it can be used for blocklisting.
+                torrentInfo.InfoHash = hash;
+
+                if (remoteEpisode.ReleaseSource != ReleaseSourceType.InteractiveSearch &&
+                    indexerSettings?.RejectBlocklistedTorrentHashesWhileGrabbing == true &&
+                    _blocklistService.BlocklistedTorrentHash(remoteEpisode.Series.Id, hash))
+                {
+                    throw new ReleaseBlockedException(remoteEpisode.Release, "Release previously added to blocklist");
+                }
+            }
         }
     }
 }

--- a/src/NzbDrone.Core/Exceptions/ReleaseBlockedException.cs
+++ b/src/NzbDrone.Core/Exceptions/ReleaseBlockedException.cs
@@ -1,0 +1,28 @@
+using System;
+using NzbDrone.Core.Parser.Model;
+
+namespace NzbDrone.Core.Exceptions
+{
+    public class ReleaseBlockedException : ReleaseDownloadException
+    {
+        public ReleaseBlockedException(ReleaseInfo release, string message, params object[] args)
+            : base(release, message, args)
+        {
+        }
+
+        public ReleaseBlockedException(ReleaseInfo release, string message)
+            : base(release, message)
+        {
+        }
+
+        public ReleaseBlockedException(ReleaseInfo release, string message, Exception innerException, params object[] args)
+            : base(release, message, innerException, args)
+        {
+        }
+
+        public ReleaseBlockedException(ReleaseInfo release, string message, Exception innerException)
+            : base(release, message, innerException)
+        {
+        }
+    }
+}

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -179,9 +179,7 @@ namespace NzbDrone.Core.History
                     history.Data.Add("ReleaseHash", message.Episode.ParsedEpisodeInfo.ReleaseHash);
                 }
 
-                var torrentRelease = message.Episode.Release as TorrentInfo;
-
-                if (torrentRelease != null)
+                if (message.Episode.Release is TorrentInfo torrentRelease)
                 {
                     history.Data.Add("TorrentInfoHash", torrentRelease.InfoHash);
                 }

--- a/src/NzbDrone.Core/ImportLists/Custom/CustomSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Custom/CustomSettings.cs
@@ -13,19 +13,14 @@ namespace NzbDrone.Core.ImportLists.Custom
         }
     }
 
-    public class CustomSettings : IImportListSettings
+    public class CustomSettings : ImportListSettingsBase<CustomSettings>
     {
-        private static readonly CustomSettingsValidator Validator = new CustomSettingsValidator();
-
-        public CustomSettings()
-        {
-            BaseUrl = "";
-        }
+        private static readonly CustomSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "List URL", HelpText = "The URL for the series list")]
-        public string BaseUrl { get; set; }
+        public override string BaseUrl { get; set; } = string.Empty;
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/ImportLists/ImportListDefinition.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListDefinition.cs
@@ -1,11 +1,14 @@
 using System;
+using Equ;
 using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.ImportLists
 {
-    public class ImportListDefinition : ProviderDefinition
+    public class ImportListDefinition : ProviderDefinition, IEquatable<ImportListDefinition>
     {
+        private static readonly MemberwiseEqualityComparer<ImportListDefinition> Comparer = MemberwiseEqualityComparer<ImportListDefinition>.ByProperties;
+
         public bool EnableAutomaticAdd { get; set; }
         public bool SearchForMissingEpisodes { get; set; }
         public ImportListMonitorTypes ShouldMonitor { get; set; }
@@ -14,11 +17,32 @@ namespace NzbDrone.Core.ImportLists
         public int QualityProfileId { get; set; }
         public string RootFolderPath { get; set; }
 
+        [MemberwiseEqualityIgnore]
         public override bool Enable => EnableAutomaticAdd;
 
+        [MemberwiseEqualityIgnore]
         public ImportListStatus Status { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public ImportListType ListType { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public TimeSpan MinRefreshInterval { get; set; }
+
+        public bool Equals(ImportListDefinition other)
+        {
+            return Comparer.Equals(this, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as ImportListDefinition);
+        }
+
+        public override int GetHashCode()
+        {
+            return Comparer.GetHashCode(this);
+        }
     }
 
     public enum ImportListMonitorTypes

--- a/src/NzbDrone.Core/ImportLists/ImportListSettingsBase.cs
+++ b/src/NzbDrone.Core/ImportLists/ImportListSettingsBase.cs
@@ -1,0 +1,31 @@
+using System;
+using Equ;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.ImportLists
+{
+    public abstract class ImportListSettingsBase<TSettings> : IImportListSettings, IEquatable<TSettings>
+        where TSettings : ImportListSettingsBase<TSettings>
+    {
+        private static readonly MemberwiseEqualityComparer<TSettings> Comparer = MemberwiseEqualityComparer<TSettings>.ByProperties;
+
+        public abstract string BaseUrl { get; set; }
+
+        public abstract NzbDroneValidationResult Validate();
+
+        public bool Equals(TSettings other)
+        {
+            return Comparer.Equals(this as TSettings, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as TSettings);
+        }
+
+        public override int GetHashCode()
+        {
+            return Comparer.GetHashCode(this as TSettings);
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexListSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexListSettings.cs
@@ -14,9 +14,9 @@ namespace NzbDrone.Core.ImportLists.Plex
         }
     }
 
-    public class PlexListSettings : IImportListSettings
+    public class PlexListSettings : ImportListSettingsBase<PlexListSettings>
     {
-        protected virtual PlexListSettingsValidator Validator => new PlexListSettingsValidator();
+        private static readonly PlexListSettingsValidator Validator = new ();
 
         public PlexListSettings()
         {
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.ImportLists.Plex
 
         public virtual string Scope => "";
 
-        public string BaseUrl { get; set; }
+        public override string BaseUrl { get; set; }
 
         [FieldDefinition(0, Label = "Access Token", Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
         public string AccessToken { get; set; }
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.ImportLists.Plex
         [FieldDefinition(99, Label = "Authenticate with Plex.tv", Type = FieldType.OAuth)]
         public string SignIn { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/ImportLists/Rss/Plex/PlexRssImportSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/Plex/PlexRssImportSettings.cs
@@ -12,9 +12,9 @@ namespace NzbDrone.Core.ImportLists.Rss.Plex
         }
     }
 
-    public class PlexRssImportSettings : RssImportBaseSettings
+    public class PlexRssImportSettings : RssImportBaseSettings<PlexRssImportSettings>
     {
-        private PlexRssImportSettingsValidator Validator => new ();
+        private static readonly PlexRssImportSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "Url", Type = FieldType.Textbox, HelpLink = "https://app.plex.tv/desktop/#!/settings/watchlist")]
         public override string Url { get; set; }

--- a/src/NzbDrone.Core/ImportLists/Rss/RssImportBase.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/RssImportBase.cs
@@ -9,7 +9,7 @@ using NzbDrone.Core.Parser.Model;
 namespace NzbDrone.Core.ImportLists.Rss
 {
     public class RssImportBase<TSettings> : HttpImportListBase<TSettings>
-        where TSettings : RssImportBaseSettings, new()
+        where TSettings : RssImportBaseSettings<TSettings>, new()
     {
         public override string Name => "RSS List Base";
         public override ImportListType ListType => ImportListType.Advanced;
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.ImportLists.Rss
 
         public override IImportListRequestGenerator GetRequestGenerator()
         {
-            return new RssImportRequestGenerator
+            return new RssImportRequestGenerator<TSettings>
             {
                 Settings = Settings
             };

--- a/src/NzbDrone.Core/ImportLists/Rss/RssImportBaseSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/RssImportBaseSettings.cs
@@ -4,7 +4,8 @@ using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.ImportLists.Rss
 {
-    public class RssImportSettingsValidator : AbstractValidator<RssImportBaseSettings>
+    public class RssImportSettingsValidator<TSettings> : AbstractValidator<TSettings>
+        where TSettings : RssImportBaseSettings<TSettings>
     {
         public RssImportSettingsValidator()
         {
@@ -12,18 +13,19 @@ namespace NzbDrone.Core.ImportLists.Rss
         }
     }
 
-    public class RssImportBaseSettings : IImportListSettings
+    public class RssImportBaseSettings<TSettings> : ImportListSettingsBase<TSettings>
+        where TSettings : RssImportBaseSettings<TSettings>
     {
-        private RssImportSettingsValidator Validator => new ();
+        private static readonly RssImportSettingsValidator<TSettings> Validator = new ();
 
-        public string BaseUrl { get; set; }
+        public override string BaseUrl { get; set; }
 
         [FieldDefinition(0, Label = "Url", Type = FieldType.Textbox)]
         public virtual string Url { get; set; }
 
-        public virtual NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
-            return new NzbDroneValidationResult(Validator.Validate(this));
+            return new NzbDroneValidationResult(Validator.Validate(this as TSettings));
         }
     }
 }

--- a/src/NzbDrone.Core/ImportLists/Rss/RssImportRequestGenerator.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/RssImportRequestGenerator.cs
@@ -3,9 +3,10 @@ using NzbDrone.Common.Http;
 
 namespace NzbDrone.Core.ImportLists.Rss
 {
-    public class RssImportRequestGenerator : IImportListRequestGenerator
+    public class RssImportRequestGenerator<TSettings> : IImportListRequestGenerator
+        where TSettings : RssImportBaseSettings<TSettings>, new()
     {
-        public RssImportBaseSettings Settings { get; set; }
+        public RssImportBaseSettings<TSettings> Settings { get; set; }
 
         public virtual ImportListPageableRequestChain GetListItems()
         {
@@ -18,9 +19,7 @@ namespace NzbDrone.Core.ImportLists.Rss
 
         private IEnumerable<ImportListRequest> GetSeriesRequest()
         {
-            var request = new ImportListRequest(Settings.Url, HttpAccept.Rss);
-
-            yield return request;
+            yield return new ImportListRequest(Settings.Url, HttpAccept.Rss);
         }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Fanzub/FanzubSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Fanzub/FanzubSettings.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+using Equ;
+using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
 
@@ -12,9 +13,9 @@ namespace NzbDrone.Core.Indexers.Fanzub
         }
     }
 
-    public class FanzubSettings : IIndexerSettings
+    public class FanzubSettings : PropertywiseEquatable<FanzubSettings>, IIndexerSettings
     {
-        private static readonly FanzubSettingsValidator Validator = new FanzubSettingsValidator();
+        private static readonly FanzubSettingsValidator Validator = new ();
 
         public FanzubSettings()
         {

--- a/src/NzbDrone.Core/Indexers/FileList/FileListSettings.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListSettings.cs
@@ -51,6 +51,9 @@ namespace NzbDrone.Core.Indexers.FileList
         [FieldDefinition(7)]
         public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
 
+        [FieldDefinition(8, Type = FieldType.Checkbox, Label = "Reject Blocklisted Torrent Hashes While Grabbing", HelpText = "If a torrent is blocked by hash it may not properly be rejected during RSS/Search for some indexers, enabling this will allow it to be rejected after the torrent is grabbed, but before it is sent to the client.", Advanced = true)]
+        public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));

--- a/src/NzbDrone.Core/Indexers/FileList/FileListSettings.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListSettings.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Equ;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
@@ -17,9 +18,9 @@ namespace NzbDrone.Core.Indexers.FileList
         }
     }
 
-    public class FileListSettings : ITorrentIndexerSettings
+    public class FileListSettings : PropertywiseEquatable<FileListSettings>, ITorrentIndexerSettings
     {
-        private static readonly FileListSettingsValidator Validator = new FileListSettingsValidator();
+        private static readonly FileListSettingsValidator Validator = new ();
 
         public FileListSettings()
         {
@@ -48,7 +49,7 @@ namespace NzbDrone.Core.Indexers.FileList
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(7)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new SeedCriteriaSettings();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Indexers/HDBits/HDBitsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/HDBits/HDBitsSettings.cs
@@ -41,6 +41,9 @@ namespace NzbDrone.Core.Indexers.HDBits
         [FieldDefinition(4)]
         public SeedCriteriaSettings SeedCriteria { get; set; } = new SeedCriteriaSettings();
 
+        [FieldDefinition(8, Type = FieldType.Checkbox, Label = "Reject Blocklisted Torrent Hashes While Grabbing", HelpText = "If a torrent is blocked by hash it may not properly be rejected during RSS/Search for some indexers, enabling this will allow it to be rejected after the torrent is grabbed, but before it is sent to the client.", Advanced = true)]
+        public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));

--- a/src/NzbDrone.Core/Indexers/HDBits/HDBitsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/HDBits/HDBitsSettings.cs
@@ -1,3 +1,4 @@
+using Equ;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
@@ -15,7 +16,7 @@ namespace NzbDrone.Core.Indexers.HDBits
         }
     }
 
-    public class HDBitsSettings : ITorrentIndexerSettings
+    public class HDBitsSettings : PropertywiseEquatable<HDBitsSettings>, ITorrentIndexerSettings
     {
         private static readonly HDBitsSettingsValidator Validator = new HDBitsSettingsValidator();
 

--- a/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsSettings.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Equ;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
@@ -22,9 +23,9 @@ namespace NzbDrone.Core.Indexers.IPTorrents
         }
     }
 
-    public class IPTorrentsSettings : ITorrentIndexerSettings
+    public class IPTorrentsSettings : PropertywiseEquatable<IPTorrentsSettings>, ITorrentIndexerSettings
     {
-        private static readonly IPTorrentsSettingsValidator Validator = new IPTorrentsSettingsValidator();
+        private static readonly IPTorrentsSettingsValidator Validator = new ();
 
         public IPTorrentsSettings()
         {
@@ -38,7 +39,7 @@ namespace NzbDrone.Core.Indexers.IPTorrents
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(2)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new SeedCriteriaSettings();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsSettings.cs
@@ -41,6 +41,9 @@ namespace NzbDrone.Core.Indexers.IPTorrents
         [FieldDefinition(2)]
         public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
 
+        [FieldDefinition(3, Type = FieldType.Checkbox, Label = "Reject Blocklisted Torrent Hashes While Grabbing", HelpText = "If a torrent is blocked by hash it may not properly be rejected during RSS/Search for some indexers, enabling this will allow it to be rejected after the torrent is grabbed, but before it is sent to the client.", Advanced = true)]
+        public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));

--- a/src/NzbDrone.Core/Indexers/ITorrentIndexerSettings.cs
+++ b/src/NzbDrone.Core/Indexers/ITorrentIndexerSettings.cs
@@ -6,5 +6,6 @@ namespace NzbDrone.Core.Indexers
 
         // TODO: System.Text.Json requires setter be public for sub-object deserialization in 3.0. https://github.com/dotnet/corefx/issues/42515
         SeedCriteriaSettings SeedCriteria { get; set; }
+        bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }
     }
 }

--- a/src/NzbDrone.Core/Indexers/IndexerDefinition.cs
+++ b/src/NzbDrone.Core/Indexers/IndexerDefinition.cs
@@ -1,9 +1,13 @@
+using System;
+using Equ;
 using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.Indexers
 {
-    public class IndexerDefinition : ProviderDefinition
+    public class IndexerDefinition : ProviderDefinition, IEquatable<IndexerDefinition>
     {
+        private static readonly MemberwiseEqualityComparer<IndexerDefinition> Comparer = MemberwiseEqualityComparer<IndexerDefinition>.ByProperties;
+
         public const int DefaultPriority = 25;
 
         public IndexerDefinition()
@@ -11,18 +15,41 @@ namespace NzbDrone.Core.Indexers
             Priority = DefaultPriority;
         }
 
+        [MemberwiseEqualityIgnore]
+        public DownloadProtocol Protocol { get; set; }
+
+        [MemberwiseEqualityIgnore]
+        public bool SupportsRss { get; set; }
+
+        [MemberwiseEqualityIgnore]
+        public bool SupportsSearch { get; set; }
+
         public bool EnableRss { get; set; }
         public bool EnableAutomaticSearch { get; set; }
         public bool EnableInteractiveSearch { get; set; }
         public int DownloadClientId { get; set; }
-        public DownloadProtocol Protocol { get; set; }
-        public bool SupportsRss { get; set; }
-        public bool SupportsSearch { get; set; }
         public int Priority { get; set; }
         public int SeasonSearchMaximumSingleEpisodeAge { get; set; }
 
+        [MemberwiseEqualityIgnore]
         public override bool Enable => EnableRss || EnableAutomaticSearch || EnableInteractiveSearch;
 
+        [MemberwiseEqualityIgnore]
         public IndexerStatus Status { get; set; }
+
+        public bool Equals(IndexerDefinition other)
+        {
+            return Comparer.Equals(this, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as IndexerDefinition);
+        }
+
+        public override int GetHashCode()
+        {
+            return Comparer.GetHashCode(this);
+        }
     }
 }

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Equ;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
@@ -40,7 +41,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             return settings.BaseUrl != null && ApiKeyWhiteList.Any(c => settings.BaseUrl.ToLowerInvariant().Contains(c));
         }
 
-        private static readonly Regex AdditionalParametersRegex = new Regex(@"(&.+?\=.+?)+", RegexOptions.Compiled);
+        private static readonly Regex AdditionalParametersRegex = new (@"(&.+?\=.+?)+", RegexOptions.Compiled);
 
         public NewznabSettingsValidator()
         {
@@ -60,9 +61,9 @@ namespace NzbDrone.Core.Indexers.Newznab
         }
     }
 
-    public class NewznabSettings : IIndexerSettings
+    public class NewznabSettings : PropertywiseEquatable<NewznabSettings>, IIndexerSettings
     {
-        private static readonly NewznabSettingsValidator Validator = new NewznabSettingsValidator();
+        private static readonly NewznabSettingsValidator Validator = new ();
 
         public NewznabSettings()
         {

--- a/src/NzbDrone.Core/Indexers/SeedCriteriaSettings.cs
+++ b/src/NzbDrone.Core/Indexers/SeedCriteriaSettings.cs
@@ -1,3 +1,4 @@
+using Equ;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
@@ -46,7 +47,7 @@ namespace NzbDrone.Core.Indexers
         }
     }
 
-    public class SeedCriteriaSettings
+    public class SeedCriteriaSettings : PropertywiseEquatable<SeedCriteriaSettings>
     {
         [FieldDefinition(0, Type = FieldType.Number, Label = "Seed Ratio", HelpText = "The ratio a torrent should reach before stopping, empty is download client's default. Ratio should be at least 1.0 and follow the indexers rules")]
         public double? SeedRatio { get; set; }

--- a/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerSettings.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerSettings.cs
@@ -41,6 +41,9 @@ namespace NzbDrone.Core.Indexers.TorrentRss
         [FieldDefinition(4)]
         public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
 
+        [FieldDefinition(5, Type = FieldType.Checkbox, Label = "Reject Blocklisted Torrent Hashes While Grabbing", HelpText = "If a torrent is blocked by hash it may not properly be rejected during RSS/Search for some indexers, enabling this will allow it to be rejected after the torrent is grabbed, but before it is sent to the client.", Advanced = true)]
+        public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }
+
         public NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));

--- a/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerSettings.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerSettings.cs
@@ -1,3 +1,4 @@
+using Equ;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
@@ -14,9 +15,9 @@ namespace NzbDrone.Core.Indexers.TorrentRss
         }
     }
 
-    public class TorrentRssIndexerSettings : ITorrentIndexerSettings
+    public class TorrentRssIndexerSettings : PropertywiseEquatable<TorrentRssIndexerSettings>, ITorrentIndexerSettings
     {
-        private static readonly TorrentRssIndexerSettingsValidator Validator = new TorrentRssIndexerSettingsValidator();
+        private static readonly TorrentRssIndexerSettingsValidator Validator = new ();
 
         public TorrentRssIndexerSettings()
         {
@@ -38,7 +39,7 @@ namespace NzbDrone.Core.Indexers.TorrentRss
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(4)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new SeedCriteriaSettings();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
 
         public NzbDroneValidationResult Validate()
         {

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
@@ -58,6 +58,9 @@ namespace NzbDrone.Core.Indexers.Torznab
         [FieldDefinition(13)]
         public SeedCriteriaSettings SeedCriteria { get; set; } = new SeedCriteriaSettings();
 
+        [FieldDefinition(9, Type = FieldType.Checkbox, Label = "Reject Blocklisted Torrent Hashes While Grabbing", HelpText = "If a torrent is blocked by hash it may not properly be rejected during RSS/Search for some indexers, enabling this will allow it to be rejected after the torrent is grabbed, but before it is sent to the client.", Advanced = true)]
+        public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }
+
         public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Equ;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
@@ -18,7 +19,7 @@ namespace NzbDrone.Core.Indexers.Torznab
             return settings.BaseUrl != null && ApiKeyWhiteList.Any(c => settings.BaseUrl.ToLowerInvariant().Contains(c));
         }
 
-        private static readonly Regex AdditionalParametersRegex = new Regex(@"(&.+?\=.+?)+", RegexOptions.Compiled);
+        private static readonly Regex AdditionalParametersRegex = new (@"(&.+?\=.+?)+", RegexOptions.Compiled);
 
         public TorznabSettingsValidator()
         {
@@ -40,9 +41,11 @@ namespace NzbDrone.Core.Indexers.Torznab
         }
     }
 
-    public class TorznabSettings : NewznabSettings, ITorrentIndexerSettings
+    public class TorznabSettings : NewznabSettings, ITorrentIndexerSettings, IEquatable<TorznabSettings>
     {
-        private static readonly TorznabSettingsValidator Validator = new TorznabSettingsValidator();
+        private static readonly TorznabSettingsValidator Validator = new ();
+
+        private static readonly MemberwiseEqualityComparer<TorznabSettings> Comparer = MemberwiseEqualityComparer<TorznabSettings>.ByProperties;
 
         public TorznabSettings()
         {
@@ -58,6 +61,21 @@ namespace NzbDrone.Core.Indexers.Torznab
         public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+
+        public bool Equals(TorznabSettings other)
+        {
+            return Comparer.Equals(this, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as TorznabSettings);
+        }
+
+        public override int GetHashCode()
+        {
+            return Comparer.GetHashCode(this);
         }
     }
 }

--- a/src/NzbDrone.Core/Notifications/Apprise/AppriseSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/AppriseSettings.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Apprise
@@ -35,7 +34,7 @@ namespace NzbDrone.Core.Notifications.Apprise
         }
     }
 
-    public class AppriseSettings : IProviderConfig
+    public class AppriseSettings : NotificationSettingsBase<AppriseSettings>
     {
         private static readonly AppriseSettingsValidator Validator = new ();
 
@@ -66,7 +65,7 @@ namespace NzbDrone.Core.Notifications.Apprise
         [FieldDefinition(7, Label = "Password", Type = FieldType.Password, HelpText = "HTTP Basic Auth Password", Privacy = PrivacyLevel.Password)]
         public string AuthPassword { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScriptSettings.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScriptSettings.cs
@@ -1,6 +1,5 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
 
@@ -16,9 +15,9 @@ namespace NzbDrone.Core.Notifications.CustomScript
         }
     }
 
-    public class CustomScriptSettings : IProviderConfig
+    public class CustomScriptSettings : NotificationSettingsBase<CustomScriptSettings>
     {
-        private static readonly CustomScriptSettingsValidator Validator = new CustomScriptSettingsValidator();
+        private static readonly CustomScriptSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "Path", Type = FieldType.FilePath)]
         public string Path { get; set; }
@@ -26,7 +25,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
         [FieldDefinition(1, Label = "Arguments", HelpText = "Arguments to pass to the script", Hidden = HiddenType.HiddenIfNotSet)]
         public string Arguments { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Discord
@@ -14,7 +13,7 @@ namespace NzbDrone.Core.Notifications.Discord
         }
     }
 
-    public class DiscordSettings : IProviderConfig
+    public class DiscordSettings : NotificationSettingsBase<DiscordSettings>
     {
         public DiscordSettings()
         {
@@ -89,7 +88,7 @@ namespace NzbDrone.Core.Notifications.Discord
         [FieldDefinition(6, Label = "On Manual Interaction Fields", Advanced = true, SelectOptions = typeof(DiscordManualInteractionFieldType), HelpText = "Change the fields that are passed for this 'on manual interaction' notification", Type = FieldType.Select)]
         public IEnumerable<int> ManualInteractionFields { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Email
@@ -26,9 +25,9 @@ namespace NzbDrone.Core.Notifications.Email
         }
     }
 
-    public class EmailSettings : IProviderConfig
+    public class EmailSettings : NotificationSettingsBase<EmailSettings>
     {
-        private static readonly EmailSettingsValidator Validator = new EmailSettingsValidator();
+        private static readonly EmailSettingsValidator Validator = new ();
 
         public EmailSettings()
         {
@@ -66,7 +65,7 @@ namespace NzbDrone.Core.Notifications.Email
         [FieldDefinition(8, Label = "BCC Address(es)", HelpText = "Comma separated list of email bcc recipients", Advanced = true)]
         public IEnumerable<string> Bcc { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Gotify/GotifySettings.cs
+++ b/src/NzbDrone.Core/Notifications/Gotify/GotifySettings.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Gotify
@@ -42,9 +41,9 @@ namespace NzbDrone.Core.Notifications.Gotify
         }
     }
 
-    public class GotifySettings : IProviderConfig
+    public class GotifySettings : NotificationSettingsBase<GotifySettings>
     {
-        private static readonly GotifySettingsValidator Validator = new GotifySettingsValidator();
+        private static readonly GotifySettingsValidator Validator = new ();
 
         public GotifySettings()
         {
@@ -71,7 +70,7 @@ namespace NzbDrone.Core.Notifications.Gotify
         [FieldDefinition(5, Label = "NotificationsGotifySettingsPreferredMetadataLink", Type = FieldType.Select, SelectOptions = typeof(MetadataLinkType), HelpText = "NotificationsGotifySettingsPreferredMetadataLinkHelpText")]
         public int PreferredMetadataLink { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Join/JoinSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Join
@@ -14,14 +13,14 @@ namespace NzbDrone.Core.Notifications.Join
         }
     }
 
-    public class JoinSettings : IProviderConfig
+    public class JoinSettings : NotificationSettingsBase<JoinSettings>
     {
+        private static readonly JoinSettingsValidator Validator = new JoinSettingsValidator();
+
         public JoinSettings()
         {
             Priority = (int)JoinPriority.Normal;
         }
-
-        private static readonly JoinSettingsValidator Validator = new JoinSettingsValidator();
 
         [FieldDefinition(0, Label = "API Key", HelpText = "The API Key from your Join account settings (click Join API button).", HelpLink = "https://joinjoaomgcd.appspot.com/")]
         public string ApiKey { get; set; }
@@ -35,7 +34,7 @@ namespace NzbDrone.Core.Notifications.Join
         [FieldDefinition(3, Label = "Notification Priority", Type = FieldType.Select, SelectOptions = typeof(JoinPriority))]
         public int Priority { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Mailgun/MailgunSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Mailgun/MailgunSettings.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Mailgun
@@ -16,9 +15,9 @@ namespace NzbDrone.Core.Notifications.Mailgun
         }
     }
 
-    public class MailgunSettings : IProviderConfig
+    public class MailgunSettings : NotificationSettingsBase<MailgunSettings>
     {
-      private static readonly  MailGunSettingsValidator Validator = new MailGunSettingsValidator();
+      private static readonly  MailGunSettingsValidator Validator = new ();
 
       public MailgunSettings()
       {
@@ -40,7 +39,7 @@ namespace NzbDrone.Core.Notifications.Mailgun
       [FieldDefinition(4, Label = "Recipient Address(es)", Type = FieldType.Tag)]
       public IEnumerable<string> Recipients { get; set; }
 
-      public NzbDroneValidationResult Validate()
+      public override NzbDroneValidationResult Validate()
       {
           return new NzbDroneValidationResult(Validator.Validate(this));
       }

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
@@ -2,7 +2,6 @@ using FluentValidation;
 using Newtonsoft.Json;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Emby
@@ -19,9 +18,9 @@ namespace NzbDrone.Core.Notifications.Emby
         }
     }
 
-    public class MediaBrowserSettings : IProviderConfig
+    public class MediaBrowserSettings : NotificationSettingsBase<MediaBrowserSettings>
     {
-        private static readonly MediaBrowserSettingsValidator Validator = new MediaBrowserSettingsValidator();
+        private static readonly MediaBrowserSettingsValidator Validator = new ();
 
         public MediaBrowserSettings()
         {
@@ -61,7 +60,7 @@ namespace NzbDrone.Core.Notifications.Emby
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Host) && Port > 0;
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Notifiarr/NotifiarrSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Notifiarr/NotifiarrSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Notifiarr
@@ -13,14 +12,14 @@ namespace NzbDrone.Core.Notifications.Notifiarr
         }
     }
 
-    public class NotifiarrSettings : IProviderConfig
+    public class NotifiarrSettings : NotificationSettingsBase<NotifiarrSettings>
     {
-        private static readonly NotifiarrSettingsValidator Validator = new NotifiarrSettingsValidator();
+        private static readonly NotifiarrSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "API Key", Privacy = PrivacyLevel.ApiKey, HelpText = "Your API key from your profile", HelpLink = "https://notifiarr.com")]
         public string ApiKey { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -8,7 +8,7 @@ using NzbDrone.Core.Tv;
 namespace NzbDrone.Core.Notifications
 {
     public abstract class NotificationBase<TSettings> : INotification
-        where TSettings : IProviderConfig, new()
+        where TSettings : NotificationSettingsBase<TSettings>, new()
     {
         protected const string EPISODE_GRABBED_TITLE = "Episode Grabbed";
         protected const string EPISODE_DOWNLOADED_TITLE = "Episode Downloaded";

--- a/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationDefinition.cs
@@ -1,9 +1,13 @@
+using System;
+using Equ;
 using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.Notifications
 {
-    public class NotificationDefinition : ProviderDefinition
+    public class NotificationDefinition : ProviderDefinition, IEquatable<NotificationDefinition>
     {
+        private static readonly MemberwiseEqualityComparer<NotificationDefinition> Comparer = MemberwiseEqualityComparer<NotificationDefinition>.ByProperties;
+
         public bool OnGrab { get; set; }
         public bool OnDownload { get; set; }
         public bool OnUpgrade { get; set; }
@@ -14,24 +18,64 @@ namespace NzbDrone.Core.Notifications
         public bool OnEpisodeFileDelete { get; set; }
         public bool OnEpisodeFileDeleteForUpgrade { get; set; }
         public bool OnHealthIssue { get; set; }
+        public bool IncludeHealthWarnings { get; set; }
         public bool OnHealthRestored { get; set; }
         public bool OnApplicationUpdate { get; set; }
         public bool OnManualInteractionRequired { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnGrab { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnDownload { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnUpgrade { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnRename { get; set; }
         public bool SupportsOnImportComplete { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnSeriesAdd { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnSeriesDelete { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnEpisodeFileDelete { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnEpisodeFileDeleteForUpgrade { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnHealthIssue { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnHealthRestored { get; set; }
-        public bool IncludeHealthWarnings { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnApplicationUpdate { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public bool SupportsOnManualInteractionRequired { get; set; }
 
+        [MemberwiseEqualityIgnore]
         public override bool Enable => OnGrab || OnDownload || (OnDownload && OnUpgrade) || OnImportComplete || OnRename || OnSeriesAdd || OnSeriesDelete || OnEpisodeFileDelete || (OnEpisodeFileDelete && OnEpisodeFileDeleteForUpgrade) || OnHealthIssue || OnHealthRestored || OnApplicationUpdate || OnManualInteractionRequired;
+
+        public bool Equals(NotificationDefinition other)
+        {
+            return Comparer.Equals(this, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as NotificationDefinition);
+        }
+
+        public override int GetHashCode()
+        {
+            return Comparer.GetHashCode(this);
+        }
     }
 }

--- a/src/NzbDrone.Core/Notifications/NotificationSettingsBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationSettingsBase.cs
@@ -1,0 +1,30 @@
+using System;
+using Equ;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.Notifications
+{
+    public abstract class NotificationSettingsBase<TSettings> : IProviderConfig, IEquatable<TSettings>
+        where TSettings : NotificationSettingsBase<TSettings>
+    {
+        private static readonly MemberwiseEqualityComparer<TSettings> Comparer = MemberwiseEqualityComparer<TSettings>.ByProperties;
+
+        public abstract NzbDroneValidationResult Validate();
+
+        public bool Equals(TSettings other)
+        {
+            return Comparer.Equals(this as TSettings, other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as TSettings);
+        }
+
+        public override int GetHashCode()
+        {
+            return Comparer.GetHashCode(this as TSettings);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/Ntfy/NtfySettings.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/NtfySettings.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Ntfy
@@ -21,12 +20,12 @@ namespace NzbDrone.Core.Notifications.Ntfy
             RuleForEach(c => c.Topics).NotEmpty().Matches("[a-zA-Z0-9_-]+").Must(c => !InvalidTopics.Contains(c)).WithMessage("Invalid topic");
         }
 
-        private static List<string> InvalidTopics => new List<string> { "announcements", "app", "docs", "settings", "stats", "mytopic-rw", "mytopic-ro", "mytopic-wo" };
+        private static List<string> InvalidTopics => new () { "announcements", "app", "docs", "settings", "stats", "mytopic-rw", "mytopic-ro", "mytopic-wo" };
     }
 
-    public class NtfySettings : IProviderConfig
+    public class NtfySettings : NotificationSettingsBase<NtfySettings>
     {
-        private static readonly NtfySettingsValidator Validator = new NtfySettingsValidator();
+        private static readonly NtfySettingsValidator Validator = new ();
 
         public NtfySettings()
         {
@@ -58,7 +57,7 @@ namespace NzbDrone.Core.Notifications.Ntfy
         [FieldDefinition(7, Label = "Click URL", Type = FieldType.Url, HelpText = "Optional link when user clicks notification")]
         public string ClickUrl { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerSettings.cs
@@ -1,7 +1,6 @@
 using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Plex.Server
@@ -17,9 +16,9 @@ namespace NzbDrone.Core.Notifications.Plex.Server
         }
     }
 
-    public class PlexServerSettings : IProviderConfig
+    public class PlexServerSettings : NotificationSettingsBase<PlexServerSettings>
     {
-        private static readonly PlexServerSettingsValidator Validator = new PlexServerSettingsValidator();
+        private static readonly PlexServerSettingsValidator Validator = new ();
 
         public PlexServerSettings()
         {
@@ -57,7 +56,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Host);
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Prowl/ProwlSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Prowl/ProwlSettings.cs
@@ -1,6 +1,5 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Prowl
@@ -13,9 +12,9 @@ namespace NzbDrone.Core.Notifications.Prowl
         }
     }
 
-    public class ProwlSettings : IProviderConfig
+    public class ProwlSettings : NotificationSettingsBase<ProwlSettings>
     {
-        private static readonly ProwlSettingsValidator Validator = new ProwlSettingsValidator();
+        private static readonly ProwlSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "API Key", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://www.prowlapp.com/api_settings.php")]
         public string ApiKey { get; set; }
@@ -25,7 +24,7 @@ namespace NzbDrone.Core.Notifications.Prowl
 
         public bool IsValid => !string.IsNullOrWhiteSpace(ApiKey) && Priority >= -2 && Priority <= 2;
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBulletSettings.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBulletSettings.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.PushBullet
@@ -14,9 +13,9 @@ namespace NzbDrone.Core.Notifications.PushBullet
         }
     }
 
-    public class PushBulletSettings : IProviderConfig
+    public class PushBulletSettings : NotificationSettingsBase<PushBulletSettings>
     {
-        private static readonly PushBulletSettingsValidator Validator = new PushBulletSettingsValidator();
+        private static readonly PushBulletSettingsValidator Validator = new ();
 
         public PushBulletSettings()
         {
@@ -36,7 +35,7 @@ namespace NzbDrone.Core.Notifications.PushBullet
         [FieldDefinition(3, Label = "Sender ID", HelpText = "The device ID to send notifications from, use device_iden in the device's URL on pushbullet.com (leave blank to send from yourself)")]
         public string SenderId { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Pushcut/PushcutSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Pushcut/PushcutSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Pushcut
@@ -14,7 +13,7 @@ namespace NzbDrone.Core.Notifications.Pushcut
         }
     }
 
-    public class PushcutSettings : IProviderConfig
+    public class PushcutSettings : NotificationSettingsBase<PushcutSettings>
     {
         private static readonly PushcutSettingsValidator Validator = new ();
 
@@ -27,7 +26,7 @@ namespace NzbDrone.Core.Notifications.Pushcut
         [FieldDefinition(2, Label = "Time sensitive", Type = FieldType.Checkbox, HelpText = "Check to mark the notification as \"Time-Sensitive\"")]
         public bool TimeSensitive { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Pushover/PushoverSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Pushover/PushoverSettings.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Pushover
@@ -16,9 +15,9 @@ namespace NzbDrone.Core.Notifications.Pushover
         }
     }
 
-    public class PushoverSettings : IProviderConfig
+    public class PushoverSettings : NotificationSettingsBase<PushoverSettings>
     {
-        private static readonly PushoverSettingsValidator Validator = new PushoverSettingsValidator();
+        private static readonly PushoverSettingsValidator Validator = new ();
 
         public PushoverSettings()
         {
@@ -50,7 +49,7 @@ namespace NzbDrone.Core.Notifications.Pushover
 
         public bool IsValid => !string.IsNullOrWhiteSpace(UserKey) && Priority >= -1 && Priority <= 2;
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/SendGrid/SendGridSettings.cs
+++ b/src/NzbDrone.Core/Notifications/SendGrid/SendGridSettings.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.SendGrid
@@ -17,9 +16,9 @@ namespace NzbDrone.Core.Notifications.SendGrid
         }
     }
 
-    public class SendGridSettings : IProviderConfig
+    public class SendGridSettings : NotificationSettingsBase<SendGridSettings>
     {
-        private static readonly SendGridSettingsValidator Validator = new SendGridSettingsValidator();
+        private static readonly SendGridSettingsValidator Validator = new ();
 
         public SendGridSettings()
         {
@@ -38,7 +37,7 @@ namespace NzbDrone.Core.Notifications.SendGrid
         [FieldDefinition(3, Label = "Recipient Address(es)", Type = FieldType.Tag)]
         public IEnumerable<string> Recipients { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Signal/SignalSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Signal/SignalSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Signal
@@ -16,7 +15,7 @@ namespace NzbDrone.Core.Notifications.Signal
         }
     }
 
-    public class SignalSettings : IProviderConfig
+    public class SignalSettings : NotificationSettingsBase<SignalSettings>
     {
         private static readonly SignalSettingsValidator Validator = new ();
 
@@ -41,7 +40,7 @@ namespace NzbDrone.Core.Notifications.Signal
         [FieldDefinition(6, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password, HelpText = "Password used to authenticate requests toward signal-api")]
         public string AuthPassword { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Simplepush/SimplepushSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Simplepush/SimplepushSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Simplepush
@@ -13,9 +12,9 @@ namespace NzbDrone.Core.Notifications.Simplepush
         }
     }
 
-    public class SimplepushSettings : IProviderConfig
+    public class SimplepushSettings : NotificationSettingsBase<SimplepushSettings>
     {
-        private static readonly SimplepushSettingsValidator Validator = new SimplepushSettingsValidator();
+        private static readonly SimplepushSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "Key", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://simplepush.io/features")]
         public string Key { get; set; }
@@ -25,7 +24,7 @@ namespace NzbDrone.Core.Notifications.Simplepush
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Key);
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Slack
@@ -14,9 +13,9 @@ namespace NzbDrone.Core.Notifications.Slack
         }
     }
 
-    public class SlackSettings : IProviderConfig
+    public class SlackSettings : NotificationSettingsBase<SlackSettings>
     {
-        private static readonly SlackSettingsValidator Validator = new SlackSettingsValidator();
+        private static readonly SlackSettingsValidator Validator = new ();
 
         [FieldDefinition(0, Label = "Webhook URL", HelpText = "Slack channel webhook url", Type = FieldType.Url, HelpLink = "https://my.slack.com/services/new/incoming-webhook/")]
         public string WebHookUrl { get; set; }
@@ -30,7 +29,7 @@ namespace NzbDrone.Core.Notifications.Slack
         [FieldDefinition(3, Label = "Channel", HelpText = "Overrides the default channel for the incoming webhook (#other-channel)", Type = FieldType.Textbox)]
         public string Channel { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Stash/StashSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Stash/StashSettings.cs
@@ -2,7 +2,6 @@ using FluentValidation;
 using Newtonsoft.Json;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Stash
@@ -22,7 +21,7 @@ namespace NzbDrone.Core.Notifications.Stash
         }
     }
 
-    public class StashSettings : IProviderConfig
+    public class StashSettings : NotificationSettingsBase<StashSettings>
     {
         private static readonly StashSettingsValidator Validator = new StashSettingsValidator();
 
@@ -78,7 +77,7 @@ namespace NzbDrone.Core.Notifications.Stash
 
         public bool IsValid => !string.IsNullOrWhiteSpace(Host) && Port > 0;
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Synology/SynologyIndexerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Synology/SynologyIndexerSettings.cs
@@ -1,6 +1,5 @@
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Synology
@@ -9,9 +8,9 @@ namespace NzbDrone.Core.Notifications.Synology
     {
     }
 
-    public class SynologyIndexerSettings : IProviderConfig
+    public class SynologyIndexerSettings : NotificationSettingsBase<SynologyIndexerSettings>
     {
-        private static readonly SynologyIndexerSettingsValidator Validator = new SynologyIndexerSettingsValidator();
+        private static readonly SynologyIndexerSettingsValidator Validator = new ();
 
         public SynologyIndexerSettings()
         {
@@ -21,7 +20,7 @@ namespace NzbDrone.Core.Notifications.Synology
         [FieldDefinition(0, Label = "Update Library", Type = FieldType.Checkbox, HelpText = "Call synoindex on localhost to update a library file")]
         public bool UpdateLibrary { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Telegram/TelegramSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/TelegramSettings.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Telegram
@@ -29,9 +28,9 @@ namespace NzbDrone.Core.Notifications.Telegram
         }
     }
 
-    public class TelegramSettings : IProviderConfig
+    public class TelegramSettings : NotificationSettingsBase<TelegramSettings>
     {
-        private static readonly TelegramSettingsValidator Validator = new TelegramSettingsValidator();
+        private static readonly TelegramSettingsValidator Validator = new ();
 
         public TelegramSettings()
         {
@@ -56,7 +55,7 @@ namespace NzbDrone.Core.Notifications.Telegram
         [FieldDefinition(5, Label = "NotificationsTelegramSettingsMetadataLinks", Type = FieldType.Select, SelectOptions = typeof(MetadataLinkType), HelpText = "NotificationsTelegramSettingsMetadataLinksHelpText")]
         public IEnumerable<int> MetadataLinks { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
@@ -1,7 +1,6 @@
-﻿using FluentValidation;
+using FluentValidation;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Twitter
@@ -28,9 +27,9 @@ namespace NzbDrone.Core.Notifications.Twitter
         }
     }
 
-    public class TwitterSettings : IProviderConfig
+    public class TwitterSettings : NotificationSettingsBase<TwitterSettings>
     {
-        private static readonly TwitterSettingsValidator Validator = new TwitterSettingsValidator();
+        private static readonly TwitterSettingsValidator Validator = new ();
 
         public TwitterSettings()
         {
@@ -59,7 +58,7 @@ namespace NzbDrone.Core.Notifications.Twitter
         [FieldDefinition(6, Label = "Connect to Twitter", Type = FieldType.OAuth)]
         public string AuthorizeNotification { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
@@ -7,13 +7,12 @@ using NzbDrone.Core.Localization;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Tags;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.Notifications.Webhook
 {
     public abstract class WebhookBase<TSettings> : NotificationBase<TSettings>
-        where TSettings : IProviderConfig, new()
+        where TSettings : NotificationSettingsBase<TSettings>, new()
     {
         private readonly IConfigFileProvider _configFileProvider;
         private readonly IConfigService _configService;

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookSettings.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Webhook
@@ -14,9 +13,9 @@ namespace NzbDrone.Core.Notifications.Webhook
         }
     }
 
-    public class WebhookSettings : IProviderConfig
+    public class WebhookSettings : NotificationSettingsBase<WebhookSettings>
     {
-        private static readonly WebhookSettingsValidator Validator = new WebhookSettingsValidator();
+        private static readonly WebhookSettingsValidator Validator = new ();
 
         public WebhookSettings()
         {
@@ -35,7 +34,7 @@ namespace NzbDrone.Core.Notifications.Webhook
         [FieldDefinition(3, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
@@ -3,7 +3,6 @@ using FluentValidation;
 using Newtonsoft.Json;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Annotations;
-using NzbDrone.Core.ThingiProvider;
 using NzbDrone.Core.Validation;
 
 namespace NzbDrone.Core.Notifications.Xbmc
@@ -18,7 +17,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
         }
     }
 
-    public class XbmcSettings : IProviderConfig
+    public class XbmcSettings : NotificationSettingsBase<XbmcSettings>
     {
         private static readonly XbmcSettingsValidator Validator = new ();
 
@@ -66,7 +65,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
         [JsonIgnore]
         public string Address => $"{Host.ToUrlHost()}:{Port}{UrlBase}";
 
-        public NzbDroneValidationResult Validate()
+        public override NzbDroneValidationResult Validate()
         {
             return new NzbDroneValidationResult(Validator.Validate(this));
         }

--- a/src/NzbDrone.Core/ThingiProvider/ProviderDefinition.cs
+++ b/src/NzbDrone.Core/ThingiProvider/ProviderDefinition.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Equ;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.ThingiProvider
@@ -16,20 +17,22 @@ namespace NzbDrone.Core.ThingiProvider
         public string Name { get; set; }
 
         [JsonIgnore]
+        [MemberwiseEqualityIgnore]
         public string ImplementationName { get; set; }
 
         public string Implementation { get; set; }
         public string ConfigContract { get; set; }
         public virtual bool Enable { get; set; }
+
+        [MemberwiseEqualityIgnore]
         public ProviderMessage Message { get; set; }
+
         public HashSet<int> Tags { get; set; }
 
+        [MemberwiseEqualityIgnore]
         public IProviderConfig Settings
         {
-            get
-            {
-                return _settings;
-            }
+            get => _settings;
             set
             {
                 _settings = value;

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Diacritical.Net" Version="1.0.4" />
+    <PackageReference Include="Equ" Version="2.3.0" />
     <PackageReference Include="MailKit" Version="4.8.0" />
     <!-- Accepting GHSA-9j88-vvj5-vhgr: fixed in MailKit 4.16.0, but that drops net6.0 support via MimeKit. Whisparr only uses MailKit for outbound SMTP, not parsing untrusted STARTTLS responses. -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-9j88-vvj5-vhgr" />

--- a/src/Whisparr.Api.V3/Notifications/NotificationResource.cs
+++ b/src/Whisparr.Api.V3/Notifications/NotificationResource.cs
@@ -15,6 +15,7 @@ namespace Whisparr.Api.V3.Notifications
         public bool OnEpisodeFileDelete { get; set; }
         public bool OnEpisodeFileDeleteForUpgrade { get; set; }
         public bool OnHealthIssue { get; set; }
+        public bool IncludeHealthWarnings { get; set; }
         public bool OnHealthRestored { get; set; }
         public bool OnApplicationUpdate { get; set; }
         public bool OnManualInteractionRequired { get; set; }
@@ -31,7 +32,6 @@ namespace Whisparr.Api.V3.Notifications
         public bool SupportsOnHealthRestored { get; set; }
         public bool SupportsOnApplicationUpdate { get; set; }
         public bool SupportsOnManualInteractionRequired { get; set; }
-        public bool IncludeHealthWarnings { get; set; }
         public string TestCommand { get; set; }
     }
 
@@ -56,6 +56,7 @@ namespace Whisparr.Api.V3.Notifications
             resource.OnEpisodeFileDelete = definition.OnEpisodeFileDelete;
             resource.OnEpisodeFileDeleteForUpgrade = definition.OnEpisodeFileDeleteForUpgrade;
             resource.OnHealthIssue = definition.OnHealthIssue;
+            resource.IncludeHealthWarnings = definition.IncludeHealthWarnings;
             resource.OnHealthRestored = definition.OnHealthRestored;
             resource.OnApplicationUpdate = definition.OnApplicationUpdate;
             resource.OnManualInteractionRequired = definition.OnManualInteractionRequired;
@@ -70,7 +71,6 @@ namespace Whisparr.Api.V3.Notifications
             resource.SupportsOnEpisodeFileDeleteForUpgrade = definition.SupportsOnEpisodeFileDeleteForUpgrade;
             resource.SupportsOnHealthIssue = definition.SupportsOnHealthIssue;
             resource.SupportsOnHealthRestored = definition.SupportsOnHealthRestored;
-            resource.IncludeHealthWarnings = definition.IncludeHealthWarnings;
             resource.SupportsOnApplicationUpdate = definition.SupportsOnApplicationUpdate;
             resource.SupportsOnManualInteractionRequired = definition.SupportsOnManualInteractionRequired;
 
@@ -96,6 +96,7 @@ namespace Whisparr.Api.V3.Notifications
             definition.OnEpisodeFileDelete = resource.OnEpisodeFileDelete;
             definition.OnEpisodeFileDeleteForUpgrade = resource.OnEpisodeFileDeleteForUpgrade;
             definition.OnHealthIssue = resource.OnHealthIssue;
+            definition.IncludeHealthWarnings = resource.IncludeHealthWarnings;
             definition.OnHealthRestored = resource.OnHealthRestored;
             definition.OnApplicationUpdate = resource.OnApplicationUpdate;
             definition.OnManualInteractionRequired = resource.OnManualInteractionRequired;
@@ -110,7 +111,6 @@ namespace Whisparr.Api.V3.Notifications
             definition.SupportsOnEpisodeFileDeleteForUpgrade = resource.SupportsOnEpisodeFileDeleteForUpgrade;
             definition.SupportsOnHealthIssue = resource.SupportsOnHealthIssue;
             definition.SupportsOnHealthRestored = resource.SupportsOnHealthRestored;
-            definition.IncludeHealthWarnings = resource.IncludeHealthWarnings;
             definition.SupportsOnApplicationUpdate = resource.SupportsOnApplicationUpdate;
             definition.SupportsOnManualInteractionRequired = resource.SupportsOnManualInteractionRequired;
 

--- a/src/Whisparr.Api.V3/ProviderControllerBase.cs
+++ b/src/Whisparr.Api.V3/ProviderControllerBase.cs
@@ -91,10 +91,8 @@ namespace Whisparr.Api.V3
             var existingDefinition = _providerFactory.Find(providerResource.Id);
             var providerDefinition = GetDefinition(providerResource, existingDefinition, true, !forceSave, false);
 
-            // Comparing via JSON string to eliminate the need for every provider implementation to implement equality checks.
             // Compare settings separately because they are not serialized with the definition.
-            var hasDefinitionChanged = STJson.ToJson(existingDefinition) != STJson.ToJson(providerDefinition) ||
-                                       STJson.ToJson(existingDefinition.Settings) != STJson.ToJson(providerDefinition.Settings);
+            var hasDefinitionChanged = !existingDefinition.Equals(providerDefinition) || !existingDefinition.Settings.Equals(providerDefinition.Settings);
 
             // Only test existing definitions if it is enabled and forceSave isn't set and the definition has changed.
             if (providerDefinition.Enable && !forceSave && hasDefinitionChanged)


### PR DESCRIPTION
Back-fills two upstream commits that earlier batches skipped for conflict count. Both gate a large amount of later sync work, so they land ahead of Batch 18.

- Implement equality checks for providers — Sonarr/Sonarr@084fcc229
- Fixed: Blocklisting torrents from indexers that do not provide torrent hash — Sonarr/Sonarr@3541cd7ba

Adds the Equ package and the provider settings base classes. Localization changes declined per project policy; MailKit stays pinned at 4.8.0 with its existing audit suppression.