### PR TITLE
Chore: Sonarr Upstream Sync - Add React Query

### DIFF
--- a/frontend/src/App/App.tsx
+++ b/frontend/src/App/App.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ConnectedRouter, ConnectedRouterProps } from 'connected-react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -13,17 +14,21 @@ interface AppProps {
   history: ConnectedRouterProps['history'];
 }
 
+const queryClient = new QueryClient();
+
 function App({ store, history }: AppProps) {
   return (
     <DocumentTitle title={window.Whisparr.instanceName}>
-      <Provider store={store}>
-        <ConnectedRouter history={history}>
-          <ApplyTheme />
-          <PageConnector>
-            <AppRoutes app={App} />
-          </PageConnector>
-        </ConnectedRouter>
-      </Provider>
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <ConnectedRouter history={history}>
+            <ApplyTheme />
+            <PageConnector>
+              <AppRoutes app={App} />
+            </PageConnector>
+          </ConnectedRouter>
+        </Provider>
+      </QueryClientProvider>
     </DocumentTitle>
   );
 }

--- a/frontend/src/Helpers/Hooks/useApiQuery.ts
+++ b/frontend/src/Helpers/Hooks/useApiQuery.ts
@@ -1,0 +1,56 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+interface QueryOptions {
+  url: string;
+  headers?: HeadersInit;
+}
+
+const absUrlRegex = /^(https?:)?\/\//i;
+const apiRoot = window.Whisparr.apiRoot;
+
+function isAbsolute(url: string) {
+  return absUrlRegex.test(url);
+}
+
+function getUrl(url: string) {
+  return apiRoot + url;
+}
+
+function useApiQuery<T>(options: QueryOptions) {
+  const { url, headers } = options;
+
+  const final = useMemo(() => {
+    if (isAbsolute(url)) {
+      return {
+        url,
+        headers,
+      };
+    }
+
+    return {
+      url: getUrl(url),
+      headers: {
+        ...headers,
+        'X-Api-Key': window.Whisparr.apiKey,
+      },
+    };
+  }, [url, headers]);
+
+  return useQuery({
+    queryKey: [final.url],
+    queryFn: async () => {
+      const result = await fetch(final.url, {
+        headers: final.headers,
+      });
+
+      if (!result.ok) {
+        throw new Error('Failed to fetch');
+      }
+
+      return result.json() as T;
+    },
+  });
+}
+
+export default useApiQuery;

--- a/frontend/src/bootstrap.tsx
+++ b/frontend/src/bootstrap.tsx
@@ -9,7 +9,6 @@ import 'Diag/ConsoleApi';
 export async function bootstrap() {
   const history = createBrowserHistory();
   const store = createAppStore(history);
-
   const container = document.getElementById('root');
 
   if (container) {

--- a/frontend/typings/Globals.d.ts
+++ b/frontend/typings/Globals.d.ts
@@ -3,6 +3,7 @@ declare module '*.module.css';
 interface Window {
   Whisparr: {
     apiKey: string;
+    apiRoot: string;
     instanceName: string;
     theme: string;
     urlBase: string;

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "@microsoft/signalr": "8.0.7",
     "@sentry/browser": "7.119.1",
     "@sentry/integrations": "7.51.2",
+    "@tanstack/react-query": "5.61.0",
     "@types/node": "20.16.11",
-    "@types/react": "18.2.79",
-    "@types/react-dom": "18.2.25",
+    "@types/react": "18.3.12",
+    "@types/react-dom": "18.3.1",
     "classnames": "2.5.1",
     "connected-react-router": "6.9.3",
     "element-class": "0.2.2",
@@ -49,7 +50,7 @@
     "normalize.css": "8.0.1",
     "prop-types": "15.8.1",
     "qs": "6.13.0",
-    "react": "18.2.0",
+    "react": "18.3.1",
     "react-addons-shallow-compare": "15.6.3",
     "react-async-script": "1.2.0",
     "react-autosuggest": "10.1.0",
@@ -59,7 +60,7 @@
     "react-dnd-multi-backend": "6.0.2",
     "react-dnd-touch-backend": "14.1.1",
     "react-document-title": "2.0.3",
-    "react-dom": "18.2.0",
+    "react-dom": "18.3.1",
     "react-focus-lock": "2.9.4",
     "react-google-recaptcha": "2.1.0",
     "react-lazyload": "3.2.0",
@@ -155,7 +156,7 @@
     "yarn": "1.22.19"
   },
   "resolutions": {
-    "@types/react": "18.2.79",
-    "@types/react-dom": "18.2.25"
+    "@types/react": "18.3.12",
+    "@types/react-dom": "18.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,6 +1344,18 @@
     "@sentry/types" "7.51.2"
     tslib "^1.9.3"
 
+"@tanstack/query-core@5.60.6":
+  version "5.60.6"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.60.6.tgz#0dd33fe231b0d18bf66d0c615b29899738300658"
+  integrity sha512-tI+k0KyCo1EBJ54vxK1kY24LWj673ujTydCZmzEZKAew4NqZzTaVQJEuaG1qKj2M03kUHN46rchLRd+TxVq/zQ==
+
+"@tanstack/react-query@5.61.0":
+  version "5.61.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.61.0.tgz#73473feb37aa28ceb410e297ee060e18f06f88e0"
+  integrity sha512-SBzV27XAeCRBOQ8QcC94w2H1Md0+LI0gTWwc3qRJoaGuewKn5FNW4LSqwPFJZVEItfhMfGT7RpZuSFXjTi12pQ==
+  dependencies:
+    "@tanstack/query-core" "5.60.6"
+
 "@types/archiver@^5.3.1":
   version "5.3.4"
   resolved "https://registry.yarnpkg.com/@types/archiver/-/archiver-5.3.4.tgz#32172d5a56f165b5b4ac902e366248bf03d3ae84"
@@ -1463,10 +1475,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@18.2.25":
-  version "18.2.25"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.25.tgz#2946a30081f53e7c8d585eb138277245caedc521"
-  integrity sha512-o/V48vf4MQh7juIKZU2QGDfli6p1+OOi5oXx36Hffpc9adsHeXjVp8rHuPkjd8VT8sOJ2Zp05HR7CdpGTIUFUA==
+"@types/react-dom@18.3.1":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.1.tgz#1e4654c08a9cdcfb6594c780ac59b55aad42fe07"
+  integrity sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==
   dependencies:
     "@types/react" "*"
 
@@ -1525,10 +1537,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@18.2.79":
-  version "18.2.79"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.79.tgz#c40efb4f255711f554d47b449f796d1c7756d865"
-  integrity sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==
+"@types/react@*", "@types/react@18.3.12":
+  version "18.3.12"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
+  integrity sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -6222,13 +6234,13 @@ react-document-title@2.0.3:
     prop-types "^15.5.6"
     react-side-effect "^1.0.2"
 
-react-dom@18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
+react-dom@18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
   dependencies:
     loose-envify "^1.1.0"
-    scheduler "^0.23.0"
+    scheduler "^0.23.2"
 
 react-focus-lock@2.9.4:
   version "2.9.4"
@@ -6400,10 +6412,10 @@ react-window@1.8.10:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+react@18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"
+  integrity sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==
   dependencies:
     loose-envify "^1.1.0"
 
@@ -6839,7 +6851,7 @@ sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.23.0:
+scheduler@^0.23.2:
   version "0.23.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
   integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==


### PR DESCRIPTION
Adds `@tanstack/react-query` and moves React to 18.3.1. Six files.

This was deferred back in Batch 19 as "take only if Whisparr wants react-query on its own merits". That framing no longer holds: **it is a hard prerequisite for February's TypeScript conversions.** Upstream's converted `App.tsx` wraps the tree in `QueryClientProvider`, so the Page, Modal, Filter, Menu and Table conversions — and every frontend fix that lands on them afterwards — are blocked behind it. Same accumulating-blockage pattern as the earlier conversions, just larger.

Whisparr was already on React 18, so this is small.

### Whisparr adaptations
- `window.Sonarr` to `window.Whisparr` in the new `useApiQuery` hook.
- The merge left a duplicated `const container` in `bootstrap.tsx`; Whisparr's guarded form is kept over upstream's non-null assertion.
- `index.ts` keeps Whisparr's `typeof parameter === 'string'` guard rather than upstream's form, which assumes a string.
- The `resolutions` pin moved from `@types/react` 18.2.79 to 18.3.12 alongside the dependency bump. Leaving it behind would have forced two different React type trees into the build.

Frontend lint clean and production build clean. No backend files are touched.
