### PR TITLE
Chore: Sonarr Upstream Sync - Webhook Headers

### DIFF
--- a/frontend/src/Components/Form/ProviderFieldFormGroup.js
+++ b/frontend/src/Components/Form/ProviderFieldFormGroup.js
@@ -14,6 +14,8 @@ function getType({ type, selectOptionsProviderAction }) {
       return inputTypes.CHECK;
     case 'device':
       return inputTypes.DEVICE;
+    case 'keyValueList':
+      return inputTypes.KEY_VALUE_LIST;
     case 'password':
       return inputTypes.PASSWORD;
     case 'number':

--- a/frontend/src/typings/inputs.ts
+++ b/frontend/src/typings/inputs.ts
@@ -3,4 +3,6 @@ export type InputChanged<T = unknown> = {
   value: T;
 };
 
+export type InputOnChange<T> = (change: InputChanged<T>) => void;
+
 export type CheckInputChanged = InputChanged<boolean>;

--- a/src/NzbDrone.Common/Reflection/ReflectionExtensions.cs
+++ b/src/NzbDrone.Common/Reflection/ReflectionExtensions.cs
@@ -34,7 +34,8 @@ namespace NzbDrone.Common.Reflection
                    || type == typeof(string)
                    || type == typeof(DateTime)
                    || type == typeof(Version)
-                   || type == typeof(decimal);
+                   || type == typeof(decimal)
+                   || (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>));
         }
 
         public static bool IsReadable(this PropertyInfo propertyInfo)

--- a/src/NzbDrone.Core/Annotations/FieldDefinitionAttribute.cs
+++ b/src/NzbDrone.Core/Annotations/FieldDefinitionAttribute.cs
@@ -68,7 +68,9 @@ namespace NzbDrone.Core.Annotations
         Device,
         TagSelect,
         RootFolder,
-        QualityProfile
+        QualityProfile,
+        SeriesTag,
+        KeyValueList,
     }
 
     public enum HiddenType

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookProxy.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookProxy.cs
@@ -43,6 +43,11 @@ namespace NzbDrone.Core.Notifications.Webhook
                     request.Credentials = new BasicNetworkCredential(settings.Username, settings.Password);
                 }
 
+                foreach (var header in settings.Headers)
+                {
+                    request.Headers.Add(header.Key, header.Value);
+                }
+
                 _httpClient.Execute(request);
             }
             catch (HttpException ex)

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using FluentValidation;
 using NzbDrone.Core.Annotations;
 using NzbDrone.Core.Validation;
@@ -20,6 +21,7 @@ namespace NzbDrone.Core.Notifications.Webhook
         public WebhookSettings()
         {
             Method = Convert.ToInt32(WebhookMethod.POST);
+            Headers = new List<KeyValuePair<string, string>>();
         }
 
         [FieldDefinition(0, Label = "URL", Type = FieldType.Url)]
@@ -33,6 +35,9 @@ namespace NzbDrone.Core.Notifications.Webhook
 
         [FieldDefinition(3, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password)]
         public string Password { get; set; }
+
+        [FieldDefinition(4, Label = "Headers", Type = FieldType.KeyValueList, Advanced = true)]
+        public IEnumerable<KeyValuePair<string, string>> Headers { get; set; }
 
         public override NzbDroneValidationResult Validate()
         {


### PR DESCRIPTION
Brings in a commit dropped from Batch 19, whose frontend referenced a type Whisparr does not have.

- Add `InputOnChange` to `typings/inputs` — Whisparr had `InputChanged` but not the handler type upstream's form inputs use.
- New: Add headers setting in webhook connection — Sonarr/Sonarr@78fb20282

Whisparr's own `KeyValueListInput.js` is kept rather than taking upstream's `.tsx` conversion, and the Headers field uses a literal English label to match the `URL`/`Method`/`Username` fields beside it.

Sonarr/Sonarr@c62fc9d05 (Kometa file creation disabled) was attempted here and dropped again: its frontend is a full TypeScript conversion of the Metadata settings pages and needs a typed `selectSettings`, which Whisparr does not have. It also deletes `typings/Pending.ts`, which Whisparr still imports. Kometa targets mainstream film and TV metadata and is deprecated upstream, so chasing a second TS conversion for it is not worth it.