### PR TITLE
Chore: Sonarr Upstream Sync - Bump to .NET 8

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -99,7 +99,10 @@ runs:
         if [[ "${runtime}" == freebsd* ]]; then
           echo "FreeBSD target detected - using framework-dependent publish to avoid missing apphost"
           SELF_CONTAINED=false
-          MSBUILD_EXTRA="-p:UseAppHost=false"
+          # The FreeBSD runtime pack comes from the dotnet-bsd-crossbuild feed,
+          # which lags the SDK's own patch level. Without this the restore asks
+          # for the SDK's runtime version and fails with NU1102.
+          MSBUILD_EXTRA="-p:UseAppHost=false -p:RuntimeFrameworkVersion=${FREEBSD_RUNTIME_VERSION:-8.0.27}"
         fi
         dotnet msbuild -restore $slnFile -p:SelfContained=${SELF_CONTAINED} -p:Configuration=Release -p:Platform=$platform -p:RuntimeIdentifiers=$runtime -p:EnableWindowsTargeting=true $MSBUILD_EXTRA -t:PublishAllRids
 

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Setup Environment Variables
       id: variables

--- a/.github/actions/package/package.sh
+++ b/.github/actions/package/package.sh
@@ -3,7 +3,7 @@
 outputFolder=_output
 artifactsFolder=_artifacts
 uiFolder="$outputFolder/UI"
-framework="${FRAMEWORK:=net6.0}"
+framework="${FRAMEWORK:=net8.0}"
 
 # Sanitize BRANCH for safe file names (replace / with _)
 safeBranch="${BRANCH//\//_}"

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Setup Postgres
       if: ${{ inputs.use_postgres }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FRAMEWORK: net6.0
+  FRAMEWORK: net8.0
   RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   WHISPARR_MAJOR_VERSION: 2
   VERSION: 2.2.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,27 +119,27 @@ stages:
         artifact: '$(osName)Backend'
         displayName: Publish Backend
         condition: and(succeeded(), eq(variables['osName'], 'Windows'))
-      - publish: '$(testsFolder)/net6.0/win-x64/publish'
+      - publish: '$(testsFolder)/net8.0/win-x64/publish'
         artifact: win-x64-tests
         displayName: Publish win-x64 Test Package
         condition: and(succeeded(), eq(variables['osName'], 'Windows'))
-      - publish: '$(testsFolder)/net6.0/linux-x64/publish'
+      - publish: '$(testsFolder)/net8.0/linux-x64/publish'
         artifact: linux-x64-tests
         displayName: Publish linux-x64 Test Package
         condition: and(succeeded(), eq(variables['osName'], 'Windows'))
-      - publish: '$(testsFolder)/net6.0/linux-x86/publish'
+      - publish: '$(testsFolder)/net8.0/linux-x86/publish'
         artifact: linux-x86-tests
         displayName: Publish linux-x86 Test Package
         condition: and(succeeded(), eq(variables['osName'], 'Windows'))
-      - publish: '$(testsFolder)/net6.0/linux-musl-x64/publish'
+      - publish: '$(testsFolder)/net8.0/linux-musl-x64/publish'
         artifact: linux-musl-x64-tests
         displayName: Publish linux-musl-x64 Test Package
         condition: and(succeeded(), eq(variables['osName'], 'Windows'))
-      - publish: '$(testsFolder)/net6.0/freebsd-x64/publish'
+      - publish: '$(testsFolder)/net8.0/freebsd-x64/publish'
         artifact: freebsd-x64-tests
         displayName: Publish freebsd-x64 Test Package
         condition: and(succeeded(), eq(variables['osName'], 'Windows'))
-      - publish: '$(testsFolder)/net6.0/osx-x64/publish'
+      - publish: '$(testsFolder)/net8.0/osx-x64/publish'
         artifact: osx-x64-tests
         displayName: Publish osx-x64 Test Package
         condition: and(succeeded(), eq(variables['osName'], 'Windows'))
@@ -257,21 +257,21 @@ stages:
           archiveFile: '$(Build.ArtifactStagingDirectory)/Whisparr.$(buildName).windows-core-x64.zip'
           archiveType: 'zip'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/win-x64/net6.0
+          rootFolderOrFile: $(artifactsFolder)/win-x64/net8.0
       - task: ArchiveFiles@2
         displayName: Create win-x86 zip
         inputs:
           archiveFile: '$(Build.ArtifactStagingDirectory)/Whisparr.$(buildName).windows-core-x86.zip'
           archiveType: 'zip'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/win-x86/net6.0
+          rootFolderOrFile: $(artifactsFolder)/win-x86/net8.0
       - task: ArchiveFiles@2
         displayName: Create osx-x64 app
         inputs:
           archiveFile: '$(Build.ArtifactStagingDirectory)/Whisparr.$(buildName).osx-app-core-x64.zip'
           archiveType: 'zip'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/osx-x64-app/net6.0
+          rootFolderOrFile: $(artifactsFolder)/osx-x64-app/net8.0
       - task: ArchiveFiles@2
         displayName: Create osx-x64 tar
         inputs:
@@ -279,14 +279,14 @@ stages:
           archiveType: 'tar'
           tarCompression: 'gz'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/osx-x64/net6.0
+          rootFolderOrFile: $(artifactsFolder)/osx-x64/net8.0
       - task: ArchiveFiles@2
         displayName: Create osx-arm64 app
         inputs:
           archiveFile: '$(Build.ArtifactStagingDirectory)/Whisparr.$(buildName).osx-app-core-arm64.zip'
           archiveType: 'zip'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/osx-arm64-app/net6.0
+          rootFolderOrFile: $(artifactsFolder)/osx-arm64-app/net8.0
       - task: ArchiveFiles@2
         displayName: Create osx-arm64 tar
         inputs:
@@ -294,7 +294,7 @@ stages:
           archiveType: 'tar'
           tarCompression: 'gz'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/osx-arm64/net6.0
+          rootFolderOrFile: $(artifactsFolder)/osx-arm64/net8.0
       - task: ArchiveFiles@2
         displayName: Create linux-x64 tar
         inputs:
@@ -302,7 +302,7 @@ stages:
           archiveType: 'tar'
           tarCompression: 'gz'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/linux-x64/net6.0
+          rootFolderOrFile: $(artifactsFolder)/linux-x64/net8.0
       - task: ArchiveFiles@2
         displayName: Create linux-musl-x64 tar
         inputs:
@@ -310,7 +310,7 @@ stages:
           archiveType: 'tar'
           tarCompression: 'gz'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/linux-musl-x64/net6.0
+          rootFolderOrFile: $(artifactsFolder)/linux-musl-x64/net8.0
       - task: ArchiveFiles@2
         displayName: Create linux-x86 tar
         inputs:
@@ -318,7 +318,7 @@ stages:
           archiveType: 'tar'
           tarCompression: 'gz'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/linux-x86/net6.0
+          rootFolderOrFile: $(artifactsFolder)/linux-x86/net8.0
       - task: ArchiveFiles@2
         displayName: Create linux-arm tar
         inputs:
@@ -326,7 +326,7 @@ stages:
           archiveType: 'tar'
           tarCompression: 'gz'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/linux-arm/net6.0
+          rootFolderOrFile: $(artifactsFolder)/linux-arm/net8.0
       - task: ArchiveFiles@2
         displayName: Create linux-musl-arm tar
         inputs:
@@ -334,7 +334,7 @@ stages:
           archiveType: 'tar'
           tarCompression: 'gz'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/linux-musl-arm/net6.0
+          rootFolderOrFile: $(artifactsFolder)/linux-musl-arm/net8.0
       - task: ArchiveFiles@2
         displayName: Create linux-arm64 tar
         inputs:
@@ -342,7 +342,7 @@ stages:
           archiveType: 'tar'
           tarCompression: 'gz'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/linux-arm64/net6.0
+          rootFolderOrFile: $(artifactsFolder)/linux-arm64/net8.0
       - task: ArchiveFiles@2
         displayName: Create linux-musl-arm64 tar
         inputs:
@@ -350,7 +350,7 @@ stages:
           archiveType: 'tar'
           tarCompression: 'gz'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/linux-musl-arm64/net6.0
+          rootFolderOrFile: $(artifactsFolder)/linux-musl-arm64/net8.0
       - task: ArchiveFiles@2
         displayName: Create freebsd-x64 tar
         inputs:
@@ -358,7 +358,7 @@ stages:
           archiveType: 'tar'
           tarCompression: 'gz'
           includeRootFolder: false
-          rootFolderOrFile: $(artifactsFolder)/freebsd-x64/net6.0
+          rootFolderOrFile: $(artifactsFolder)/freebsd-x64/net8.0
       - publish: $(Build.ArtifactStagingDirectory)
         artifact: 'Packages'
         displayName: Publish Packages

--- a/build.sh
+++ b/build.sh
@@ -79,9 +79,9 @@ Build()
 
     if [[ -z "$RID" || -z "$FRAMEWORK" ]];
     then
-        dotnet msbuild -restore $slnFile -p:Configuration=Release -p:Platform=$platform -t:PublishAllRids
+        dotnet msbuild -restore $slnFile -p:SelfContained=True -p:Configuration=Release -p:Platform=$platform -t:PublishAllRids
     else
-        dotnet msbuild -restore $slnFile -p:Configuration=Release -p:Platform=$platform -p:RuntimeIdentifiers=$RID -t:PublishAllRids
+        dotnet msbuild -restore $slnFile -p:SelfContained=True -p:Configuration=Release -p:Platform=$platform -p:RuntimeIdentifiers=$RID -t:PublishAllRids
     fi
 
     ProgressEnd 'Build'
@@ -137,7 +137,7 @@ PackageLinux()
 
     echo "Adding Whisparr.Mono to UpdatePackage"
     cp $folder/Whisparr.Mono.* $folder/Whisparr.Update
-    if [ "$framework" = "net6.0" ]; then
+    if [ "$framework" = "net8.0" ]; then
         cp $folder/Mono.Posix.NETStandard.* $folder/Whisparr.Update
         cp $folder/libMonoPosixHelper.* $folder/Whisparr.Update
     fi
@@ -165,7 +165,7 @@ PackageMacOS()
 
     echo "Adding Whisparr.Mono to UpdatePackage"
     cp $folder/Whisparr.Mono.* $folder/Whisparr.Update
-    if [ "$framework" = "net6.0" ]; then
+    if [ "$framework" = "net8.0" ]; then
         cp $folder/Mono.Posix.NETStandard.* $folder/Whisparr.Update
         cp $folder/libMonoPosixHelper.* $folder/Whisparr.Update
     fi
@@ -377,15 +377,15 @@ then
     Build
     if [[ -z "$RID" || -z "$FRAMEWORK" ]];
     then
-        PackageTests "net6.0" "win-x64"
-        PackageTests "net6.0" "win-x86"
-        PackageTests "net6.0" "linux-x64"
-        PackageTests "net6.0" "linux-musl-x64"
-        PackageTests "net6.0" "osx-x64"
+        PackageTests "net8.0" "win-x64"
+        PackageTests "net8.0" "win-x86"
+        PackageTests "net8.0" "linux-x64"
+        PackageTests "net8.0" "linux-musl-x64"
+        PackageTests "net8.0" "osx-x64"
         if [ "$ENABLE_EXTRA_PLATFORMS" = "YES" ];
         then
-            PackageTests "net6.0" "freebsd-x64"
-            PackageTests "net6.0" "linux-x86"
+            PackageTests "net8.0" "freebsd-x64"
+            PackageTests "net8.0" "linux-x86"
         fi
     else
         PackageTests "$FRAMEWORK" "$RID"
@@ -414,20 +414,20 @@ then
 
     if [[ -z "$RID" || -z "$FRAMEWORK" ]];
     then
-        Package "net6.0" "win-x64"
-        Package "net6.0" "win-x86"
-        Package "net6.0" "linux-x64"
-        Package "net6.0" "linux-musl-x64"
-        Package "net6.0" "linux-arm64"
-        Package "net6.0" "linux-musl-arm64"
-        Package "net6.0" "linux-arm"
-        Package "net6.0" "linux-musl-arm"
-        Package "net6.0" "osx-x64"
-        Package "net6.0" "osx-arm64"
+        Package "net8.0" "win-x64"
+        Package "net8.0" "win-x86"
+        Package "net8.0" "linux-x64"
+        Package "net8.0" "linux-musl-x64"
+        Package "net8.0" "linux-arm64"
+        Package "net8.0" "linux-musl-arm64"
+        Package "net8.0" "linux-arm"
+        Package "net8.0" "linux-musl-arm"
+        Package "net8.0" "osx-x64"
+        Package "net8.0" "osx-arm64"
         if [ "$ENABLE_EXTRA_PLATFORMS" = "YES" ];
         then
-            Package "net6.0" "freebsd-x64"
-            Package "net6.0" "linux-x86"
+            Package "net8.0" "freebsd-x64"
+            Package "net8.0" "linux-x86"
         fi
     else
         Package "$FRAMEWORK" "$RID"
@@ -437,7 +437,7 @@ fi
 if [ "$INSTALLER" = "YES" ];
 then
     InstallInno
-    BuildInstaller "net6.0" "win-x64"
-    BuildInstaller "net6.0" "win-x86"
+    BuildInstaller "net8.0" "win-x64"
+    BuildInstaller "net8.0" "win-x86"
     RemoveInno
 fi

--- a/docs.sh
+++ b/docs.sh
@@ -29,7 +29,7 @@ dotnet msbuild -restore $slnFile -p:Configuration=Debug -p:Platform=$platform -p
 dotnet new tool-manifest
 dotnet tool install --version 6.3.0 Swashbuckle.AspNetCore.Cli
 
-dotnet tool run swagger tofile --output ./src/Whisparr.Api.V3/openapi.json "$outputFolder/net6.0/$RUNTIME/whisparr.console.dll" v3 &
+dotnet tool run swagger tofile --output ./src/Whisparr.Api.V3/openapi.json "$outputFolder/net8.0/$RUNTIME/whisparr.console.dll" v3 &
 
 sleep 45
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@fortawesome/free-solid-svg-icons": "6.7.1",
     "@fortawesome/react-fontawesome": "0.2.2",
     "@juggle/resize-observer": "3.4.0",
-    "@microsoft/signalr": "6.0.21",
+    "@microsoft/signalr": "8.0.7",
     "@sentry/browser": "7.119.1",
     "@sentry/integrations": "7.51.2",
     "@types/node": "20.16.11",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -100,14 +100,14 @@
 
   <!-- Standard testing packages -->
   <ItemGroup Condition="'$(TestProject)'=='true'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="3.0.131" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TestProject)'=='true' and '$(TargetFramework)'=='net6.0'">
+  <ItemGroup Condition="'$(TestProject)'=='true' and '$(TargetFramework)'=='net8.0'">
     <PackageReference Include="coverlet.collector" Version="3.0.4-preview.27.ge7cb7c3b40" />
   </ItemGroup>
 

--- a/src/NzbDrone.Api.Test/Whisparr.Api.Test.csproj
+++ b/src/NzbDrone.Api.Test/Whisparr.Api.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NBuilder" Version="6.1.0" />

--- a/src/NzbDrone.Automation.Test/Whisparr.Automation.Test.csproj
+++ b/src/NzbDrone.Automation.Test/Whisparr.Automation.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Selenium.Support" Version="3.141.0" />

--- a/src/NzbDrone.Common.Test/DiskTests/DirectoryLookupServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DirectoryLookupServiceFixture.cs
@@ -49,7 +49,7 @@ namespace NzbDrone.Common.Test.DiskTests
                 .Setup(s => s.GetDirectoryInfos(It.IsAny<string>()))
                 .Returns(_folders);
 
-            Subject.LookupContents(root, false, false).Directories.Should().NotContain(Path.Combine(root, RECYCLING_BIN));
+            Subject.LookupContents(root, false, false).Directories.Should().NotContain(dir => dir.Path == Path.Combine(root, RECYCLING_BIN));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace NzbDrone.Common.Test.DiskTests
                 .Setup(s => s.GetDirectoryInfos(It.IsAny<string>()))
                 .Returns(_folders);
 
-            Subject.LookupContents(root, false, false).Directories.Should().NotContain(Path.Combine(root, SYSTEM_VOLUME_INFORMATION));
+            Subject.LookupContents(root, false, false).Directories.Should().NotContain(dir => dir.Path == Path.Combine(root, SYSTEM_VOLUME_INFORMATION));
         }
 
         [Test]

--- a/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/DiskTests/DiskTransferServiceFixture.cs
@@ -603,7 +603,7 @@ namespace NzbDrone.Common.Test.DiskTests
 
             var count = Subject.MirrorFolder(source.FullName, destination.FullName);
 
-            count.Should().Equals(0);
+            count.Should().Be(0);
             destination.GetFileSystemInfos().Should().BeEmpty();
         }
 
@@ -623,7 +623,7 @@ namespace NzbDrone.Common.Test.DiskTests
 
             var count = Subject.MirrorFolder(source.FullName, destination.FullName);
 
-            count.Should().Equals(0);
+            count.Should().Be(0);
             destination.GetFileSystemInfos().Should().HaveCount(1);
         }
 
@@ -640,7 +640,7 @@ namespace NzbDrone.Common.Test.DiskTests
 
             var count = Subject.MirrorFolder(source.FullName, destination.FullName);
 
-            count.Should().Equals(3);
+            count.Should().Be(3);
             VerifyCopyFolder(original.FullName, destination.FullName);
         }
 
@@ -657,7 +657,7 @@ namespace NzbDrone.Common.Test.DiskTests
 
             var count = Subject.MirrorFolder(source.FullName, destination.FullName);
 
-            count.Should().Equals(3);
+            count.Should().Be(3);
 
             File.Exists(Path.Combine(destination.FullName, _nfsFile)).Should().BeFalse();
         }
@@ -677,7 +677,7 @@ namespace NzbDrone.Common.Test.DiskTests
 
             var count = Subject.MirrorFolder(source.FullName, destination.FullName);
 
-            count.Should().Equals(0);
+            count.Should().Be(0);
             VerifyCopyFolder(original.FullName, destination.FullName);
         }
 
@@ -694,7 +694,7 @@ namespace NzbDrone.Common.Test.DiskTests
 
             var count = Subject.MirrorFolder(source.FullName + Path.DirectorySeparatorChar, destination.FullName);
 
-            count.Should().Equals(3);
+            count.Should().Be(3);
             VerifyCopyFolder(original.FullName, destination.FullName);
         }
 

--- a/src/NzbDrone.Common.Test/TPLTests/RateLimitServiceFixture.cs
+++ b/src/NzbDrone.Common.Test/TPLTests/RateLimitServiceFixture.cs
@@ -120,7 +120,7 @@ namespace NzbDrone.Common.Test.TPLTests
 
             Subject.WaitAndPulse("me", "sub", TimeSpan.FromMilliseconds(100));
 
-            (GetRateLimitStore()["me"] - _epoch).Should().BeCloseTo(TimeSpan.FromMilliseconds(200));
+            (GetRateLimitStore()["me"] - _epoch).Should().BeCloseTo(TimeSpan.FromMilliseconds(200), TimeSpan.FromMilliseconds(50));
         }
     }
 }

--- a/src/NzbDrone.Common.Test/Whisparr.Common.Test.csproj
+++ b/src/NzbDrone.Common.Test/Whisparr.Common.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Host\Whisparr.Host.csproj" />

--- a/src/NzbDrone.Common/Disk/DestinationAlreadyExistsException.cs
+++ b/src/NzbDrone.Common/Disk/DestinationAlreadyExistsException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Runtime.Serialization;
 
 namespace NzbDrone.Common.Disk
 {
@@ -22,11 +21,6 @@ namespace NzbDrone.Common.Disk
 
         public DestinationAlreadyExistsException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        protected DestinationAlreadyExistsException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/src/NzbDrone.Common/EnvironmentInfo/AppFolderFactory.cs
+++ b/src/NzbDrone.Common/EnvironmentInfo/AppFolderFactory.cs
@@ -38,6 +38,7 @@ namespace NzbDrone.Common.EnvironmentInfo
         {
             try
             {
+                MigrateAppDataFolder();
                 _diskProvider.EnsureFolder(_appFolderInfo.AppDataFolder);
             }
             catch (UnauthorizedAccessException)
@@ -56,6 +57,28 @@ namespace NzbDrone.Common.EnvironmentInfo
             }
 
             InitializeMonoApplicationData();
+        }
+
+        private void MigrateAppDataFolder()
+        {
+            try
+            {
+                if (OsInfo.IsOsx)
+                {
+                    var userAppDataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.DoNotVerify), ".config", "Whisparr");
+
+                    if (_diskProvider.FolderExists(userAppDataFolder) && !_diskProvider.FileExists(_appFolderInfo.GetConfigPath()))
+                    {
+                        _diskTransferService.MirrorFolder(userAppDataFolder, _appFolderInfo.AppDataFolder);
+                        _diskProvider.DeleteFolder(userAppDataFolder, true);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, ex.Message);
+                throw new WhisparrStartupException(ex, "Unable to migrate AppData folder to {0}. Migrate manually", _appFolderInfo.AppDataFolder);
+            }
         }
 
         public void SetPermissions()

--- a/src/NzbDrone.Common/Whisparr.Common.csproj
+++ b/src/NzbDrone.Common/Whisparr.Common.csproj
@@ -1,26 +1,26 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <DefineConstants Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64' or '$(RuntimeIdentifier)' == 'linux-musl-arm64'">ISMUSL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="5.4.1" />
     <PackageReference Include="IPAddressRange" Version="6.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="NLog.Targets.Syslog" Version="6.0.3" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
     <PackageReference Include="Sentry" Version="3.23.1" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="System.Text.Json" Version="6.0.10" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.1" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="EnsureThat\Resources\ExceptionMessages.Designer.cs">

--- a/src/NzbDrone.Console/Whisparr.Console.csproj
+++ b/src/NzbDrone.Console/Whisparr.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
 
     <ApplicationIcon>..\NzbDrone.Host\Whisparr.ico</ApplicationIcon>
   </PropertyGroup>

--- a/src/NzbDrone.Core.Test/Datastore/BasicRepositoryFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/BasicRepositoryFixture.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Test.Datastore
         {
             AssertionOptions.AssertEquivalencyUsing(options =>
             {
-                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation.ToUniversalTime())).WhenTypeIs<DateTime>();
+                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation.ToUniversalTime(), TimeSpan.FromSeconds(1))).WhenTypeIs<DateTime>();
                 return options;
             });
 

--- a/src/NzbDrone.Core.Test/Datastore/DatabaseRelationshipFixture.cs
+++ b/src/NzbDrone.Core.Test/Datastore/DatabaseRelationshipFixture.cs
@@ -21,8 +21,8 @@ namespace NzbDrone.Core.Test.Datastore
         {
             AssertionOptions.AssertEquivalencyUsing(options =>
             {
-                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation.ToUniversalTime())).WhenTypeIs<DateTime>();
-                options.Using<DateTime?>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation.Value.ToUniversalTime())).WhenTypeIs<DateTime?>();
+                options.Using<DateTime>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation.ToUniversalTime(), TimeSpan.FromSeconds(1))).WhenTypeIs<DateTime>();
+                options.Using<DateTime?>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation.Value.ToUniversalTime(), TimeSpan.FromSeconds(1))).WhenTypeIs<DateTime?>();
                 return options;
             });
         }

--- a/src/NzbDrone.Core.Test/SeriesStatsTests/SeriesStatisticsFixture.cs
+++ b/src/NzbDrone.Core.Test/SeriesStatsTests/SeriesStatisticsFixture.cs
@@ -78,7 +78,7 @@ namespace NzbDrone.Core.Test.SeriesStatsTests
             var stats = Subject.SeriesStatistics();
 
             stats.Should().HaveCount(1);
-            stats.First().NextAiring.Should().BeCloseTo(_episode.AirDateUtc.Value, 1000);
+            stats.First().NextAiring.Should().BeCloseTo(_episode.AirDateUtc.Value, TimeSpan.FromSeconds(1));
             stats.First().PreviousAiring.Should().NotHaveValue();
         }
 
@@ -105,7 +105,7 @@ namespace NzbDrone.Core.Test.SeriesStatsTests
 
             stats.Should().HaveCount(1);
             stats.First().NextAiring.Should().NotHaveValue();
-            stats.First().PreviousAiring.Should().BeCloseTo(_episode.AirDateUtc.Value, 1000);
+            stats.First().PreviousAiring.Should().BeCloseTo(_episode.AirDateUtc.Value, TimeSpan.FromSeconds(1));
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
   </ItemGroup>

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/RecycleBinException.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/RecycleBinException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Runtime.Serialization;
 
 namespace NzbDrone.Core.MediaFiles.EpisodeImport
 {
@@ -17,11 +16,6 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
         public RecycleBinException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        protected RecycleBinException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/RootFolderNotFoundException.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/RootFolderNotFoundException.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Runtime.Serialization;
 
 namespace NzbDrone.Core.MediaFiles.EpisodeImport
 {
@@ -17,11 +16,6 @@ namespace NzbDrone.Core.MediaFiles.EpisodeImport
 
         public RootFolderNotFoundException(string message, Exception innerException)
             : base(message, innerException)
-        {
-        }
-
-        protected RootFolderNotFoundException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -1,23 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Diacritical.Net" Version="1.0.4" />
     <PackageReference Include="Equ" Version="2.3.0" />
-    <PackageReference Include="MailKit" Version="4.8.0" />
-    <!-- Accepting GHSA-9j88-vvj5-vhgr: fixed in MailKit 4.16.0, but that drops net6.0 support via MimeKit. Whisparr only uses MailKit for outbound SMTP, not parsing untrusted STARTTLS responses. -->
+    <PackageReference Include="MailKit" Version="4.9.0" />
+    <!-- Accepting GHSA-9j88-vvj5-vhgr: fixed in MailKit 4.16.0, but that drops net8.0 support via MimeKit. Whisparr only uses MailKit for outbound SMTP, not parsing untrusted STARTTLS responses. -->
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-9j88-vvj5-vhgr" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="6.0.21" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.12" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
-    <PackageReference Include="Polly" Version="8.5.0" />
+    <PackageReference Include="Polly" Version="8.5.1" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
     <PackageReference Include="Servarr.FFprobe" Version="5.1.4.112" />
     <PackageReference Include="System.Memory" Version="4.6.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Servarr.FluentMigrator.Runner" Version="3.3.2.9" />
     <PackageReference Include="Servarr.FluentMigrator.Runner.SQLite" Version="3.3.2.9" />
     <PackageReference Include="Servarr.FluentMigrator.Runner.Postgres" Version="3.3.2.9" />
@@ -27,8 +27,8 @@
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="MonoTorrent" Version="2.0.7" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
-    <PackageReference Include="System.Text.Json" Version="6.0.10" />
-    <PackageReference Include="Npgsql" Version="7.0.9" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="Semver" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -6,9 +6,7 @@
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="Diacritical.Net" Version="1.0.4" />
     <PackageReference Include="Equ" Version="2.3.0" />
-    <PackageReference Include="MailKit" Version="4.9.0" />
-    <!-- Accepting GHSA-9j88-vvj5-vhgr: fixed in MailKit 4.16.0, but that drops net8.0 support via MimeKit. Whisparr only uses MailKit for outbound SMTP, not parsing untrusted STARTTLS responses. -->
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-9j88-vvj5-vhgr" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.12" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.1.7" />
     <PackageReference Include="Polly" Version="8.5.1" />

--- a/src/NzbDrone.Host.Test/Whisparr.Host.Test.csproj
+++ b/src/NzbDrone.Host.Test/Whisparr.Host.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Host\Whisparr.Host.csproj" />

--- a/src/NzbDrone.Host/Whisparr.Host.csproj
+++ b/src/NzbDrone.Host/Whisparr.Host.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="6.0.21" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="6.0.1" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
     <PackageReference Include="DryIoc.dll" Version="5.4.1" />
     <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.0" />
   </ItemGroup>

--- a/src/NzbDrone.Integration.Test/Whisparr.Integration.Test.csproj
+++ b/src/NzbDrone.Integration.Test/Whisparr.Integration.Test.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.21" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.12" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />

--- a/src/NzbDrone.Libraries.Test/Whisparr.Libraries.Test.csproj
+++ b/src/NzbDrone.Libraries.Test/Whisparr.Libraries.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />

--- a/src/NzbDrone.Mono.Test/Whisparr.Mono.Test.csproj
+++ b/src/NzbDrone.Mono.Test/Whisparr.Mono.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <!--
        The netstandard version here doesn't work in net framework

--- a/src/NzbDrone.Mono/Whisparr.Mono.csproj
+++ b/src/NzbDrone.Mono/Whisparr.Mono.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <!-- 

--- a/src/NzbDrone.SignalR/Whisparr.SignalR.csproj
+++ b/src/NzbDrone.SignalR/Whisparr.SignalR.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/NzbDrone.Test.Common/NzbDroneRunner.cs
+++ b/src/NzbDrone.Test.Common/NzbDroneRunner.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Test.Common
 
             if (BuildInfo.IsDebug)
             {
-                Start(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "_output", "net6.0", consoleExe));
+                Start(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "_output", "net8.0", consoleExe));
             }
             else
             {

--- a/src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NLog" Version="4.7.14" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NzbDrone.Test.Dummy/Whisparr.Test.Dummy.csproj
+++ b/src/NzbDrone.Test.Dummy/Whisparr.Test.Dummy.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/NzbDrone.Update.Test/Whisparr.Update.Test.csproj
+++ b/src/NzbDrone.Update.Test/Whisparr.Update.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />

--- a/src/NzbDrone.Update/Whisparr.Update.csproj
+++ b/src/NzbDrone.Update/Whisparr.Update.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DryIoc.dll" Version="5.4.1" />

--- a/src/NzbDrone.Windows.Test/Whisparr.Windows.Test.csproj
+++ b/src/NzbDrone.Windows.Test/Whisparr.Windows.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common.Test\Whisparr.Common.Test.csproj" />

--- a/src/NzbDrone.Windows/Whisparr.Windows.csproj
+++ b/src/NzbDrone.Windows/Whisparr.Windows.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>

--- a/src/NzbDrone/Whisparr.csproj
+++ b/src/NzbDrone/Whisparr.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>..\NzbDrone.Host\Whisparr.ico</ApplicationIcon>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Host\Whisparr.Host.csproj" />

--- a/src/ServiceHelpers/ServiceInstall/ServiceInstall.csproj
+++ b/src/ServiceHelpers/ServiceInstall/ServiceInstall.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Security.Principal.Windows" Version="6.0.0-preview.5.21301.5" />

--- a/src/ServiceHelpers/ServiceUninstall/ServiceUninstall.csproj
+++ b/src/ServiceHelpers/ServiceUninstall/ServiceUninstall.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Security.Principal.Windows" Version="6.0.0-preview.5.21301.5" />

--- a/src/Whisparr.Api.V3/Queue/QueueController.cs
+++ b/src/Whisparr.Api.V3/Queue/QueueController.cs
@@ -177,10 +177,10 @@ namespace Whisparr.Api.V3.Queue
             var filteredQueue = includeUnknownSeriesItems ? queue : queue.Where(q => q.Series != null);
             var pending = _pendingReleaseService.GetPendingQueue();
 
-            var hasSeriesIdFilter = seriesIds.Any();
-            var hasLanguageFilter = languages.Any();
-            var hasQualityFilter = quality.Any();
-            var hasStatusFilter = status.Any();
+            var hasSeriesIdFilter = seriesIds is { Count: > 0 };
+            var hasLanguageFilter = languages is { Count: > 0 };
+            var hasQualityFilter = quality is { Count: > 0 };
+            var hasStatusFilter = status is { Count: > 0 };
 
             var fullQueue = filteredQueue.Concat(pending).Where(q =>
             {

--- a/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
+++ b/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.5.4" />

--- a/src/Whisparr.Http/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/src/Whisparr.Http/Authentication/ApiKeyAuthenticationHandler.cs
@@ -28,9 +28,8 @@ namespace Whisparr.Http.Authentication
         public ApiKeyAuthenticationHandler(IOptionsMonitor<ApiKeyAuthenticationOptions> options,
             ILoggerFactory logger,
             UrlEncoder encoder,
-            ISystemClock clock,
             IConfigFileProvider config)
-            : base(options, logger, encoder, clock)
+            : base(options, logger, encoder)
         {
             _apiKey = config.ApiKey;
         }

--- a/src/Whisparr.Http/Authentication/BasicAuthenticationHandler.cs
+++ b/src/Whisparr.Http/Authentication/BasicAuthenticationHandler.cs
@@ -20,9 +20,8 @@ namespace Whisparr.Http.Authentication
         public BasicAuthenticationHandler(IAuthenticationService authService,
             IOptionsMonitor<AuthenticationSchemeOptions> options,
             ILoggerFactory logger,
-            UrlEncoder encoder,
-            ISystemClock clock)
-            : base(options, logger, encoder, clock)
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
         {
             _authService = authService;
         }
@@ -71,7 +70,7 @@ namespace Whisparr.Http.Authentication
 
         protected override Task HandleChallengeAsync(AuthenticationProperties properties)
         {
-            Response.Headers.Add("WWW-Authenticate", $"Basic realm=\"{BuildInfo.AppName}\"");
+            Response.Headers["WWW-Authenticate"] = $"Basic realm=\"{BuildInfo.AppName}\"";
             Response.StatusCode = 401;
             return Task.CompletedTask;
         }

--- a/src/Whisparr.Http/Authentication/NoAuthenticationHandler.cs
+++ b/src/Whisparr.Http/Authentication/NoAuthenticationHandler.cs
@@ -13,9 +13,8 @@ namespace Whisparr.Http.Authentication
     {
         public NoAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
             ILoggerFactory logger,
-            UrlEncoder encoder,
-            ISystemClock clock)
-            : base(options, logger, encoder, clock)
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
         {
         }
 

--- a/src/Whisparr.Http/Middleware/VersionMiddleware.cs
+++ b/src/Whisparr.Http/Middleware/VersionMiddleware.cs
@@ -22,7 +22,7 @@ namespace Whisparr.Http.Middleware
         {
             if (context.Request.IsApiRequest() && !context.Response.Headers.ContainsKey(VERSIONHEADER))
             {
-                context.Response.Headers.Add(VERSIONHEADER, _version);
+                context.Response.Headers[VERSIONHEADER] = _version;
             }
 
             await _next(context);

--- a/src/Whisparr.Http/REST/RestController.cs
+++ b/src/Whisparr.Http/REST/RestController.cs
@@ -106,7 +106,7 @@ namespace Whisparr.Http.REST
             if (controllerAttributes.Any(x => x.AttributeType == DEPRECATED_ATTRIBUTE) || attributes.Any(x => x.AttributeType == DEPRECATED_ATTRIBUTE))
             {
                 _logger.Warn("API call made to deprecated endpoint from {0}", Request.Headers.UserAgent.ToString());
-                Response.Headers.Add("Deprecation", "true");
+                Response.Headers["Deprecation"] = "true";
             }
 
             base.OnActionExecuting(context);

--- a/src/Whisparr.Http/Whisparr.Http.csproj
+++ b/src/Whisparr.Http/Whisparr.Http.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.5.4" />
-    <PackageReference Include="ImpromptuInterface" Version="7.0.1" />
+    <PackageReference Include="ImpromptuInterface" Version="8.0.6" />
     <PackageReference Include="NLog" Version="4.7.14" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Whisparr.RuntimePatches/Whisparr.RuntimePatches.csproj
+++ b/src/Whisparr.RuntimePatches/Whisparr.RuntimePatches.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">  
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>  
   <ItemGroup>
     <PackageReference Include="Lib.Harmony" Version="2.3.5" />

--- a/test.sh
+++ b/test.sh
@@ -40,8 +40,11 @@ if [ "$PLATFORM" = "Windows" ]; then
 elif [ "$PLATFORM" = "Linux" ] || [ "$PLATFORM" = "Mac" ] ; then
   mkdir -p ~/.config/Whisparr
   WHERE="$WHERE&Category!=WINDOWS"
+elif  [ "$PLATFORM" = "Mac" ]; then
+  mkdir -p ~/Library/Application\ Support/Sonarr
+  WHERE="$WHERE&Category!=WINDOWS"
 else
-  echo "Platform must be provided as first arguement: Windows, Linux or Mac"
+  echo "Platform must be provided as first argument: Windows, Linux or Mac"
   exit 1
 fi
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,14 +1180,14 @@
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
   integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
-"@microsoft/signalr@6.0.21":
-  version "6.0.21"
-  resolved "https://registry.yarnpkg.com/@microsoft/signalr/-/signalr-6.0.21.tgz#b45f335df7011abba831cb3d7974b58da7e725c7"
-  integrity sha512-3MWhSUE7AxkQs3QBuJ/spJJpg1mAHo0/6yRGhs5+Hew3Z+iqYrHVfo0yTElC7W2bVA9t3fW3jliQ9rBN0OvJLA==
+"@microsoft/signalr@8.0.7":
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/@microsoft/signalr/-/signalr-8.0.7.tgz#94419ddbf9418753e493f4ae4c13990316ec2ea5"
+  integrity sha512-PHcdMv8v5hJlBkRHAuKG5trGViQEkPYee36LnJQx4xHOQ5LL4X0nEWIxOp5cCtZ7tu+30quz5V3k0b1YNuc6lw==
   dependencies:
     abort-controller "^3.0.0"
-    eventsource "^1.0.7"
-    fetch-cookie "^0.11.0"
+    eventsource "^2.0.2"
+    fetch-cookie "^2.0.3"
     node-fetch "^2.6.7"
     ws "^7.4.5"
 
@@ -3676,10 +3676,10 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-eventsource@^1.0.7:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-1.1.2.tgz#bc75ae1c60209e7cb1541231980460343eaea7c2"
-  integrity sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA==
+eventsource@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
+  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -3742,12 +3742,13 @@ faye-websocket@~0.10.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fetch-cookie@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/fetch-cookie/-/fetch-cookie-0.11.0.tgz#e046d2abadd0ded5804ce7e2cae06d4331c15407"
-  integrity sha512-BQm7iZLFhMWFy5CZ/162sAGjBfdNWb7a8LEqqnzsHFhxT/X/SVj/z2t2nu3aJvjlbQkrAlTUApplPRjWyH4mhA==
+fetch-cookie@^2.0.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-cookie/-/fetch-cookie-2.2.0.tgz#01086b6b5b1c3e08f15ffd8647b02ca100377365"
+  integrity sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==
   dependencies:
-    tough-cookie "^2.3.3 || ^3.0.1 || ^4.0.0"
+    set-cookie-parser "^2.4.8"
+    tough-cookie "^4.0.0"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -6913,6 +6914,11 @@ serialize-javascript@^6.0.1:
   dependencies:
     randombytes "^2.1.0"
 
+set-cookie-parser@^2.4.8:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz#ccd08673a9ae5d2e44ea2a2de25089e67c7edf68"
+  integrity sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==
+
 set-function-length@^1.2.1, set-function-length@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
@@ -7530,10 +7536,10 @@ to-space-case@^1.0.0:
   dependencies:
     to-no-case "^1.0.0"
 
-"tough-cookie@^2.3.3 || ^3.0.1 || ^4.0.0":
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
-  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
+tough-cookie@^4.0.0:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
+  integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
   dependencies:
     psl "^1.1.33"
     punycode "^2.1.1"


### PR DESCRIPTION
Whisparr moves from **.NET 6 to .NET 8**, following Sonarr's own 6 → 8 → 10 progression. .NET 6 left support in November 2024.

### Commits
- Sonarr/Sonarr@6b9262700 New: Bump to .NET 8
- Sonarr/Sonarr@f4f3fdfb0 New: Migrate appdata folder for .NET 8 on OSX
- Take the fixed MailKit and drop a security suppression (see below)

### What changed
Target framework across every project, the CI SDK version, `azure-pipelines.yml` paths, the build and test scripts, and the package set .NET 8 requires — `Microsoft.Extensions.*` 6.x to 8.x, `System.Text.Json`, `Npgsql`, `Dapper`, `NUnit`, `Microsoft.NET.Test.Sdk`. `Microsoft.SourceLink.GitHub` and `Microsoft.AspNetCore.Owin` are gone; .NET 8 provides the first and no longer needs the second.

### Whisparr adaptations
- Every conflict took Whisparr's side (project names, namespaces, config paths), then the framework retarget, the package bumps and the removals were applied on top. Versions were **compared, not assigned** — Whisparr had already taken later bumps for several packages, and a straight take-theirs would have walked them backwards.
- **macOS appdata migration**: on .NET 8 `SpecialFolder.ApplicationData` resolves to `~/Library/Application Support`, stranding an existing install's config under `~/.config/Whisparr`. Whisparr has no legacy-folder migration at all, so only the OSX half of upstream's method applies, pointed at Whisparr's own folder. **Without this, macOS users lose their configuration on upgrade.**
- **FluentAssertions 5.10.3 → 6.12.0** is a two-major jump for Whisparr (upstream went 6.10 → 6.12). Eight call sites needed updating: `BeCloseTo` now takes an explicit precision, and collection assertions compare elements rather than paths.
- **MailKit**: the `GHSA-9j88-vvj5-vhgr` suppression existed only because the fixed release drops net6.0 through MimeKit. On net8.0 that constraint is gone, so MailKit goes to 4.17.0 (upstream's version) and the suppression is deleted — a real advisory closed rather than accepted.

### Verified running, not just building
A build says the code compiles; it does not say Whisparr starts. Launched against a clean data directory on .NET 8:

```
appName          Whisparr
runtimeVersion   8.0.30
databaseType     sqLite
migrationVersion 216
```

All migrations ran against fresh Main and Log databases, the UI returns 200, and `/api/v3/health` returns 200.

**Worth running against a copy of a real database before merge** — a fresh install exercises the migrations but not an upgrade path.

Build clean with analyzers, frontend lint and production build clean, 3546 tests passing.
