### PR TITLE
Chore: Sonarr Upstream Sync - Batch 18 (October 2024)

### DIFF
--- a/frontend/src/Components/SignalRConnector.js
+++ b/frontend/src/Components/SignalRConnector.js
@@ -168,7 +168,7 @@ class SignalRConnector extends Component {
     const status = resource.status;
 
     // Both successful and failed commands need to be
-    // completed, otherwise they spin until they timeout.
+    // completed, otherwise they spin until they time out.
 
     if (status === 'completed' || status === 'failed') {
       this.props.dispatchFinishCommand(resource);
@@ -202,8 +202,56 @@ class SignalRConnector extends Component {
     }
   };
 
+  handleDownloadclient = ({ action, resource }) => {
+    const section = 'settings.downloadClients';
+
+    if (action === 'created' || action === 'updated') {
+      this.props.dispatchUpdateItem({ section, ...resource });
+    } else if (action === 'deleted') {
+      this.props.dispatchRemoveItem({ section, id: resource.id });
+    }
+  };
+
   handleHealth = () => {
     this.props.dispatchFetchHealth();
+  };
+
+  handleImportlist = ({ action, resource }) => {
+    const section = 'settings.importLists';
+
+    if (action === 'created' || action === 'updated') {
+      this.props.dispatchUpdateItem({ section, ...resource });
+    } else if (action === 'deleted') {
+      this.props.dispatchRemoveItem({ section, id: resource.id });
+    }
+  };
+
+  handleIndexer = ({ action, resource }) => {
+    const section = 'settings.indexers';
+
+    if (action === 'created' || action === 'updated') {
+      this.props.dispatchUpdateItem({ section, ...resource });
+    } else if (action === 'deleted') {
+      this.props.dispatchRemoveItem({ section, id: resource.id });
+    }
+  };
+
+  handleMetadata = ({ action, resource }) => {
+    const section = 'settings.metadata';
+
+    if (action === 'updated') {
+      this.props.dispatchUpdateItem({ section, ...resource });
+    }
+  };
+
+  handleNotification = ({ action, resource }) => {
+    const section = 'settings.notifications';
+
+    if (action === 'created' || action === 'updated') {
+      this.props.dispatchUpdateItem({ section, ...resource });
+    } else if (action === 'deleted') {
+      this.props.dispatchRemoveItem({ section, id: resource.id });
+    }
   };
 
   handleSeries = (body) => {

--- a/src/NzbDrone.Common.Test/PathExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/PathExtensionFixture.cs
@@ -392,5 +392,26 @@ namespace NzbDrone.Common.Test
             PosixOnly();
             path.AsOsAgnostic().IsPathValid(PathValidationType.CurrentOs).Should().BeFalse();
         }
+
+        [TestCase(@"C:\", @"C:\")]
+        [TestCase(@"C:\\", @"C:\")]
+        [TestCase(@"C:\Test", @"C:\Test")]
+        [TestCase(@"C:\Test\", @"C:\Test")]
+        [TestCase(@"\\server\share", @"\\server\share")]
+        [TestCase(@"\\server\share\", @"\\server\share")]
+        public void windows_path_should_return_clean_path(string path, string cleanPath)
+        {
+            path.GetCleanPath().Should().Be(cleanPath);
+        }
+
+        [TestCase("/", "/")]
+        [TestCase("//", "/")]
+        [TestCase("/test", "/test")]
+        [TestCase("/test/", "/test")]
+        [TestCase("/test//", "/test")]
+        public void unix_path_should_return_clean_path(string path, string cleanPath)
+        {
+            path.GetCleanPath().Should().Be(cleanPath);
+        }
     }
 }

--- a/src/NzbDrone.Common.Test/PathExtensionFixture.cs
+++ b/src/NzbDrone.Common.Test/PathExtensionFixture.cs
@@ -413,5 +413,25 @@ namespace NzbDrone.Common.Test
         {
             path.GetCleanPath().Should().Be(cleanPath);
         }
+
+        [TestCase(@"C:\Test\", @"C:\Test\Series Title", "Series Title")]
+        [TestCase(@"C:\Test\", @"C:\Test\Collection\Series Title", @"Collection\Series Title")]
+        [TestCase(@"C:\Test\mydir\", @"C:\Test\mydir\Collection\Series Title", @"Collection\Series Title")]
+        [TestCase(@"\\server\share", @"\\server\share\Series Title", "Series Title")]
+        [TestCase(@"\\server\share\mydir\", @"\\server\share\mydir\/Collection\Series Title", @"Collection\Series Title")]
+        public void windows_path_should_return_relative_path(string parentPath, string childPath, string relativePath)
+        {
+            parentPath.GetRelativePath(childPath).Should().Be(relativePath);
+        }
+
+        [TestCase(@"/test", "/test/Series Title", "Series Title")]
+        [TestCase(@"/test/", "/test/Collection/Series Title", "Collection/Series Title")]
+        [TestCase(@"/test/mydir", "/test/mydir/Series Title", "Series Title")]
+        [TestCase(@"/test/mydir/", "/test/mydir/Collection/Series Title", "Collection/Series Title")]
+        [TestCase(@"/test/mydir/", @"/test/mydir/\Collection/Series Title", "Collection/Series Title")]
+        public void unix_path_should_return_relative_path(string parentPath, string childPath, string relativePath)
+        {
+            parentPath.GetRelativePath(childPath).Should().Be(relativePath);
+        }
     }
 }

--- a/src/NzbDrone.Common/Disk/OsPath.cs
+++ b/src/NzbDrone.Common/Disk/OsPath.cs
@@ -104,9 +104,19 @@ namespace NzbDrone.Common.Disk
             switch (kind)
             {
                 case OsPathKind.Windows when !path.EndsWith(":\\"):
-                    return path.TrimEnd('\\');
+                    while (!path.EndsWith(":\\") && path.EndsWith('\\'))
+                    {
+                        path = path[..^1];
+                    }
+
+                    return path;
                 case OsPathKind.Unix when path != "/":
-                    return path.TrimEnd('/');
+                    while (path != "/" && path.EndsWith('/'))
+                    {
+                        path = path[..^1];
+                    }
+
+                    return path;
             }
 
             return path;

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -90,7 +90,7 @@ namespace NzbDrone.Common.Extensions
                 throw new NotParentException("{0} is not a child of {1}", childPath, parentPath);
             }
 
-            return childPath.Substring(parentPath.Length).Trim(Path.DirectorySeparatorChar);
+            return childPath.Substring(parentPath.Length).Trim('\\', '/');
         }
 
         public static string GetParentPath(this string childPath)

--- a/src/NzbDrone.Common/Extensions/PathExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/PathExtensions.cs
@@ -25,8 +25,6 @@ namespace NzbDrone.Common.Extensions
         private static readonly string UPDATE_CLIENT_FOLDER_NAME = "Whisparr.Update" + Path.DirectorySeparatorChar;
         private static readonly string UPDATE_LOG_FOLDER_NAME = "UpdateLogs" + Path.DirectorySeparatorChar;
 
-        private static readonly Regex PARENT_PATH_END_SLASH_REGEX = new Regex(@"(?<!:)\\$", RegexOptions.Compiled);
-
         public static string CleanFilePath(this string path)
         {
             if (path.IsNotNullOrWhiteSpace())
@@ -118,11 +116,9 @@ namespace NzbDrone.Common.Extensions
 
         public static string GetCleanPath(this string path)
         {
-            var cleanPath = OsInfo.IsWindows
-                ? PARENT_PATH_END_SLASH_REGEX.Replace(path, "")
-                : path.TrimEnd(Path.DirectorySeparatorChar);
+            var osPath = new OsPath(path);
 
-            return cleanPath;
+            return osPath == OsPath.Null ? null : osPath.PathWithoutTrailingSlash;
         }
 
         public static bool IsParentPath(this string parentPath, string childPath)

--- a/src/NzbDrone.Core.Test/DecisionEngineTests/FreeSpaceSpecificationFixture.cs
+++ b/src/NzbDrone.Core.Test/DecisionEngineTests/FreeSpaceSpecificationFixture.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
@@ -86,6 +87,17 @@ namespace NzbDrone.Core.Test.DecisionEngineTests
             WithMinimumFreeSpace(150);
             WithAvailableSpace(200);
             WithSize(100);
+
+            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
+        }
+
+        [Test]
+        public void should_return_true_if_root_folder_is_not_available()
+        {
+            WithMinimumFreeSpace(150);
+            WithSize(100);
+
+            Mocker.GetMock<IDiskProvider>().Setup(s => s.GetAvailableSpace(It.IsAny<string>())).Throws<DirectoryNotFoundException>();
 
             Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
         }

--- a/src/NzbDrone.Core.Test/Download/DownloadClientProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientProviderFixture.cs
@@ -201,16 +201,8 @@ namespace NzbDrone.Core.Test.Download
             var clientTags = new HashSet<int> { 1 };
 
             WithTorrentClient(0, clientTags);
-            WithTorrentClient(0, clientTags);
-            WithTorrentClient(0, clientTags);
-            WithTorrentClient(0, clientTags);
 
-            var client1 = Subject.GetDownloadClient(DownloadProtocol.Torrent, 0, false, seriesTags);
-            var client2 = Subject.GetDownloadClient(DownloadProtocol.Torrent, 0, false, seriesTags);
-            var client3 = Subject.GetDownloadClient(DownloadProtocol.Torrent, 0, false, seriesTags);
-            var client4 = Subject.GetDownloadClient(DownloadProtocol.Torrent, 0, false, seriesTags);
-
-            Subject.GetDownloadClient(DownloadProtocol.Torrent, 0, false, seriesTags).Should().BeNull();
+            Assert.Throws<DownloadClientUnavailableException>(() => Subject.GetDownloadClient(DownloadProtocol.Torrent, 0, false, seriesTags));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Download/DownloadClientTests/DelugeTests/DelugeFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadClientTests/DelugeTests/DelugeFixture.cs
@@ -312,11 +312,12 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
         [Test]
         public void should_return_status_with_outputdirs()
         {
-            var configItems = new Dictionary<string, object>();
-
-            configItems.Add("download_location", @"C:\Downloads\Downloading\deluge".AsOsAgnostic());
-            configItems.Add("move_completed_path", @"C:\Downloads\Finished\deluge".AsOsAgnostic());
-            configItems.Add("move_completed", true);
+            var configItems = new Dictionary<string, object>
+            {
+                { "download_location", @"C:\Downloads\Downloading\deluge".AsOsAgnostic() },
+                { "move_completed_path", @"C:\Downloads\Finished\deluge".AsOsAgnostic() },
+                { "move_completed", true }
+            };
 
             Mocker.GetMock<IDelugeProxy>()
                 .Setup(v => v.GetConfig(It.IsAny<DelugeSettings>()))
@@ -327,6 +328,19 @@ namespace NzbDrone.Core.Test.Download.DownloadClientTests.DelugeTests
             result.IsLocalhost.Should().BeTrue();
             result.OutputRootFolders.Should().NotBeNull();
             result.OutputRootFolders.First().Should().Be(@"C:\Downloads\Finished\deluge".AsOsAgnostic());
+        }
+
+        [Test]
+        public void should_return_status_with_outputdirs_for_directories_in_settings()
+        {
+            Subject.Definition.Settings.As<DelugeSettings>().DownloadDirectory =  @"D:\Downloads\Downloading\deluge".AsOsAgnostic();
+            Subject.Definition.Settings.As<DelugeSettings>().CompletedDirectory =  @"D:\Downloads\Finished\deluge".AsOsAgnostic();
+
+            var result = Subject.GetStatus();
+
+            result.IsLocalhost.Should().BeTrue();
+            result.OutputRootFolders.Should().NotBeNull();
+            result.OutputRootFolders.First().Should().Be(@"D:\Downloads\Finished\deluge".AsOsAgnostic());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeFileMovingServiceTests/MoveEpisodeFileFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeFileMovingServiceTests/MoveEpisodeFileFixture.cs
@@ -12,6 +12,7 @@ using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.RootFolders;
 using NzbDrone.Core.Test.Framework;
 using NzbDrone.Core.Tv;
 using NzbDrone.Test.Common;
@@ -47,6 +48,11 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeFileMovingServiceTests
                   .Returns(@"C:\Test\TV\Series\Season 01\File Name.avi".AsOsAgnostic());
 
             var rootFolder = @"C:\Test\TV\".AsOsAgnostic();
+
+            Mocker.GetMock<IRootFolderService>()
+                .Setup(s => s.GetBestRootFolderPath(It.IsAny<string>()))
+                .Returns(rootFolder);
+
             Mocker.GetMock<IDiskProvider>()
                   .Setup(s => s.FolderExists(rootFolder))
                   .Returns(true);

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/FreeSpaceSpecification.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using NLog;
 using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
@@ -32,11 +33,21 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
             }
 
             var size = subject.Release.Size;
-            var freeSpace = _diskProvider.GetAvailableSpace(subject.Series.Path);
+            var path = subject.Series.Path;
+            long? freeSpace = null;
+
+            try
+            {
+                freeSpace = _diskProvider.GetAvailableSpace(path);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // Ignore so it'll be skipped in the following checks
+            }
 
             if (!freeSpace.HasValue)
             {
-                _logger.Debug("Unable to get available space for {0}. Skipping", subject.Series.Path);
+                _logger.Debug("Unable to get available space for {0}. Skipping", path);
 
                 return Decision.Accept();
             }

--- a/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
+++ b/src/NzbDrone.Core/DecisionEngine/Specifications/UpgradeDiskSpecification.cs
@@ -36,8 +36,6 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                     continue;
                 }
 
-                var customFormats = _formatService.ParseCustomFormat(file);
-
                 _logger.Debug("Comparing file quality with report. Existing file is {0}.", file.Quality);
 
                 if (!_upgradableSpecification.CutoffNotMet(qualityProfile,
@@ -47,11 +45,13 @@ namespace NzbDrone.Core.DecisionEngine.Specifications
                 {
                     _logger.Debug("Cutoff already met, rejecting.");
 
-                    var qualityCutoffIndex = qualityProfile.GetIndex(qualityProfile.Cutoff);
-                    var qualityCutoff = qualityProfile.Items[qualityCutoffIndex.Index];
+                    var cutoff = qualityProfile.UpgradeAllowed ? qualityProfile.Cutoff : qualityProfile.FirststAllowedQuality().Id;
+                    var qualityCutoff = qualityProfile.Items[qualityProfile.GetIndex(cutoff).Index];
 
                     return Decision.Reject("Existing file meets cutoff: {0}", qualityCutoff);
                 }
+
+                var customFormats = _formatService.ParseCustomFormat(file);
 
                 var upgradeableRejectReason = _upgradableSpecification.IsUpgradable(qualityProfile,
                     file.Quality,

--- a/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/Deluge.cs
@@ -212,9 +212,18 @@ namespace NzbDrone.Core.Download.Clients.Deluge
         {
             var config = _proxy.GetConfig(Settings);
             var label = _proxy.GetLabelOptions(Settings);
+
             OsPath destDir;
 
-            if (label != null && label.ApplyMoveCompleted && label.MoveCompleted)
+            if (Settings.CompletedDirectory.IsNotNullOrWhiteSpace())
+            {
+                destDir = new OsPath(Settings.CompletedDirectory);
+            }
+            else if (Settings.DownloadDirectory.IsNotNullOrWhiteSpace())
+            {
+                destDir = new OsPath(Settings.DownloadDirectory);
+            }
+            else if (label is { ApplyMoveCompleted: true, MoveCompleted: true })
             {
                 // if label exists and a label completed path exists and is enabled use it instead of global
                 destDir = new OsPath(label.MoveCompletedPath);
@@ -230,7 +239,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
             var status = new DownloadClientInfo
             {
-                IsLocalhost = Settings.Host == "127.0.0.1" || Settings.Host == "localhost"
+                IsLocalhost = Settings.Host is "127.0.0.1" or "localhost"
             };
 
             if (!destDir.IsEmpty)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxySelector.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxySelector.cs
@@ -26,8 +26,6 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
         Dictionary<string, QBittorrentLabel> GetLabels(QBittorrentSettings settings);
         void SetTorrentSeedingConfiguration(string hash, TorrentSeedConfiguration seedConfiguration, QBittorrentSettings settings);
         void MoveTorrentToTopInQueue(string hash, QBittorrentSettings settings);
-        void PauseTorrent(string hash, QBittorrentSettings settings);
-        void ResumeTorrent(string hash, QBittorrentSettings settings);
         void SetForceStart(string hash, bool enabled, QBittorrentSettings settings);
     }
 

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV1.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentProxyV1.cs
@@ -147,7 +147,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 request.AddFormParameter("paused", false);
             }
-            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
+            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Stop)
             {
                 request.AddFormParameter("paused", true);
             }
@@ -177,7 +177,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             {
                 request.AddFormParameter("paused", false);
             }
-            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Pause)
+            else if ((QBittorrentState)settings.InitialState == QBittorrentState.Stop)
             {
                 request.AddFormParameter("paused", true);
             }
@@ -213,7 +213,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             catch (DownloadClientException ex)
             {
                 // if setCategory fails due to method not being found, then try older setLabel command for qBittorrent < v.3.3.5
-                if (ex.InnerException is HttpException && (ex.InnerException as HttpException).Response.StatusCode == HttpStatusCode.NotFound)
+                if (ex.InnerException is HttpException httpException && httpException.Response.StatusCode == HttpStatusCode.NotFound)
                 {
                     var setLabelRequest = BuildRequest(settings).Resource("/command/setLabel")
                                                                 .Post()
@@ -255,29 +255,13 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
             catch (DownloadClientException ex)
             {
                 // qBittorrent rejects all Prio commands with 403: Forbidden if Options -> BitTorrent -> Torrent Queueing is not enabled
-                if (ex.InnerException is HttpException && (ex.InnerException as HttpException).Response.StatusCode == HttpStatusCode.Forbidden)
+                if (ex.InnerException is HttpException httpException && httpException.Response.StatusCode == HttpStatusCode.Forbidden)
                 {
                     return;
                 }
 
                 throw;
             }
-        }
-
-        public void PauseTorrent(string hash, QBittorrentSettings settings)
-        {
-            var request = BuildRequest(settings).Resource("/command/pause")
-                                                 .Post()
-                                                 .AddFormParameter("hash", hash);
-            ProcessRequest(request, settings);
-        }
-
-        public void ResumeTorrent(string hash, QBittorrentSettings settings)
-        {
-            var request = BuildRequest(settings).Resource("/command/resume")
-                                                .Post()
-                                                .AddFormParameter("hash", hash);
-            ProcessRequest(request, settings);
         }
 
         public void SetForceStart(string hash, bool enabled, QBittorrentSettings settings)

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentState.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentState.cs
@@ -1,9 +1,16 @@
+using NzbDrone.Core.Annotations;
+
 namespace NzbDrone.Core.Download.Clients.QBittorrent
 {
     public enum QBittorrentState
     {
+        [FieldOption(Label = "Started")]
         Start = 0,
+
+        [FieldOption(Label = "Force Started")]
         ForceStart = 1,
-        Pause = 2
+
+        [FieldOption(Label = "Stopped")]
+        Stop = 2
     }
 }

--- a/src/NzbDrone.Core/Instrumentation/DatabaseTarget.cs
+++ b/src/NzbDrone.Core/Instrumentation/DatabaseTarget.cs
@@ -57,33 +57,36 @@ namespace NzbDrone.Core.Instrumentation
         {
             try
             {
-                var log = new Log();
-                log.Time = logEvent.TimeStamp;
-                log.Message = CleanseLogMessage.Cleanse(logEvent.FormattedMessage);
-
-                log.Logger = logEvent.LoggerName;
+                var log = new Log
+                {
+                    Time = logEvent.TimeStamp,
+                    Logger = logEvent.LoggerName,
+                    Level = logEvent.Level.Name
+                };
 
                 if (log.Logger.StartsWith("NzbDrone."))
                 {
                     log.Logger = log.Logger.Remove(0, 9);
                 }
 
+                var message = logEvent.FormattedMessage;
+
                 if (logEvent.Exception != null)
                 {
-                    if (string.IsNullOrWhiteSpace(log.Message))
+                    if (string.IsNullOrWhiteSpace(message))
                     {
-                        log.Message = logEvent.Exception.Message;
+                        message = logEvent.Exception.Message;
                     }
                     else
                     {
-                        log.Message += ": " + logEvent.Exception.Message;
+                        message += ": " + logEvent.Exception.Message;
                     }
 
-                    log.Exception = logEvent.Exception.ToString();
+                    log.Exception = CleanseLogMessage.Cleanse(logEvent.Exception.ToString());
                     log.ExceptionType = logEvent.Exception.GetType().ToString();
                 }
 
-                log.Level = logEvent.Level.Name;
+                log.Message = CleanseLogMessage.Cleanse(message);
 
                 var connectionInfo = _connectionStringFactory.LogDbConnection;
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeFileMovingService.cs
@@ -12,6 +12,7 @@ using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.Organizer;
 using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.RootFolders;
 using NzbDrone.Core.Tv;
 
 namespace NzbDrone.Core.MediaFiles
@@ -32,6 +33,7 @@ namespace NzbDrone.Core.MediaFiles
         private readonly IDiskProvider _diskProvider;
         private readonly IMediaFileAttributeService _mediaFileAttributeService;
         private readonly IImportScript _scriptImportDecider;
+        private readonly IRootFolderService _rootFolderService;
         private readonly IEventAggregator _eventAggregator;
         private readonly IConfigService _configService;
         private readonly Logger _logger;
@@ -43,6 +45,7 @@ namespace NzbDrone.Core.MediaFiles
                                 IDiskProvider diskProvider,
                                 IMediaFileAttributeService mediaFileAttributeService,
                                 IImportScript scriptImportDecider,
+                                IRootFolderService rootFolderService,
                                 IEventAggregator eventAggregator,
                                 IConfigService configService,
                                 Logger logger)
@@ -54,6 +57,7 @@ namespace NzbDrone.Core.MediaFiles
             _diskProvider = diskProvider;
             _mediaFileAttributeService = mediaFileAttributeService;
             _scriptImportDecider = scriptImportDecider;
+            _rootFolderService = rootFolderService;
             _eventAggregator = eventAggregator;
             _configService = configService;
             _logger = logger;
@@ -173,7 +177,17 @@ namespace NzbDrone.Core.MediaFiles
         {
             var episodeFolder = Path.GetDirectoryName(filePath);
             var seriesFolder = series.Path;
-            var rootFolder = new OsPath(seriesFolder).Directory.FullPath;
+            var rootFolder = _rootFolderService.GetBestRootFolderPath(seriesFolder);
+
+            if (rootFolder.IsNullOrWhiteSpace())
+            {
+                throw new RootFolderNotFoundException($"Root folder was not found, '{seriesFolder}' is not a subdirectory of a defined root folder.");
+            }
+
+            if (!_diskProvider.FolderExists(rootFolder))
+            {
+                throw new RootFolderNotFoundException($"Root folder '{rootFolder}' was not found.");
+            }
 
             var changed = false;
             var newEvent = new EpisodeFolderCreatedEvent(series, episodeFile);

--- a/src/NzbDrone.Core/Messaging/Commands/CommandQueueManager.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/CommandQueueManager.cs
@@ -106,6 +106,8 @@ namespace NzbDrone.Core.Messaging.Commands
             _logger.Trace("Publishing {0}", command.Name);
             _logger.Trace("Checking if command is queued or started: {0}", command.Name);
 
+            command.Trigger = trigger;
+
             lock (_commandQueue)
             {
                 var existingCommands = QueuedOrStarted(command.Name);
@@ -142,7 +144,6 @@ namespace NzbDrone.Core.Messaging.Commands
             var command = GetCommand(commandName);
             command.LastExecutionTime = lastExecutionTime;
             command.LastStartTime = lastStartTime;
-            command.Trigger = trigger;
 
             return Push(command, priority, trigger);
         }
@@ -244,13 +245,13 @@ namespace NzbDrone.Core.Messaging.Commands
             _repo.Trim();
         }
 
-        private dynamic GetCommand(string commandName)
+        private Command GetCommand(string commandName)
         {
             commandName = commandName.Split('.').Last();
             var commands = _knownTypes.GetImplementations(typeof(Command));
             var commandType = commands.Single(c => c.Name.Equals(commandName, StringComparison.InvariantCultureIgnoreCase));
 
-            return Json.Deserialize("{}", commandType);
+            return Json.Deserialize("{}", commandType) as Command;
         }
 
         private void Update(CommandModel command, CommandStatus status, string message)

--- a/src/Whisparr.Api.V3/Commands/CommandController.cs
+++ b/src/Whisparr.Api.V3/Commands/CommandController.cs
@@ -66,9 +66,8 @@ namespace Whisparr.Api.V3.Commands
                     ? CommandPriority.High
                     : CommandPriority.Normal;
 
-                dynamic command = STJson.Deserialize(body, commandType);
+                var command = STJson.Deserialize(body, commandType) as Command;
 
-                command.Trigger = CommandTrigger.Manual;
                 command.SuppressMessages = !command.SendUpdatesToClient;
                 command.SendUpdatesToClient = true;
                 command.ClientUserAgent = Request.Headers["UserAgent"];

--- a/src/Whisparr.Api.V3/DownloadClient/DownloadClientController.cs
+++ b/src/Whisparr.Api.V3/DownloadClient/DownloadClientController.cs
@@ -1,4 +1,5 @@
 using NzbDrone.Core.Download;
+using NzbDrone.SignalR;
 using Whisparr.Http;
 
 namespace Whisparr.Api.V3.DownloadClient
@@ -9,8 +10,8 @@ namespace Whisparr.Api.V3.DownloadClient
         public static readonly DownloadClientResourceMapper ResourceMapper = new ();
         public static readonly DownloadClientBulkResourceMapper BulkResourceMapper = new ();
 
-        public DownloadClientController(IDownloadClientFactory downloadClientFactory)
-            : base(downloadClientFactory, "downloadclient", ResourceMapper, BulkResourceMapper)
+        public DownloadClientController(IBroadcastSignalRMessage signalRBroadcaster, IDownloadClientFactory downloadClientFactory)
+            : base(signalRBroadcaster, downloadClientFactory, "downloadclient", ResourceMapper, BulkResourceMapper)
         {
         }
     }

--- a/src/Whisparr.Api.V3/ImportLists/ImportListController.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListController.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using NzbDrone.Core.ImportLists;
 using NzbDrone.Core.Validation;
 using NzbDrone.Core.Validation.Paths;
+using NzbDrone.SignalR;
 using Whisparr.Http;
 
 namespace Whisparr.Api.V3.ImportLists
@@ -12,8 +13,11 @@ namespace Whisparr.Api.V3.ImportLists
         public static readonly ImportListResourceMapper ResourceMapper = new ();
         public static readonly ImportListBulkResourceMapper BulkResourceMapper = new ();
 
-        public ImportListController(IImportListFactory importListFactory, RootFolderExistsValidator rootFolderExistsValidator, ProfileExistsValidator profileExistsValidator)
-            : base(importListFactory, "importlist", ResourceMapper, BulkResourceMapper)
+        public ImportListController(IBroadcastSignalRMessage signalRBroadcaster,
+            IImportListFactory importListFactory,
+            RootFolderExistsValidator rootFolderExistsValidator,
+            ProfileExistsValidator profileExistsValidator)
+            : base(signalRBroadcaster, importListFactory, "importlist", ResourceMapper, BulkResourceMapper)
         {
             SharedValidator.RuleFor(c => c.RootFolderPath).Cascade(CascadeMode.Stop)
                 .IsValidPath()

--- a/src/Whisparr.Api.V3/Indexers/IndexerController.cs
+++ b/src/Whisparr.Api.V3/Indexers/IndexerController.cs
@@ -1,5 +1,6 @@
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Validation;
+using NzbDrone.SignalR;
 using Whisparr.Http;
 
 namespace Whisparr.Api.V3.Indexers
@@ -10,8 +11,10 @@ namespace Whisparr.Api.V3.Indexers
         public static readonly IndexerResourceMapper ResourceMapper = new ();
         public static readonly IndexerBulkResourceMapper BulkResourceMapper = new ();
 
-        public IndexerController(IndexerFactory indexerFactory, DownloadClientExistsValidator downloadClientExistsValidator)
-            : base(indexerFactory, "indexer", ResourceMapper, BulkResourceMapper)
+        public IndexerController(IBroadcastSignalRMessage signalRBroadcaster,
+            IndexerFactory indexerFactory,
+            DownloadClientExistsValidator downloadClientExistsValidator)
+            : base(signalRBroadcaster, indexerFactory, "indexer", ResourceMapper, BulkResourceMapper)
         {
             SharedValidator.RuleFor(c => c.DownloadClientId).SetValidator(downloadClientExistsValidator);
         }

--- a/src/Whisparr.Api.V3/Metadata/MetadataController.cs
+++ b/src/Whisparr.Api.V3/Metadata/MetadataController.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Extras.Metadata;
+using NzbDrone.SignalR;
 using Whisparr.Http;
 
 namespace Whisparr.Api.V3.Metadata
@@ -11,8 +12,8 @@ namespace Whisparr.Api.V3.Metadata
         public static readonly MetadataResourceMapper ResourceMapper = new ();
         public static readonly MetadataBulkResourceMapper BulkResourceMapper = new ();
 
-        public MetadataController(IMetadataFactory metadataFactory)
-            : base(metadataFactory, "metadata", ResourceMapper, BulkResourceMapper)
+        public MetadataController(IBroadcastSignalRMessage signalRBroadcaster, IMetadataFactory metadataFactory)
+            : base(signalRBroadcaster, metadataFactory, "metadata", ResourceMapper, BulkResourceMapper)
         {
         }
 

--- a/src/Whisparr.Api.V3/Notifications/NotificationController.cs
+++ b/src/Whisparr.Api.V3/Notifications/NotificationController.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.Notifications;
+using NzbDrone.SignalR;
 using Whisparr.Http;
 
 namespace Whisparr.Api.V3.Notifications
@@ -11,8 +12,8 @@ namespace Whisparr.Api.V3.Notifications
         public static readonly NotificationResourceMapper ResourceMapper = new ();
         public static readonly NotificationBulkResourceMapper BulkResourceMapper = new ();
 
-        public NotificationController(NotificationFactory notificationFactory)
-            : base(notificationFactory, "notification", ResourceMapper, BulkResourceMapper)
+        public NotificationController(IBroadcastSignalRMessage signalRBroadcaster, NotificationFactory notificationFactory)
+            : base(signalRBroadcaster, notificationFactory, "notification", ResourceMapper, BulkResourceMapper)
         {
         }
 

--- a/src/Whisparr.Api.V3/ProviderControllerBase.cs
+++ b/src/Whisparr.Api.V3/ProviderControllerBase.cs
@@ -5,14 +5,21 @@ using FluentValidation.Results;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Datastore.Events;
+using NzbDrone.Core.Messaging.Events;
 using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.ThingiProvider.Events;
 using NzbDrone.Core.Validation;
+using NzbDrone.SignalR;
 using Whisparr.Http.REST;
 using Whisparr.Http.REST.Attributes;
 
 namespace Whisparr.Api.V3
 {
-    public abstract class ProviderControllerBase<TProviderResource, TBulkProviderResource, TProvider, TProviderDefinition> : RestController<TProviderResource>
+    public abstract class ProviderControllerBase<TProviderResource, TBulkProviderResource, TProvider, TProviderDefinition> : RestControllerWithSignalR<TProviderResource, TProviderDefinition>,
+        IHandle<ProviderAddedEvent<TProvider>>,
+        IHandle<ProviderUpdatedEvent<TProvider>>,
+        IHandle<ProviderDeletedEvent<TProvider>>
         where TProviderDefinition : ProviderDefinition, new()
         where TProvider : IProvider
         where TProviderResource : ProviderResource<TProviderResource>, new()
@@ -22,11 +29,13 @@ namespace Whisparr.Api.V3
         private readonly ProviderResourceMapper<TProviderResource, TProviderDefinition> _resourceMapper;
         private readonly ProviderBulkResourceMapper<TBulkProviderResource, TProviderDefinition> _bulkResourceMapper;
 
-        protected ProviderControllerBase(IProviderFactory<TProvider,
+        protected ProviderControllerBase(IBroadcastSignalRMessage signalRBroadcaster,
+            IProviderFactory<TProvider,
             TProviderDefinition> providerFactory,
             string resource,
             ProviderResourceMapper<TProviderResource, TProviderDefinition> resourceMapper,
             ProviderBulkResourceMapper<TBulkProviderResource, TProviderDefinition> bulkResourceMapper)
+            : base(signalRBroadcaster)
         {
             _providerFactory = providerFactory;
             _resourceMapper = resourceMapper;
@@ -263,6 +272,24 @@ namespace Whisparr.Api.V3
             var data = _providerFactory.RequestAction(providerDefinition, name, query);
 
             return Content(data.ToJson(), "application/json");
+        }
+
+        [NonAction]
+        public virtual void Handle(ProviderAddedEvent<TProvider> message)
+        {
+            BroadcastResourceChange(ModelAction.Created, message.Definition.Id);
+        }
+
+        [NonAction]
+        public virtual void Handle(ProviderUpdatedEvent<TProvider> message)
+        {
+            BroadcastResourceChange(ModelAction.Updated, message.Definition.Id);
+        }
+
+        [NonAction]
+        public virtual void Handle(ProviderDeletedEvent<TProvider> message)
+        {
+            BroadcastResourceChange(ModelAction.Deleted, message.ProviderId);
         }
 
         private void Validate(TProviderDefinition definition, bool includeWarnings)

--- a/src/Whisparr.Api.V3/ProviderControllerBase.cs
+++ b/src/Whisparr.Api.V3/ProviderControllerBase.cs
@@ -86,9 +86,16 @@ namespace Whisparr.Api.V3
         [RestPutById]
         [Consumes("application/json")]
         [Produces("application/json")]
-        public ActionResult<TProviderResource> UpdateProvider([FromBody] TProviderResource providerResource, [FromQuery] bool forceSave = false)
+        public ActionResult<TProviderResource> UpdateProvider([FromRoute] int id, [FromBody] TProviderResource providerResource, [FromQuery] bool forceSave = false)
         {
-            var existingDefinition = _providerFactory.Find(providerResource.Id);
+            // TODO: Remove fallback to Id from body in next API version bump
+            var existingDefinition = _providerFactory.Find(id) ?? _providerFactory.Find(providerResource.Id);
+
+            if (existingDefinition == null)
+            {
+                return NotFound();
+            }
+
             var providerDefinition = GetDefinition(providerResource, existingDefinition, true, !forceSave, false);
 
             // Comparing via JSON string to eliminate the need for every provider implementation to implement equality checks.
@@ -107,7 +114,7 @@ namespace Whisparr.Api.V3
                 _providerFactory.Update(providerDefinition);
             }
 
-            return Accepted(providerResource.Id);
+            return Accepted(existingDefinition.Id);
         }
 
         [HttpPut("bulk")]

--- a/src/Whisparr.Api.V3/Series/SeriesController.cs
+++ b/src/Whisparr.Api.V3/Series/SeriesController.cs
@@ -185,9 +185,8 @@ namespace Whisparr.Api.V3.Series
                 {
                     SeriesId = series.Id,
                     SourcePath = sourcePath,
-                    DestinationPath = destinationPath,
-                    Trigger = CommandTrigger.Manual
-                });
+                    DestinationPath = destinationPath
+                }, trigger: CommandTrigger.Manual);
             }
 
             var model = seriesResource.ToModel(series);

--- a/src/Whisparr.Api.V3/Series/SeriesController.cs
+++ b/src/Whisparr.Api.V3/Series/SeriesController.cs
@@ -68,26 +68,34 @@ namespace Whisparr.Api.V3.Series
             _commandQueueManager = commandQueueManager;
             _rootFolderService = rootFolderService;
 
-            Http.Validation.RuleBuilderExtensions.ValidId(SharedValidator.RuleFor(s => s.QualityProfileId));
-
-            SharedValidator.RuleFor(s => s.Path)
-                .Cascade(CascadeMode.Stop)
+            SharedValidator.RuleFor(s => s.Path).Cascade(CascadeMode.Stop)
                 .IsValidPath()
-                           .SetValidator(rootFolderValidator)
-                           .SetValidator(mappedNetworkDriveValidator)
-                           .SetValidator(seriesPathValidator)
-                           .SetValidator(seriesAncestorValidator)
-                           .SetValidator(systemFolderValidator)
-                           .When(s => !s.Path.IsNullOrWhiteSpace());
+                .SetValidator(rootFolderValidator)
+                .SetValidator(mappedNetworkDriveValidator)
+                .SetValidator(seriesPathValidator)
+                .SetValidator(seriesAncestorValidator)
+                .SetValidator(systemFolderValidator)
+                .When(s => s.Path.IsNotNullOrWhiteSpace());
 
-            SharedValidator.RuleFor(s => s.QualityProfileId).SetValidator(profileExistsValidator);
+            PostValidator.RuleFor(s => s.Path).Cascade(CascadeMode.Stop)
+                .NotEmpty()
+                .IsValidPath()
+                .When(s => s.RootFolderPath.IsNullOrWhiteSpace());
+            PostValidator.RuleFor(s => s.RootFolderPath).Cascade(CascadeMode.Stop)
+                .NotEmpty()
+                .IsValidPath()
+                .SetValidator(rootFolderExistsValidator)
+                .SetValidator(seriesFolderAsRootFolderValidator)
+                .When(s => s.Path.IsNullOrWhiteSpace());
 
-            PostValidator.RuleFor(s => s.Path).IsValidPath().When(s => s.RootFolderPath.IsNullOrWhiteSpace());
-            PostValidator.RuleFor(s => s.RootFolderPath)
-                         .IsValidPath()
-                         .SetValidator(rootFolderExistsValidator)
-                         .SetValidator(seriesFolderAsRootFolderValidator)
-                         .When(s => s.Path.IsNullOrWhiteSpace());
+            PutValidator.RuleFor(s => s.Path).Cascade(CascadeMode.Stop)
+                .NotEmpty()
+                .IsValidPath();
+
+            SharedValidator.RuleFor(s => s.QualityProfileId).Cascade(CascadeMode.Stop)
+                .ValidId()
+                .SetValidator(profileExistsValidator);
+
             PostValidator.RuleFor(s => s.Title).NotEmpty();
             PostValidator.RuleFor(s => s.TvdbId).GreaterThan(0).SetValidator(seriesExistsValidator);
         }

--- a/src/Whisparr.Http/Middleware/UrlBaseMiddleware.cs
+++ b/src/Whisparr.Http/Middleware/UrlBaseMiddleware.cs
@@ -20,6 +20,8 @@ namespace Whisparr.Http.Middleware
             if (_urlBase.IsNotNullOrWhiteSpace() && context.Request.PathBase.Value.IsNullOrWhiteSpace())
             {
                 context.Response.Redirect($"{_urlBase}{context.Request.Path}{context.Request.QueryString}");
+                context.Response.StatusCode = 307;
+
                 return;
             }
 


### PR DESCRIPTION
16 commits from Sonarr's October 2024 range. Each is a separate cherry-pick keeping its original author and linking back to the upstream commit.

Notable: qBittorrent v5.0 initial state, real-time UI updates for provider changes, 307 redirect for requests missing URL Base, and several path-validation and root-folder fixes.

Skipped: translations and generated API docs (policy), frontend-only changes, and commits depending on models Whisparr replaced — episode numbering for .plexmatch mappings, anime absolute numbering, and upstream's TV-oriented FileList categories.

Deferred: Sonarr/Sonarr@8a558b379 (maintain '...' in naming format) — it touches FileNameBuilder, where Whisparr's colon replacement runs at a different point in the pipeline than Sonarr's, so the ellipsis placeholder lands wrong. Needs focused work rather than a conflict resolution.