### PR TITLE
Chore: Sonarr Upstream Sync - Upgrade StyleCop.Analyzers to 1.2.0.556

### DIFF
--- a/src/NzbDrone.Api.Test/Whisparr.Api.Test.csproj
+++ b/src/NzbDrone.Api.Test/Whisparr.Api.Test.csproj
@@ -4,6 +4,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NBuilder" Version="6.1.0" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Core\Whisparr.Core.csproj" />

--- a/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
+++ b/src/NzbDrone.Api.Test/v3/Qualities/QualityDefinitionResourceValidatorTest.cs
@@ -8,7 +8,7 @@ namespace NzbDrone.Api.Test.v3.Qualities;
 [Parallelizable(ParallelScope.All)]
 public class QualityDefinitionResourceValidatorTests
 {
-    private readonly QualityDefinitionResourceValidator _validator = new ();
+    private readonly QualityDefinitionResourceValidator _validator = new();
 
     [Test]
     public void Validate_fails_when_min_size_is_below_min_limit()

--- a/src/NzbDrone.Automation.Test/Whisparr.Automation.Test.csproj
+++ b/src/NzbDrone.Automation.Test/Whisparr.Automation.Test.csproj
@@ -5,6 +5,11 @@
   <ItemGroup>
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="137.0.7151.6800" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />

--- a/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
+++ b/src/NzbDrone.Common.Test/Http/HttpClientFixture.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Common.Test.Http
         private string _httpBinHost;
         private string _httpBinHost2;
 
-        private System.Net.Http.HttpClient _httpClient = new ();
+        private System.Net.Http.HttpClient _httpClient = new();
 
         [OneTimeSetUp]
         public void FixtureSetUp()

--- a/src/NzbDrone.Common.Test/Whisparr.Common.Test.csproj
+++ b/src/NzbDrone.Common.Test/Whisparr.Common.Test.csproj
@@ -7,4 +7,12 @@
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />
     <ProjectReference Include="..\NzbDrone.Test.Dummy\Whisparr.Test.Dummy.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
+  </ItemGroup>
+
 </Project>

--- a/src/NzbDrone.Common/Disk/OsPath.cs
+++ b/src/NzbDrone.Common/Disk/OsPath.cs
@@ -296,7 +296,7 @@ namespace NzbDrone.Common.Disk
             return _path.Split(new char[] { '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
-        public static OsPath Null => new (null);
+        public static OsPath Null => new(null);
 
         public override string ToString()
         {

--- a/src/NzbDrone.Common/Extensions/DictionaryExtensions.cs
+++ b/src/NzbDrone.Common/Extensions/DictionaryExtensions.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Common.Extensions
         }
 
         public static IDictionary<TNewKey, TNewValue> SelectDictionary<TKey, TValue, TNewKey, TNewValue>(this IDictionary<TKey, TValue> dictionary,
-            Func<KeyValuePair<TKey, TValue>, ValueTuple<TNewKey, TNewValue>> selection)
+            Func<KeyValuePair<TKey, TValue>, (TNewKey Item1, TNewValue Item2)> selection)
         {
             return dictionary.Select(selection).ToDictionary(t => t.Item1, t => t.Item2);
         }

--- a/src/NzbDrone.Common/Http/HttpResponse.cs
+++ b/src/NzbDrone.Common/Http/HttpResponse.cs
@@ -9,7 +9,7 @@ namespace NzbDrone.Common.Http
 {
     public class HttpResponse
     {
-        private static readonly Regex RegexSetCookie = new ("^(.*?)=(.*?)(?:;|$)", RegexOptions.Compiled);
+        private static readonly Regex RegexSetCookie = new("^(.*?)=(.*?)(?:;|$)", RegexOptions.Compiled);
 
         public HttpResponse(HttpRequest request, HttpHeader headers, byte[] binaryData, HttpStatusCode statusCode = HttpStatusCode.OK, Version version = null)
         {

--- a/src/NzbDrone.Common/Instrumentation/CleanseLogMessage.cs
+++ b/src/NzbDrone.Common/Instrumentation/CleanseLogMessage.cs
@@ -11,56 +11,56 @@ namespace NzbDrone.Common.Instrumentation
         private static readonly Regex[] CleansingRules =
         {
             // Url
-            new (@"(?<=\?|&)(apikey|token|passkey|auth|authkey|user|uid|api|[a-z_]*apikey|account|passwd)=(?<secret>[^&=""]+?)(?=[ ""&=]|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"(?<=\?|&)[^=]*?(username|password)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"rss(24h)?\.torrentleech\.org/(?!rss)(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"torrentleech\.org/rss/download/[0-9]+/(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"iptorrents\.com/[/a-z0-9?&;]*?(?:[?&;](u|tp)=(?<secret>[^&=;]+?))+(?= |;|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"/fetch/[a-z0-9]{32}/(?<secret>[a-z0-9]{32})", RegexOptions.Compiled),
-            new (@"getnzb.*?(?<=\?|&)(r)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"\b(\w*)?(_?(?<!use|get_)token|username|passwo?rd)=(?<secret>[^&=]+?)(?= |&|$|;)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=\?|&)(apikey|token|passkey|auth|authkey|user|uid|api|[a-z_]*apikey|account|passwd)=(?<secret>[^&=""]+?)(?=[ ""&=]|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=\?|&)[^=]*?(username|password)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"rss(24h)?\.torrentleech\.org/(?!rss)(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"torrentleech\.org/rss/download/[0-9]+/(?<secret>[0-9a-z]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"iptorrents\.com/[/a-z0-9?&;]*?(?:[?&;](u|tp)=(?<secret>[^&=;]+?))+(?= |;|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"/fetch/[a-z0-9]{32}/(?<secret>[a-z0-9]{32})", RegexOptions.Compiled),
+            new(@"getnzb.*?(?<=\?|&)(r)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"\b(\w*)?(_?(?<!use|get_)token|username|passwo?rd)=(?<secret>[^&=]+?)(?= |&|$|;)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Trackers Announce Keys; Designed for Qbit Json; should work for all in theory
-            new (@"announce(\.php)?(/|%2f|%3fpasskey%3d)(?<secret>[a-z0-9]{16,})|(?<secret>[a-z0-9]{16,})(/|%2f)announce", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"announce(\.php)?(/|%2f|%3fpasskey%3d)(?<secret>[a-z0-9]{16,})|(?<secret>[a-z0-9]{16,})(/|%2f)announce", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Path
-            new (@"C:\\Users\\(?<secret>[^\""]+?)(\\|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"/(home|Users)/(?<secret>[^/""]+?)(/|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"C:\\Users\\(?<secret>[^\""]+?)(\\|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"/(home|Users)/(?<secret>[^/""]+?)(/|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // NzbGet
-            new (@"""Name""\s*:\s*""[^""]*(username|password)""\s*,\s*""Value""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""Name""\s*:\s*""[^""]*(username|password)""\s*,\s*""Value""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Sabnzbd
-            new (@"""[^""]*(username|password|api_?key|nzb_key)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"""email_(account|to|from|pwd)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""[^""]*(username|password|api_?key|nzb_key)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""email_(account|to|from|pwd)""\s*:\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // uTorrent
-            new (@"\[""[a-z._]*(username|password)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"\[""(boss_key|boss_key_salt|proxy\.proxy)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"\[""[a-z._]*(username|password)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"\[""(boss_key|boss_key_salt|proxy\.proxy)"",\d,""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Deluge
-            new (@"auth.login\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"auth.login\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // BroadcastheNet
-            new (@"""?method""?\s*:\s*""(getTorrents)"",\s*""?params""?\s*:\s*\[\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"getTorrents\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
-            new (@"(?<=\?|&)(authkey|torrent_pass)=(?<secret>[^&=]+?)(?=""|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"""?method""?\s*:\s*""(getTorrents)"",\s*""?params""?\s*:\s*\[\s*""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"getTorrents\(""(?<secret>[^""]+?)""", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=\?|&)(authkey|torrent_pass)=(?<secret>[^&=]+?)(?=""|&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Plex
-            new (@"(?<=\?|&)(X-Plex-Client-Identifier|X-Plex-Token)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"(?<=\?|&)(X-Plex-Client-Identifier|X-Plex-Token)=(?<secret>[^&=]+?)(?= |&|$)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Webhooks
             // Notifiarr
-            new (@"api/v[0-9]/notification/whisparr/(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"api/v[0-9]/notification/whisparr/(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Discord
-            new (@"discord.com/api/webhooks/((?<secret>[\w-]+)/)?(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
+            new(@"discord.com/api/webhooks/((?<secret>[\w-]+)/)?(?<secret>[\w-]+)", RegexOptions.Compiled | RegexOptions.IgnoreCase),
 
             // Telegram
-            new (@"api.telegram.org/bot(?<id>[\d]+):(?<secret>[\w-]+)/", RegexOptions.Compiled | RegexOptions.IgnoreCase)
+            new(@"api.telegram.org/bot(?<id>[\d]+):(?<secret>[\w-]+)/", RegexOptions.Compiled | RegexOptions.IgnoreCase)
         };
 
-        private static readonly Regex CleanseRemoteIPRegex = new (@"(?:Auth-\w+(?<!Failure|Unauthorized) ip|from) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})", RegexOptions.Compiled);
+        private static readonly Regex CleanseRemoteIPRegex = new(@"(?:Auth-\w+(?<!Failure|Unauthorized) ip|from) (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})", RegexOptions.Compiled);
 
         public static string Cleanse(string message)
         {

--- a/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
+++ b/src/NzbDrone.Common/Instrumentation/NzbDroneLogger.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.IO;
 using NLog;
@@ -15,7 +15,7 @@ namespace NzbDrone.Common.Instrumentation
         private const string FileLogLayout = @"${date:format=yyyy-MM-dd HH\:mm\:ss.f}|${level}|${logger}|${message}${onexception:inner=${newline}${newline}[v${assembly-version}] ${exception:format=ToString}${newline}}";
         private const string ConsoleFormat = "[${level}] ${logger}: ${message} ${onexception:inner=${newline}${newline}[v${assembly-version}] ${exception:format=ToString}${newline}}";
 
-        private static readonly CleansingConsoleLogLayout CleansingConsoleLayout = new (ConsoleFormat);
+        private static readonly CleansingConsoleLogLayout CleansingConsoleLayout = new(ConsoleFormat);
 
         private static bool _isConfigured;
 

--- a/src/NzbDrone.Common/TPL/LimitedConcurrencyLevelTaskScheduler.cs
+++ b/src/NzbDrone.Common/TPL/LimitedConcurrencyLevelTaskScheduler.cs
@@ -94,7 +94,8 @@ namespace NzbDrone.Common.TPL
                     {
                         _currentThreadIsProcessingItems = false;
                     }
-                }, null);
+                },
+                null);
         }
 
         /// <summary>Attempts to execute the specified task on the current thread.</summary>

--- a/src/NzbDrone.Common/TPL/TaskExtensions.cs
+++ b/src/NzbDrone.Common/TPL/TaskExtensions.cs
@@ -20,7 +20,8 @@ namespace NzbDrone.Common.TPL
                             Logger.Error(exception, "Task Error");
                         }
                     }
-                }, TaskContinuationOptions.OnlyOnFaulted);
+                },
+                TaskContinuationOptions.OnlyOnFaulted);
 
             return task;
         }

--- a/src/NzbDrone.Common/Whisparr.Common.csproj
+++ b/src/NzbDrone.Common/Whisparr.Common.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
     <PackageReference Include="Sentry" Version="3.23.1" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
@@ -21,6 +25,7 @@
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="EnsureThat\Resources\ExceptionMessages.Designer.cs">

--- a/src/NzbDrone.Console/Whisparr.Console.csproj
+++ b/src/NzbDrone.Console/Whisparr.Console.csproj
@@ -12,4 +12,11 @@
     <ProjectReference Include="..\NzbDrone.Host\Whisparr.Host.csproj" />
     <ProjectReference Include="..\Whisparr.RuntimePatches\Whisparr.RuntimePatches.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
+  </ItemGroup>
 </Project>

--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ImportFixture.cs
@@ -116,17 +116,21 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
         public void should_not_mark_as_imported_if_all_files_were_rejected()
         {
             Mocker.GetMock<IDownloadedEpisodesImportService>()
-                  .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
-                  .Returns(new List<ImportResult>
-                           {
-                               new ImportResult(
-                                   new ImportDecision(
-                                       new LocalEpisode { Path = @"C:\TestPath\Droned.S01E01.mkv", Episodes = { _episode1 } }, new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")), "Test Failure"),
+                .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
+                .Returns(new List<ImportResult>
+                {
+                    new ImportResult(
+                        new ImportDecision(
+                            new LocalEpisode { Path = @"C:\TestPath\Droned.S01E01.mkv", Episodes = { _episode1 } },
+                            new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")),
+                        "Test Failure"),
 
-                               new ImportResult(
-                                   new ImportDecision(
-                                       new LocalEpisode { Path = @"C:\TestPath\Droned.S01E02.mkv", Episodes = { _episode2 } }, new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")), "Test Failure")
-                           });
+                    new ImportResult(
+                        new ImportDecision(
+                            new LocalEpisode { Path = @"C:\TestPath\Droned.S01E02.mkv", Episodes = { _episode2 } },
+                            new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")),
+                        "Test Failure")
+                });
 
             Subject.Import(_trackedDownload);
 
@@ -145,11 +149,13 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
                            {
                                new ImportResult(
                                    new ImportDecision(
-                                       new LocalEpisode { Path = @"C:\TestPath\Droned.S01E01.mkv", Episodes = { _episode1 } }, new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")), "Test Failure"),
+                                       new LocalEpisode { Path = @"C:\TestPath\Droned.S01E01.mkv", Episodes = { _episode1 } }, new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")),
+                                   "Test Failure"),
 
                                new ImportResult(
                                    new ImportDecision(
-                                       new LocalEpisode { Path = @"C:\TestPath\Droned.S01E02.mkv", Episodes = { _episode2 } }, new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")), "Test Failure")
+                                       new LocalEpisode { Path = @"C:\TestPath\Droned.S01E02.mkv", Episodes = { _episode2 } }, new ImportRejection(ImportRejectionReason.Unknown, "Rejected!")),
+                                   "Test Failure")
                            });
 
             _trackedDownload.RemoteEpisode.Episodes.Clear();
@@ -272,16 +278,24 @@ namespace NzbDrone.Core.Test.Download.CompletedDownloadServiceTests
 
             Mocker.GetMock<IDownloadedEpisodesImportService>()
                 .Setup(v => v.ProcessPath(It.IsAny<string>(), It.IsAny<ImportMode>(), It.IsAny<Series>(), It.IsAny<DownloadClientItem>()))
-                .Returns(new List<ImportResult>
-                {
-                    new ImportResult(
-                        new ImportDecision(
-                            new LocalEpisode { Path = @"C:\TestPath\Droned.S01E01.mkv", Episodes = new List<Episode> { episode1 } })),
+                .Returns(
+                    new List<ImportResult>
+                    {
+                        new ImportResult(
+                            new ImportDecision(
+                                new LocalEpisode
+                                {
+                                    Path = @"C:\TestPath\Droned.S01E01.mkv", Episodes = new List<Episode> { episode1 }
+                                })),
 
-                    new ImportResult(
-                        new ImportDecision(
-                            new LocalEpisode { Path = @"C:\TestPath\Droned.S01E02.mkv", Episodes = new List<Episode> { episode2 } }), "Test Failure")
-                });
+                        new ImportResult(
+                            new ImportDecision(
+                                new LocalEpisode
+                                {
+                                    Path = @"C:\TestPath\Droned.S01E02.mkv", Episodes = new List<Episode> { episode2 }
+                                }),
+                            "Test Failure")
+                    });
 
             var history = Builder<EpisodeHistory>.CreateListOfSize(2)
                                                   .BuildList();

--- a/src/NzbDrone.Core.Test/Download/DownloadServiceFixture.cs
+++ b/src/NzbDrone.Core.Test/Download/DownloadServiceFixture.cs
@@ -166,7 +166,8 @@ namespace NzbDrone.Core.Test.Download
 
             Mocker.GetMock<IIndexerStatusService>()
                 .Verify(v => v.RecordFailure(It.IsAny<int>(),
-                    It.IsInRange<TimeSpan>(TimeSpan.FromMinutes(4.9), TimeSpan.FromMinutes(5.1), Moq.Range.Inclusive)), Times.Once());
+                    It.IsInRange<TimeSpan>(TimeSpan.FromMinutes(4.9), TimeSpan.FromMinutes(5.1), Moq.Range.Inclusive)),
+                    Times.Once());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/HealthCheck/Checks/DownloadClientRootFolderCheckFixture.cs
+++ b/src/NzbDrone.Core.Test/HealthCheck/Checks/DownloadClientRootFolderCheckFixture.cs
@@ -84,7 +84,7 @@ namespace NzbDrone.Core.Test.HealthCheck.Checks
 
             GivenRootFolder(rootFolderPath);
 
-            _clientStatus.OutputRootFolders = new List<OsPath> { new (downloadRootPath) };
+            _clientStatus.OutputRootFolders = new List<OsPath> { new(downloadRootPath) };
 
             Subject.Check().ShouldBeWarning();
         }

--- a/src/NzbDrone.Core.Test/MediaFiles/EpisodeFileMovingServiceTests/MoveEpisodeFileFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/EpisodeFileMovingServiceTests/MoveEpisodeFileFixture.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using FizzWare.NBuilder;
@@ -93,7 +93,8 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeFileMovingServiceTests
 
             Mocker.GetMock<IEventAggregator>()
                   .Verify(s => s.PublishEvent<EpisodeFolderCreatedEvent>(It.Is<EpisodeFolderCreatedEvent>(p =>
-                      p.SeriesFolder.IsNotNullOrWhiteSpace())), Times.Once());
+                      p.SeriesFolder.IsNotNullOrWhiteSpace())),
+                      Times.Once());
         }
 
         [Test]
@@ -107,7 +108,8 @@ namespace NzbDrone.Core.Test.MediaFiles.EpisodeFileMovingServiceTests
 
             Mocker.GetMock<IEventAggregator>()
                   .Verify(s => s.PublishEvent<EpisodeFolderCreatedEvent>(It.Is<EpisodeFolderCreatedEvent>(p =>
-                      p.SeriesFolder.IsNotNullOrWhiteSpace())), Times.Never());
+                      p.SeriesFolder.IsNotNullOrWhiteSpace())),
+                      Times.Never());
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetSeriesFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetSeriesFixture.cs
@@ -42,7 +42,8 @@ namespace NzbDrone.Core.Test.ParserTests.ParsingServiceTests
 
             Mocker.GetMock<ISeriesService>()
                   .Verify(s => s.FindByTitle(parsedEpisodeInfo.SeriesTitleInfo.TitleWithoutYear,
-                                             parsedEpisodeInfo.SeriesTitleInfo.Year), Times.Once());
+                                             parsedEpisodeInfo.SeriesTitleInfo.Year),
+                      Times.Once());
         }
 
         [Test]

--- a/src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj
@@ -5,7 +5,12 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="NBuilder" Version="6.1.0" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />

--- a/src/NzbDrone.Core/AutoTagging/Specifications/GenreSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/GenreSpecification.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class GenreSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly GenreSpecificationValidator Validator = new ();
+        private static readonly GenreSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Genre";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/MonitoredSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/MonitoredSpecification.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class MonitoredSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly MonitoredSpecificationValidator Validator = new ();
+        private static readonly MonitoredSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Monitored";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/OriginalLanguageSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/OriginalLanguageSpecification.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class OriginalLanguageSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly OriginalLanguageSpecificationValidator Validator = new ();
+        private static readonly OriginalLanguageSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Original Language";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/QualityProfileSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/QualityProfileSpecification.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class QualityProfileSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly QualityProfileSpecificationValidator Validator = new ();
+        private static readonly QualityProfileSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Quality Profile";

--- a/src/NzbDrone.Core/AutoTagging/Specifications/StatusSpecification.cs
+++ b/src/NzbDrone.Core/AutoTagging/Specifications/StatusSpecification.cs
@@ -11,7 +11,7 @@ namespace NzbDrone.Core.AutoTagging.Specifications
 
     public class StatusSpecification : AutoTaggingSpecificationBase
     {
-        private static readonly StatusSpecificationValidator Validator = new ();
+        private static readonly StatusSpecificationValidator Validator = new();
 
         public override int Order => 1;
         public override string ImplementationName => "Status";

--- a/src/NzbDrone.Core/CustomFormats/Specifications/IndexerFlagSpecification.cs
+++ b/src/NzbDrone.Core/CustomFormats/Specifications/IndexerFlagSpecification.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.CustomFormats
 
     public class IndexerFlagSpecification : CustomFormatSpecificationBase
     {
-        private static readonly IndexerFlagSpecificationValidator Validator = new ();
+        private static readonly IndexerFlagSpecificationValidator Validator = new();
 
         public override int Order => 4;
         public override string ImplementationName => "Indexer Flag";

--- a/src/NzbDrone.Core/Datastore/DatabaseVersionParser.cs
+++ b/src/NzbDrone.Core/Datastore/DatabaseVersionParser.cs
@@ -5,7 +5,7 @@ namespace NzbDrone.Core.Datastore;
 
 public static class DatabaseVersionParser
 {
-    private static readonly Regex VersionRegex = new (@"^[^ ]+", RegexOptions.Compiled);
+    private static readonly Regex VersionRegex = new(@"^[^ ]+", RegexOptions.Compiled);
 
     public static Version ParseServerVersion(string serverVersion)
     {

--- a/src/NzbDrone.Core/DecisionEngine/DownloadSpecDecision.cs
+++ b/src/NzbDrone.Core/DecisionEngine/DownloadSpecDecision.cs
@@ -6,7 +6,7 @@
         public DownloadRejectionReason Reason { get; set; }
         public string Message { get; private set; }
 
-        private static readonly DownloadSpecDecision AcceptDownloadSpecDecision = new () { Accepted = true };
+        private static readonly DownloadSpecDecision AcceptDownloadSpecDecision = new() { Accepted = true };
         private DownloadSpecDecision()
         {
         }

--- a/src/NzbDrone.Core/Download/Clients/Aria2/Aria2Settings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Aria2/Aria2Settings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Download.Clients.Aria2
 
     public class Aria2Settings : DownloadClientSettingsBase<Aria2Settings>
     {
-        private static readonly Aria2SettingsValidator Validator = new ();
+        private static readonly Aria2SettingsValidator Validator = new();
 
         public Aria2Settings()
         {

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackholeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/TorrentBlackholeSettings.cs
@@ -25,7 +25,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
             ReadOnly = true;
         }
 
-        private static readonly TorrentBlackholeSettingsValidator Validator = new ();
+        private static readonly TorrentBlackholeSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "TorrentBlackholeTorrentFolder", Type = FieldType.Path, HelpText = "BlackholeFolderHelpText")]
         [FieldToken(TokenField.HelpText, "TorrentBlackholeTorrentFolder", "extension", ".torrent")]

--- a/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackholeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Blackhole/UsenetBlackholeSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Download.Clients.Blackhole
 
     public class UsenetBlackholeSettings : DownloadClientSettingsBase<UsenetBlackholeSettings>
     {
-        private static readonly UsenetBlackholeSettingsValidator Validator = new ();
+        private static readonly UsenetBlackholeSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "UsenetBlackholeNzbFolder", Type = FieldType.Path, HelpText = "BlackholeFolderHelpText")]
         [FieldToken(TokenField.HelpText, "UsenetBlackholeNzbFolder", "extension", ".nzb")]

--- a/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Deluge/DelugeSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Download.Clients.Deluge
 
     public class DelugeSettings : DownloadClientSettingsBase<DelugeSettings>
     {
-        private static readonly DelugeSettingsValidator Validator = new ();
+        private static readonly DelugeSettingsValidator Validator = new();
 
         public DelugeSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/DownloadStation/DownloadStationSettings.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Download.Clients.DownloadStation
 
     public class DownloadStationSettings : DownloadClientSettingsBase<DownloadStationSettings>
     {
-        private static readonly DownloadStationSettingsValidator Validator = new ();
+        private static readonly DownloadStationSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox)]
         public string Host { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/Flood/FloodSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Flood/FloodSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Download.Clients.Flood
 
     public class FloodSettings : DownloadClientSettingsBase<FloodSettings>
     {
-        private static readonly FloodSettingsValidator Validator = new ();
+        private static readonly FloodSettingsValidator Validator = new();
 
         public FloodSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/FreeboxDownload/FreeboxDownloadSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/FreeboxDownload/FreeboxDownloadSettings.cs
@@ -35,7 +35,7 @@ namespace NzbDrone.Core.Download.Clients.FreeboxDownload
 
     public class FreeboxDownloadSettings : DownloadClientSettingsBase<FreeboxDownloadSettings>
     {
-        private static readonly FreeboxDownloadSettingsValidator Validator = new ();
+        private static readonly FreeboxDownloadSettingsValidator Validator = new();
 
         public FreeboxDownloadSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Hadouken/HadoukenSettings.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Core.Download.Clients.Hadouken
 
     public class HadoukenSettings : DownloadClientSettingsBase<HadoukenSettings>
     {
-        private static readonly HadoukenSettingsValidator Validator = new ();
+        private static readonly HadoukenSettingsValidator Validator = new();
 
         public HadoukenSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/NzbVortex/NzbVortexSettings.cs
@@ -24,7 +24,7 @@ namespace NzbDrone.Core.Download.Clients.NzbVortex
 
     public class NzbVortexSettings : DownloadClientSettingsBase<NzbVortexSettings>
     {
-        private static readonly NzbVortexSettingsValidator Validator = new ();
+        private static readonly NzbVortexSettingsValidator Validator = new();
 
         public NzbVortexSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Nzbget/NzbgetSettings.cs
@@ -22,7 +22,7 @@ namespace NzbDrone.Core.Download.Clients.Nzbget
 
     public class NzbgetSettings : DownloadClientSettingsBase<NzbgetSettings>
     {
-        private static readonly NzbgetSettingsValidator Validator = new ();
+        private static readonly NzbgetSettingsValidator Validator = new();
 
         public NzbgetSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/Pneumatic/PneumaticSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Pneumatic/PneumaticSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Download.Clients.Pneumatic
 
     public class PneumaticSettings : DownloadClientSettingsBase<PneumaticSettings>
     {
-        private static readonly PneumaticSettingsValidator Validator = new ();
+        private static readonly PneumaticSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "DownloadClientPneumaticSettingsNzbFolder", Type = FieldType.Path, HelpText = "DownloadClientPneumaticSettingsNzbFolderHelpText")]
         public string NzbFolder { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/QBittorrent/QBittorrentSettings.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Download.Clients.QBittorrent
 
     public class QBittorrentSettings : DownloadClientSettingsBase<QBittorrentSettings>
     {
-        private static readonly QBittorrentSettingsValidator Validator = new ();
+        private static readonly QBittorrentSettingsValidator Validator = new();
 
         public QBittorrentSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Sabnzbd/SabnzbdSettings.cs
@@ -33,7 +33,7 @@ namespace NzbDrone.Core.Download.Clients.Sabnzbd
 
     public class SabnzbdSettings : DownloadClientSettingsBase<SabnzbdSettings>
     {
-        private static readonly SabnzbdSettingsValidator Validator = new ();
+        private static readonly SabnzbdSettingsValidator Validator = new();
 
         public SabnzbdSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/TorrentSeedConfiguration.cs
+++ b/src/NzbDrone.Core/Download/Clients/TorrentSeedConfiguration.cs
@@ -4,7 +4,7 @@ namespace NzbDrone.Core.Download.Clients
 {
     public class TorrentSeedConfiguration
     {
-        public static TorrentSeedConfiguration DefaultConfiguration = new ();
+        public static TorrentSeedConfiguration DefaultConfiguration = new();
 
         public double? Ratio { get; set; }
         public TimeSpan? SeedTime { get; set; }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionSettings.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
 
     public class TransmissionSettings : DownloadClientSettingsBase<TransmissionSettings>
     {
-        private static readonly TransmissionSettingsValidator Validator = new ();
+        private static readonly TransmissionSettingsValidator Validator = new();
 
         // This constructor is used when creating a new instance, such as the user adding a new Transmission client.
         public TransmissionSettings()

--- a/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/rTorrent/RTorrentSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Download.Clients.RTorrent
 
     public class RTorrentSettings : DownloadClientSettingsBase<RTorrentSettings>
     {
-        private static readonly RTorrentSettingsValidator Validator = new ();
+        private static readonly RTorrentSettingsValidator Validator = new();
 
         public RTorrentSettings()
         {

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrent.cs
@@ -105,7 +105,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
 
         public override string Name => "uTorrent";
 
-        public override ProviderMessage Message => new (_localizationService.GetLocalizedString("DownloadClientUTorrentProviderMessage"), ProviderMessageType.Warning);
+        public override ProviderMessage Message => new(_localizationService.GetLocalizedString("DownloadClientUTorrentProviderMessage"), ProviderMessageType.Warning);
 
         public override IEnumerable<DownloadClientItem> GetItems()
         {

--- a/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
+++ b/src/NzbDrone.Core/Download/Clients/uTorrent/UTorrentSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Download.Clients.UTorrent
 
     public class UTorrentSettings : DownloadClientSettingsBase<UTorrentSettings>
     {
-        private static readonly UTorrentSettingsValidator Validator = new ();
+        private static readonly UTorrentSettingsValidator Validator = new();
 
         public UTorrentSettings()
         {

--- a/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RemotePathMappingCheck.cs
@@ -332,7 +332,8 @@ namespace NzbDrone.Core.HealthCheck.Checks
                                     { "downloadClientName", client.Definition.Name },
                                     { "path", dlpath },
                                     { "osName", _osInfo.Name }
-                                }), "#bad-remote-path-mapping");
+                                }),
+                            "#bad-remote-path-mapping");
                     }
 
                     // path mappings shouldn't be needed locally so probably a permissions issue

--- a/src/NzbDrone.Core/ImportLists/Custom/CustomSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Custom/CustomSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.ImportLists.Custom
 
     public class CustomSettings : ImportListSettingsBase<CustomSettings>
     {
-        private static readonly CustomSettingsValidator Validator = new ();
+        private static readonly CustomSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "List URL", HelpText = "The URL for the series list")]
         public override string BaseUrl { get; set; } = string.Empty;

--- a/src/NzbDrone.Core/ImportLists/Plex/PlexListSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Plex/PlexListSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.ImportLists.Plex
 
     public class PlexListSettings : ImportListSettingsBase<PlexListSettings>
     {
-        private static readonly PlexListSettingsValidator Validator = new ();
+        private static readonly PlexListSettingsValidator Validator = new();
 
         public PlexListSettings()
         {

--- a/src/NzbDrone.Core/ImportLists/Rss/Plex/PlexRssImportSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/Plex/PlexRssImportSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.ImportLists.Rss.Plex
 
     public class PlexRssImportSettings : RssImportBaseSettings<PlexRssImportSettings>
     {
-        private static readonly PlexRssImportSettingsValidator Validator = new ();
+        private static readonly PlexRssImportSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Url", Type = FieldType.Textbox, HelpLink = "https://app.plex.tv/desktop/#!/settings/watchlist")]
         public override string Url { get; set; }

--- a/src/NzbDrone.Core/ImportLists/Rss/RssImportBaseSettings.cs
+++ b/src/NzbDrone.Core/ImportLists/Rss/RssImportBaseSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.ImportLists.Rss
     public class RssImportBaseSettings<TSettings> : ImportListSettingsBase<TSettings>
         where TSettings : RssImportBaseSettings<TSettings>
     {
-        private static readonly RssImportSettingsValidator<TSettings> Validator = new ();
+        private static readonly RssImportSettingsValidator<TSettings> Validator = new();
 
         public override string BaseUrl { get; set; }
 

--- a/src/NzbDrone.Core/Indexers/Fanzub/FanzubSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Fanzub/FanzubSettings.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Indexers.Fanzub
 
     public class FanzubSettings : PropertywiseEquatable<FanzubSettings>, IIndexerSettings
     {
-        private static readonly FanzubSettingsValidator Validator = new ();
+        private static readonly FanzubSettingsValidator Validator = new();
 
         public FanzubSettings()
         {

--- a/src/NzbDrone.Core/Indexers/FileList/FileListSettings.cs
+++ b/src/NzbDrone.Core/Indexers/FileList/FileListSettings.cs
@@ -21,7 +21,7 @@ namespace NzbDrone.Core.Indexers.FileList
 
     public class FileListSettings : PropertywiseEquatable<FileListSettings>, ITorrentIndexerSettings
     {
-        private static readonly FileListSettingsValidator Validator = new ();
+        private static readonly FileListSettingsValidator Validator = new();
 
         public FileListSettings()
         {
@@ -51,7 +51,7 @@ namespace NzbDrone.Core.Indexers.FileList
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(7)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(8, Type = FieldType.Checkbox, Label = "Reject Blocklisted Torrent Hashes While Grabbing", HelpText = "If a torrent is blocked by hash it may not properly be rejected during RSS/Search for some indexers, enabling this will allow it to be rejected after the torrent is grabbed, but before it is sent to the client.", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsSettings.cs
+++ b/src/NzbDrone.Core/Indexers/IPTorrents/IPTorrentsSettings.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Indexers.IPTorrents
 
     public class IPTorrentsSettings : PropertywiseEquatable<IPTorrentsSettings>, ITorrentIndexerSettings
     {
-        private static readonly IPTorrentsSettingsValidator Validator = new ();
+        private static readonly IPTorrentsSettingsValidator Validator = new();
 
         public IPTorrentsSettings()
         {
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Indexers.IPTorrents
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(2)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(3, Type = FieldType.Checkbox, Label = "Reject Blocklisted Torrent Hashes While Grabbing", HelpText = "If a torrent is blocked by hash it may not properly be rejected during RSS/Search for some indexers, enabling this will allow it to be rejected after the torrent is grabbed, but before it is sent to the client.", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabSettings.cs
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Indexers.Newznab
             return settings.BaseUrl != null && ApiKeyWhiteList.Any(c => settings.BaseUrl.ToLowerInvariant().Contains(c));
         }
 
-        private static readonly Regex AdditionalParametersRegex = new (@"(&.+?\=.+?)+", RegexOptions.Compiled);
+        private static readonly Regex AdditionalParametersRegex = new(@"(&.+?\=.+?)+", RegexOptions.Compiled);
 
         public NewznabSettingsValidator()
         {
@@ -64,7 +64,7 @@ namespace NzbDrone.Core.Indexers.Newznab
 
     public class NewznabSettings : PropertywiseEquatable<NewznabSettings>, IIndexerSettings
     {
-        private static readonly NewznabSettingsValidator Validator = new ();
+        private static readonly NewznabSettingsValidator Validator = new();
 
         public NewznabSettings()
         {

--- a/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerSettings.cs
+++ b/src/NzbDrone.Core/Indexers/TorrentRss/TorrentRssIndexerSettings.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Indexers.TorrentRss
 
     public class TorrentRssIndexerSettings : PropertywiseEquatable<TorrentRssIndexerSettings>, ITorrentIndexerSettings
     {
-        private static readonly TorrentRssIndexerSettingsValidator Validator = new ();
+        private static readonly TorrentRssIndexerSettingsValidator Validator = new();
 
         public TorrentRssIndexerSettings()
         {
@@ -42,7 +42,7 @@ namespace NzbDrone.Core.Indexers.TorrentRss
         public int MinimumSeeders { get; set; }
 
         [FieldDefinition(4)]
-        public SeedCriteriaSettings SeedCriteria { get; set; } = new ();
+        public SeedCriteriaSettings SeedCriteria { get; set; } = new();
 
         [FieldDefinition(5, Type = FieldType.Checkbox, Label = "Reject Blocklisted Torrent Hashes While Grabbing", HelpText = "If a torrent is blocked by hash it may not properly be rejected during RSS/Search for some indexers, enabling this will allow it to be rejected after the torrent is grabbed, but before it is sent to the client.", Advanced = true)]
         public bool RejectBlocklistedTorrentHashesWhileGrabbing { get; set; }

--- a/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
+++ b/src/NzbDrone.Core/Indexers/Torznab/TorznabSettings.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Equ;
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Indexers.Torznab
             return settings.BaseUrl != null && ApiKeyWhiteList.Any(c => settings.BaseUrl.ToLowerInvariant().Contains(c));
         }
 
-        private static readonly Regex AdditionalParametersRegex = new (@"(&.+?\=.+?)+", RegexOptions.Compiled);
+        private static readonly Regex AdditionalParametersRegex = new(@"(&.+?\=.+?)+", RegexOptions.Compiled);
 
         public TorznabSettingsValidator()
         {
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Indexers.Torznab
 
     public class TorznabSettings : NewznabSettings, ITorrentIndexerSettings, IEquatable<TorznabSettings>
     {
-        private static readonly TorznabSettingsValidator Validator = new ();
+        private static readonly TorznabSettingsValidator Validator = new();
 
         private static readonly MemberwiseEqualityComparer<TorznabSettings> Comparer = MemberwiseEqualityComparer<TorznabSettings>.ByProperties;
 

--- a/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportSpecDecision.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpisodeImport/ImportSpecDecision.cs
@@ -6,7 +6,7 @@
         public ImportRejectionReason Reason { get; set; }
         public string Message { get; private set; }
 
-        private static readonly ImportSpecDecision AcceptDecision = new () { Accepted = true };
+        private static readonly ImportSpecDecision AcceptDecision = new() { Accepted = true };
         private ImportSpecDecision()
         {
         }

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -117,14 +117,14 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 // if it looks like PQ10 or similar HDR, do a frame analysis to figure out which type it is
                 if (PqTransferFunctions.Contains(mediaInfoModel.VideoTransferCharacteristics))
                 {
-                    var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new () { ExtraArguments = "-read_intervals \"%+#1\" -select_streams v" });
+                    var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new() { ExtraArguments = "-read_intervals \"%+#1\" -select_streams v" });
                     mediaInfoModel.RawFrameData = frameOutput;
 
                     frames = FFProbe.AnalyseFrameJson(frameOutput);
                 }
 
-                var streamSideData = primaryVideoStream?.SideDataList ?? new ();
-                var framesSideData = frames?.Frames?.Count > 0 ? frames?.Frames[0]?.SideDataList ?? new () : new ();
+                var streamSideData = primaryVideoStream?.SideDataList ?? new();
+                var framesSideData = frames?.Frames?.Count > 0 ? frames?.Frames[0]?.SideDataList ?? new() : new();
 
                 var sideData = streamSideData.Concat(framesSideData).ToList();
                 mediaInfoModel.VideoHdrFormat = GetHdrFormat(mediaInfoModel.VideoBitDepth, mediaInfoModel.VideoColourPrimaries, mediaInfoModel.VideoTransferCharacteristics, sideData);

--- a/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
+++ b/src/NzbDrone.Core/Messaging/Events/EventAggregator.cs
@@ -106,7 +106,8 @@ namespace NzbDrone.Core.Messaging.Events
                 _taskFactory.StartNew(() =>
                 {
                     handlerLocal.HandleAsync(@event);
-                }, TaskCreationOptions.PreferFairness)
+                },
+                        TaskCreationOptions.PreferFairness)
                 .LogExceptions();
             }
 
@@ -119,7 +120,8 @@ namespace NzbDrone.Core.Messaging.Events
                     _logger.Trace("{0} ~> {1}", eventName, handlerLocal.GetType().Name);
                     handlerLocal.HandleAsync(@event);
                     _logger.Trace("{0} <~ {1}", eventName, handlerLocal.GetType().Name);
-                }, TaskCreationOptions.PreferFairness)
+                },
+                        TaskCreationOptions.PreferFairness)
                 .LogExceptions();
             }
         }

--- a/src/NzbDrone.Core/Notifications/Apprise/AppriseSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Apprise/AppriseSettings.cs
@@ -36,7 +36,7 @@ namespace NzbDrone.Core.Notifications.Apprise
 
     public class AppriseSettings : NotificationSettingsBase<AppriseSettings>
     {
-        private static readonly AppriseSettingsValidator Validator = new ();
+        private static readonly AppriseSettingsValidator Validator = new();
 
         public AppriseSettings()
         {

--- a/src/NzbDrone.Core/Notifications/CustomScript/CustomScriptSettings.cs
+++ b/src/NzbDrone.Core/Notifications/CustomScript/CustomScriptSettings.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Notifications.CustomScript
 
     public class CustomScriptSettings : NotificationSettingsBase<CustomScriptSettings>
     {
-        private static readonly CustomScriptSettingsValidator Validator = new ();
+        private static readonly CustomScriptSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Path", Type = FieldType.FilePath)]
         public string Path { get; set; }

--- a/src/NzbDrone.Core/Notifications/Discord/Discord.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/Discord.cs
@@ -339,7 +339,7 @@ namespace NzbDrone.Core.Notifications.Discord
         {
             var attachments = new List<Embed>
             {
-                new ()
+                new()
                 {
                     Title = series.Title,
                 }
@@ -370,8 +370,8 @@ namespace NzbDrone.Core.Notifications.Discord
                 Color = (int)DiscordColors.Danger,
                 Fields = new List<DiscordField>
                 {
-                    new () { Name = "Reason", Value = reason.ToString() },
-                    new () { Name = "File name", Value = string.Format("```{0}```", deletedFile) }
+                    new() { Name = "Reason", Value = reason.ToString() },
+                    new() { Name = "File name", Value = string.Format("```{0}```", deletedFile) }
                 },
                 Timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ"),
             };
@@ -395,7 +395,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = series.Title,
                 Description = "Site Added",
                 Color = (int)DiscordColors.Success,
-                Fields = new List<DiscordField> { new () { Name = "Links", Value = GetLinksString(series) } }
+                Fields = new List<DiscordField> { new() { Name = "Links", Value = GetLinksString(series) } }
             };
 
             if (Settings.ImportFields.Contains((int)DiscordImportFieldType.Poster))
@@ -434,7 +434,7 @@ namespace NzbDrone.Core.Notifications.Discord
                 Title = series.Title,
                 Description = deleteMessage.DeletedFilesMessage,
                 Color = (int)DiscordColors.Danger,
-                Fields = new List<DiscordField> { new () { Name = "Links", Value = GetLinksString(series) } }
+                Fields = new List<DiscordField> { new() { Name = "Links", Value = GetLinksString(series) } }
             };
 
             if (Settings.ImportFields.Contains((int)DiscordImportFieldType.Poster))
@@ -512,12 +512,12 @@ namespace NzbDrone.Core.Notifications.Discord
                 Color = (int)DiscordColors.Standard,
                 Fields = new List<DiscordField>()
                 {
-                    new ()
+                    new()
                     {
                         Name = "Previous Version",
                         Value = updateMessage.PreviousVersion.ToString()
                     },
-                    new ()
+                    new()
                     {
                         Name = "New Version",
                         Value = updateMessage.NewVersion.ToString()

--- a/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Discord/DiscordSettings.cs
@@ -65,7 +65,7 @@ namespace NzbDrone.Core.Notifications.Discord
             };
         }
 
-        private static readonly DiscordSettingsValidator Validator = new ();
+        private static readonly DiscordSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Webhook URL", HelpText = "Discord channel webhook url")]
         public string WebHookUrl { get; set; }

--- a/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Email/EmailSettings.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Notifications.Email
 
     public class EmailSettings : NotificationSettingsBase<EmailSettings>
     {
-        private static readonly EmailSettingsValidator Validator = new ();
+        private static readonly EmailSettingsValidator Validator = new();
 
         public EmailSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Gotify/GotifySettings.cs
+++ b/src/NzbDrone.Core/Notifications/Gotify/GotifySettings.cs
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Notifications.Gotify
 
     public class GotifySettings : NotificationSettingsBase<GotifySettings>
     {
-        private static readonly GotifySettingsValidator Validator = new ();
+        private static readonly GotifySettingsValidator Validator = new();
 
         public GotifySettings()
         {

--- a/src/NzbDrone.Core/Notifications/Mailgun/MailgunSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Mailgun/MailgunSettings.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Notifications.Mailgun
 
     public class MailgunSettings : NotificationSettingsBase<MailgunSettings>
     {
-      private static readonly  MailGunSettingsValidator Validator = new ();
+      private static readonly  MailGunSettingsValidator Validator = new();
 
       public MailgunSettings()
       {

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserProxy.cs
@@ -80,7 +80,8 @@ namespace NzbDrone.Core.Notifications.Emby
                     }
 
                     return MediaBrowserMatchQuality.None;
-                }, item => item.Path).OrderBy(group => (int)group.Key).First();
+                },
+                    item => item.Path).OrderBy(group => (int)group.Key).First();
 
                 if (paths.Key == MediaBrowserMatchQuality.None)
                 {

--- a/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
+++ b/src/NzbDrone.Core/Notifications/MediaBrowser/MediaBrowserSettings.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Notifications.Emby
 
     public class MediaBrowserSettings : NotificationSettingsBase<MediaBrowserSettings>
     {
-        private static readonly MediaBrowserSettingsValidator Validator = new ();
+        private static readonly MediaBrowserSettingsValidator Validator = new();
 
         public MediaBrowserSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Notifiarr/NotifiarrSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Notifiarr/NotifiarrSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Notifications.Notifiarr
 
     public class NotifiarrSettings : NotificationSettingsBase<NotifiarrSettings>
     {
-        private static readonly NotifiarrSettingsValidator Validator = new ();
+        private static readonly NotifiarrSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "API Key", Privacy = PrivacyLevel.ApiKey, HelpText = "Your API key from your profile", HelpLink = "https://notifiarr.com")]
         public string ApiKey { get; set; }

--- a/src/NzbDrone.Core/Notifications/Ntfy/NtfySettings.cs
+++ b/src/NzbDrone.Core/Notifications/Ntfy/NtfySettings.cs
@@ -20,12 +20,12 @@ namespace NzbDrone.Core.Notifications.Ntfy
             RuleForEach(c => c.Topics).NotEmpty().Matches("[a-zA-Z0-9_-]+").Must(c => !InvalidTopics.Contains(c)).WithMessage("Invalid topic");
         }
 
-        private static List<string> InvalidTopics => new () { "announcements", "app", "docs", "settings", "stats", "mytopic-rw", "mytopic-ro", "mytopic-wo" };
+        private static List<string> InvalidTopics => new() { "announcements", "app", "docs", "settings", "stats", "mytopic-rw", "mytopic-ro", "mytopic-wo" };
     }
 
     public class NtfySettings : NotificationSettingsBase<NtfySettings>
     {
-        private static readonly NtfySettingsValidator Validator = new ();
+        private static readonly NtfySettingsValidator Validator = new();
 
         public NtfySettings()
         {

--- a/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Plex/Server/PlexServerSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Notifications.Plex.Server
 
     public class PlexServerSettings : NotificationSettingsBase<PlexServerSettings>
     {
-        private static readonly PlexServerSettingsValidator Validator = new ();
+        private static readonly PlexServerSettingsValidator Validator = new();
 
         public PlexServerSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Prowl/ProwlSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Prowl/ProwlSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Notifications.Prowl
 
     public class ProwlSettings : NotificationSettingsBase<ProwlSettings>
     {
-        private static readonly ProwlSettingsValidator Validator = new ();
+        private static readonly ProwlSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "API Key", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://www.prowlapp.com/api_settings.php")]
         public string ApiKey { get; set; }

--- a/src/NzbDrone.Core/Notifications/PushBullet/PushBulletSettings.cs
+++ b/src/NzbDrone.Core/Notifications/PushBullet/PushBulletSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Notifications.PushBullet
 
     public class PushBulletSettings : NotificationSettingsBase<PushBulletSettings>
     {
-        private static readonly PushBulletSettingsValidator Validator = new ();
+        private static readonly PushBulletSettingsValidator Validator = new();
 
         public PushBulletSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Pushcut/PushcutSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Pushcut/PushcutSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Notifications.Pushcut
 
     public class PushcutSettings : NotificationSettingsBase<PushcutSettings>
     {
-        private static readonly PushcutSettingsValidator Validator = new ();
+        private static readonly PushcutSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Notification name", Type = FieldType.Textbox, HelpText = "Notification name from Notifications tab of the Pushcut app.")]
         public string NotificationName { get; set; }

--- a/src/NzbDrone.Core/Notifications/Pushover/PushoverSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Pushover/PushoverSettings.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Notifications.Pushover
 
     public class PushoverSettings : NotificationSettingsBase<PushoverSettings>
     {
-        private static readonly PushoverSettingsValidator Validator = new ();
+        private static readonly PushoverSettingsValidator Validator = new();
 
         public PushoverSettings()
         {

--- a/src/NzbDrone.Core/Notifications/SendGrid/SendGridSettings.cs
+++ b/src/NzbDrone.Core/Notifications/SendGrid/SendGridSettings.cs
@@ -18,7 +18,7 @@ namespace NzbDrone.Core.Notifications.SendGrid
 
     public class SendGridSettings : NotificationSettingsBase<SendGridSettings>
     {
-        private static readonly SendGridSettingsValidator Validator = new ();
+        private static readonly SendGridSettingsValidator Validator = new();
 
         public SendGridSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Signal/SignalSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Signal/SignalSettings.cs
@@ -17,7 +17,7 @@ namespace NzbDrone.Core.Notifications.Signal
 
     public class SignalSettings : NotificationSettingsBase<SignalSettings>
     {
-        private static readonly SignalSettingsValidator Validator = new ();
+        private static readonly SignalSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Host", Type = FieldType.Textbox, HelpText = "localhost")]
         public string Host { get; set; }

--- a/src/NzbDrone.Core/Notifications/Simplepush/SimplepushSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Simplepush/SimplepushSettings.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Notifications.Simplepush
 
     public class SimplepushSettings : NotificationSettingsBase<SimplepushSettings>
     {
-        private static readonly SimplepushSettingsValidator Validator = new ();
+        private static readonly SimplepushSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Key", Privacy = PrivacyLevel.ApiKey, HelpLink = "https://simplepush.io/features")]
         public string Key { get; set; }

--- a/src/NzbDrone.Core/Notifications/Slack/Slack.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/Slack.cs
@@ -26,7 +26,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Fallback = message.Message,
                     Title = message.Series.Title,
@@ -43,7 +43,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Fallback = message.Message,
                     Title = message.Series.Title,
@@ -60,7 +60,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Fallback = message.Message,
                     Title = message.Series.Title,
@@ -77,7 +77,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = series.Title,
                 }
@@ -92,7 +92,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = GetTitle(deleteMessage.Series, deleteMessage.EpisodeFile.Episodes),
                 }
@@ -107,7 +107,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = message.Series.Title,
                 }
@@ -122,7 +122,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = deleteMessage.Series.Title,
                     Text = deleteMessage.DeletedFilesMessage
@@ -138,7 +138,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = healthCheck.Source.Name,
                     Text = healthCheck.Message,
@@ -155,7 +155,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = previousCheck.Source.Name,
                     Text = $"The following issue is now resolved: {previousCheck.Message}",
@@ -172,7 +172,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = Environment.MachineName,
                     Text = updateMessage.Message,
@@ -189,7 +189,7 @@ namespace NzbDrone.Core.Notifications.Slack
         {
             var attachments = new List<Attachment>
             {
-                new ()
+                new()
                 {
                     Title = Environment.MachineName,
                     Text = message.Message,

--- a/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Slack/SlackSettings.cs
@@ -15,7 +15,7 @@ namespace NzbDrone.Core.Notifications.Slack
 
     public class SlackSettings : NotificationSettingsBase<SlackSettings>
     {
-        private static readonly SlackSettingsValidator Validator = new ();
+        private static readonly SlackSettingsValidator Validator = new();
 
         [FieldDefinition(0, Label = "Webhook URL", HelpText = "Slack channel webhook url", Type = FieldType.Url, HelpLink = "https://my.slack.com/services/new/incoming-webhook/")]
         public string WebHookUrl { get; set; }

--- a/src/NzbDrone.Core/Notifications/Synology/SynologyIndexerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Synology/SynologyIndexerSettings.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Core.Notifications.Synology
 
     public class SynologyIndexerSettings : NotificationSettingsBase<SynologyIndexerSettings>
     {
-        private static readonly SynologyIndexerSettingsValidator Validator = new ();
+        private static readonly SynologyIndexerSettingsValidator Validator = new();
 
         public SynologyIndexerSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Telegram/TelegramSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Telegram/TelegramSettings.cs
@@ -44,7 +44,7 @@ namespace NzbDrone.Core.Notifications.Telegram
 
     public class TelegramSettings : NotificationSettingsBase<TelegramSettings>
     {
-        private static readonly TelegramSettingsValidator Validator = new ();
+        private static readonly TelegramSettingsValidator Validator = new();
 
         public TelegramSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Twitter/TwitterSettings.cs
@@ -29,7 +29,7 @@ namespace NzbDrone.Core.Notifications.Twitter
 
     public class TwitterSettings : NotificationSettingsBase<TwitterSettings>
     {
-        private static readonly TwitterSettingsValidator Validator = new ();
+        private static readonly TwitterSettingsValidator Validator = new();
 
         public TwitterSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookBase.cs
@@ -231,7 +231,7 @@ namespace NzbDrone.Core.Notifications.Webhook
                 },
                 Episodes = new List<WebhookEpisode>
                 {
-                    new ()
+                    new()
                     {
                         Id = 123,
                         EpisodeNumber = 1,

--- a/src/NzbDrone.Core/Notifications/Webhook/WebhookSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Webhook/WebhookSettings.cs
@@ -16,7 +16,7 @@ namespace NzbDrone.Core.Notifications.Webhook
 
     public class WebhookSettings : NotificationSettingsBase<WebhookSettings>
     {
-        private static readonly WebhookSettingsValidator Validator = new ();
+        private static readonly WebhookSettingsValidator Validator = new();
 
         public WebhookSettings()
         {

--- a/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
+++ b/src/NzbDrone.Core/Notifications/Xbmc/XbmcSettings.cs
@@ -19,7 +19,7 @@ namespace NzbDrone.Core.Notifications.Xbmc
 
     public class XbmcSettings : NotificationSettingsBase<XbmcSettings>
     {
-        private static readonly XbmcSettingsValidator Validator = new ();
+        private static readonly XbmcSettingsValidator Validator = new();
 
         public XbmcSettings()
         {

--- a/src/NzbDrone.Core/Parser/QualityParser.cs
+++ b/src/NzbDrone.Core/Parser/QualityParser.cs
@@ -14,7 +14,7 @@ namespace NzbDrone.Core.Parser
     {
         private static readonly Logger Logger = NzbDroneLogger.GetLogger(typeof(QualityParser));
 
-        private static readonly Regex SourceRegex = new (@"\b(?:
+        private static readonly Regex SourceRegex = new(@"\b(?:
                                                                 (?<bluray>BluRay|Blu-Ray|HD-?DVD|BDMux|BD(?!$))|
                                                                 (?<vr>VR180)|
                                                                 (?<webdl>WEB[-_. ]DL(?:mux)?|WEBDL|AmazonHD|AmazonSD|iTunesHD|MaxdomeHD|NetflixU?HD|WebHD|HBOMaxHD|DisneyHD|[. ]WEB[. ](?:[xh][ .]?26[45]|AVC|HEVC|DDP?5[. ]1)|[. ](?-i:WEB)$|(?:720|1080|2160)p[-. ]WEB[-. ]|[-. ]WEB[-. ](?:720|1080|2160)p|\b\s\/\sWEB\s\/\s\b|(?:AMZN|NF|DP)[. -]WEB[. -](?!Rip))|
@@ -30,41 +30,41 @@ namespace NzbDrone.Core.Parser
                                                                 )(?:\b|$|[ .])",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
-        private static readonly Regex RawHDRegex = new (@"\b(?<rawhd>RawHD|Raw[-_. ]HD)\b",
+        private static readonly Regex RawHDRegex = new(@"\b(?<rawhd>RawHD|Raw[-_. ]HD)\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex MPEG2Regex = new (@"\b(?<mpeg2>MPEG[-_. ]?2)\b");
+        private static readonly Regex MPEG2Regex = new(@"\b(?<mpeg2>MPEG[-_. ]?2)\b");
 
-        private static readonly Regex ProperRegex = new (@"\b(?<proper>proper)\b",
+        private static readonly Regex ProperRegex = new(@"\b(?<proper>proper)\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex RepackRegex = new (@"\b(?<repack>repack\d?|rerip\d?)\b",
+        private static readonly Regex RepackRegex = new(@"\b(?<repack>repack\d?|rerip\d?)\b",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex VersionRegex = new (@"\d[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]|repack(?<version>\d)|rerip(?<version>\d)|(?:480|576|720|1080|2160)p[._ ]v(?<version>\d)",
+        private static readonly Regex VersionRegex = new(@"\d[-._ ]?v(?<version>\d)[-._ ]|\[v(?<version>\d)\]|repack(?<version>\d)|rerip(?<version>\d)|(?:480|576|720|1080|2160)p[._ ]v(?<version>\d)",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex RealRegex = new (@"\b(?<real>REAL)\b",
+        private static readonly Regex RealRegex = new(@"\b(?<real>REAL)\b",
                                                                 RegexOptions.Compiled);
 
-        private static readonly Regex ResolutionRegex = new (@"\b(?:(?<R360p>360p)|(?<R480p>480p|480i|640x480|848x480)|(?<R540p>540p)|(?<R576p>576p)|(?<R720p>720p|1280x720|960p)|(?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|(?<R2160p>2160p|3840x2160|4k[-_. ](?:UHD|HEVC|BD|H265)|(?:UHD|HEVC|BD|H265)[-_. ]4k))\b",
+        private static readonly Regex ResolutionRegex = new(@"\b(?:(?<R360p>360p)|(?<R480p>480p|480i|640x480|848x480)|(?<R540p>540p)|(?<R576p>576p)|(?<R720p>720p|1280x720|960p)|(?<R1080p>1080p|1920x1080|1440p|FHD|1080i|4kto1080p)|(?<R2160p>2160p|3840x2160|4k[-_. ](?:UHD|HEVC|BD|H265)|(?:UHD|HEVC|BD|H265)[-_. ]4k))\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         // Handle cases where no resolution is in the release name (assume if UHD then 4k) or resolution is non-standard
-        private static readonly Regex AlternativeResolutionRegex = new (@"\b(?<R2160p>UHD)\b|(?<R2160p>\[4K\])",
+        private static readonly Regex AlternativeResolutionRegex = new(@"\b(?<R2160p>UHD)\b|(?<R2160p>\[4K\])",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex CodecRegex = new (@"\b(?:(?<x264>x264)|(?<h264>h264)|(?<xvidhd>XvidHD)|(?<xvid>Xvid)|(?<divx>divx))\b",
+        private static readonly Regex CodecRegex = new(@"\b(?:(?<x264>x264)|(?<h264>h264)|(?<xvidhd>XvidHD)|(?<xvid>Xvid)|(?<divx>divx))\b",
                                                                 RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex OtherSourceRegex = new (@"(?<hdtv>HD[-_. ]TV)|(?<sdtv>SD[-_. ]TV)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex OtherSourceRegex = new(@"(?<hdtv>HD[-_. ]TV)|(?<sdtv>SD[-_. ]TV)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex AnimeBlurayRegex = new (@"bd(?:720|1080|2160)|(?<=[-_. (\[])bd(?=[-_. )\]])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex AnimeWebDlRegex = new (@"\[WEB\]|[\[\(]WEB[ .]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AnimeBlurayRegex = new(@"bd(?:720|1080|2160)|(?<=[-_. (\[])bd(?=[-_. )\]])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex AnimeWebDlRegex = new(@"\[WEB\]|[\[\(]WEB[ .]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex HighDefPdtvRegex = new (@"hr[-_. ]ws", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex HighDefPdtvRegex = new(@"hr[-_. ]ws", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private static readonly Regex RemuxRegex = new (@"(?:[_. ]|\d{4}p-|\bHybrid-)(?<remux>(?:(BD|UHD)[-_. ]?)?Remux)\b|(?<remux>(?:(BD|UHD)[-_. ]?)?Remux[_. ]\d{4}p)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex RemuxRegex = new(@"(?:[_. ]|\d{4}p-|\bHybrid-)(?<remux>(?:(BD|UHD)[-_. ]?)?Remux)\b|(?<remux>(?:(BD|UHD)[-_. ]?)?Remux[_. ]\d{4}p)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public static QualityModel ParseQuality(string name)
         {

--- a/src/NzbDrone.Core/Queue/QueueService.cs
+++ b/src/NzbDrone.Core/Queue/QueueService.cs
@@ -20,7 +20,7 @@ namespace NzbDrone.Core.Queue
     public class QueueService : IQueueService, IHandle<TrackedDownloadRefreshedEvent>
     {
         private readonly IEventAggregator _eventAggregator;
-        private static List<Queue> _queue = new ();
+        private static List<Queue> _queue = new();
 
         public QueueService(IEventAggregator eventAggregator)
         {

--- a/src/NzbDrone.Core/SeriesStats/SeriesStatisticsRepository.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeriesStatisticsRepository.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dapper;
@@ -80,7 +80,8 @@ namespace NzbDrone.Core.SeriesStats
                              SUM(CASE WHEN (""Monitored"" = {trueIndicator} AND ""AirDateUtc"" <= @currentDate) OR ""EpisodeFileId"" > 0 THEN 1 ELSE 0 END) AS EpisodeCount,
                              SUM(CASE WHEN ""EpisodeFileId"" > 0 THEN 1 ELSE 0 END) AS EpisodeFileCount,
                              MIN(CASE WHEN ""AirDateUtc"" < @currentDate OR ""Monitored"" = {falseIndicator} THEN NULL ELSE ""AirDateUtc"" END) AS NextAiringString,
-                             MAX(CASE WHEN ""AirDateUtc"" >= @currentDate OR ""Monitored"" = {falseIndicator} THEN NULL ELSE ""AirDateUtc"" END) AS PreviousAiringString", parameters)
+                             MAX(CASE WHEN ""AirDateUtc"" >= @currentDate OR ""Monitored"" = {falseIndicator} THEN NULL ELSE ""AirDateUtc"" END) AS PreviousAiringString",
+                parameters)
             .GroupBy<Episode>(x => x.SeriesId)
             .GroupBy<Episode>(x => x.SeasonNumber);
         }

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="Polly" Version="8.5.1" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
     <PackageReference Include="Servarr.FFprobe" Version="5.1.4.112" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Memory" Version="4.6.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
@@ -28,6 +32,7 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="Semver" Version="3.0.0" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.Host.Test/Whisparr.Host.Test.csproj
+++ b/src/NzbDrone.Host.Test/Whisparr.Host.Test.csproj
@@ -6,4 +6,12 @@
     <ProjectReference Include="..\NzbDrone.Host\Whisparr.Host.csproj" />
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
+  </ItemGroup>
+
 </Project>

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -233,7 +233,7 @@ namespace NzbDrone.Host
             {
                 return new ConfigurationBuilder()
                     .AddXmlFile(configPath, optional: true, reloadOnChange: false)
-                    .AddInMemoryCollection(new List<KeyValuePair<string, string>> { new ("dataProtectionFolder", appFolder.GetDataProtectionPath()) })
+                    .AddInMemoryCollection(new List<KeyValuePair<string, string>> { new("dataProtectionFolder", appFolder.GetDataProtectionPath()) })
                     .AddEnvironmentVariables()
                     .Build();
             }

--- a/src/NzbDrone.Host/Whisparr.Host.csproj
+++ b/src/NzbDrone.Host/Whisparr.Host.csproj
@@ -10,6 +10,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
     <PackageReference Include="DryIoc.dll" Version="5.4.1" />
     <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.0" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.Integration.Test/IntegrationTest.cs
+++ b/src/NzbDrone.Integration.Test/IntegrationTest.cs
@@ -23,7 +23,7 @@ namespace NzbDrone.Integration.Test
 
         protected int Port { get; private set; }
 
-        protected PostgresOptions PostgresOptions { get; set; } = new ();
+        protected PostgresOptions PostgresOptions { get; set; } = new();
 
         protected override string RootUrl => $"http://localhost:{Port}/";
 

--- a/src/NzbDrone.Integration.Test/Whisparr.Integration.Test.csproj
+++ b/src/NzbDrone.Integration.Test/Whisparr.Integration.Test.csproj
@@ -5,6 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.12" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />

--- a/src/NzbDrone.Libraries.Test/Whisparr.Libraries.Test.csproj
+++ b/src/NzbDrone.Libraries.Test/Whisparr.Libraries.Test.csproj
@@ -5,4 +5,12 @@
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
+  </ItemGroup>
+
 </Project>

--- a/src/NzbDrone.Mono.Test/Whisparr.Mono.Test.csproj
+++ b/src/NzbDrone.Mono.Test/Whisparr.Mono.Test.csproj
@@ -8,6 +8,11 @@
   -->
   <ItemGroup>
     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr24" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common.Test\Whisparr.Common.Test.csproj" />

--- a/src/NzbDrone.Mono/Disk/FindDriveType.cs
+++ b/src/NzbDrone.Mono/Disk/FindDriveType.cs
@@ -6,7 +6,7 @@ namespace NzbDrone.Mono.Disk
 {
     public static class FindDriveType
     {
-        private static readonly Dictionary<string, DriveType> DriveTypeMap = new ()
+        private static readonly Dictionary<string, DriveType> DriveTypeMap = new()
         {
             { "afpfs", DriveType.Network },
             { "apfs", DriveType.Fixed },

--- a/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/MacOsVersionAdapter.cs
+++ b/src/NzbDrone.Mono/EnvironmentInfo/VersionAdapters/MacOsVersionAdapter.cs
@@ -10,7 +10,7 @@ namespace NzbDrone.Mono.EnvironmentInfo.VersionAdapters
     {
         private const string PLIST_DIR = "/System/Library/CoreServices/";
 
-        private static readonly Regex DarwinVersionRegex = new ("<key>ProductVersion<\\/key>\\s*<string>(?<version>1\\d\\.\\d{1,2}\\.?\\d{0,2}?)<\\/string>",
+        private static readonly Regex DarwinVersionRegex = new("<key>ProductVersion<\\/key>\\s*<string>(?<version>1\\d\\.\\d{1,2}\\.?\\d{0,2}?)<\\/string>",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private readonly IDiskProvider _diskProvider;

--- a/src/NzbDrone.Mono/Whisparr.Mono.csproj
+++ b/src/NzbDrone.Mono/Whisparr.Mono.csproj
@@ -9,7 +9,12 @@
   -->
   <ItemGroup>
     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr24" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.SignalR/Whisparr.SignalR.csproj
+++ b/src/NzbDrone.SignalR/Whisparr.SignalR.csproj
@@ -7,4 +7,11 @@
     <ProjectReference Include="..\NzbDrone.Core\Whisparr.Core.csproj" />
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
+  </ItemGroup>
 </Project>

--- a/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
+++ b/src/NzbDrone.Test.Common/AutoMoq/AutoMoqer.cs
@@ -112,7 +112,8 @@ namespace NzbDrone.Test.Common.AutoMoq
                                 var mock = (Mock)r.Resolve(mockType);
                                 SetMock(serviceType, mock);
                                 return mock.Object;
-                            }, Reuse.Singleton);
+                            },
+                                Reuse.Singleton);
 
                             return new[] { new DynamicRegistration(mockFactory, IfAlreadyRegistered.Keep) };
                         }

--- a/src/NzbDrone.Test.Common/NzbDroneRunner.cs
+++ b/src/NzbDrone.Test.Common/NzbDroneRunner.cs
@@ -136,7 +136,7 @@ namespace NzbDrone.Test.Common
 
         private void Start(string outputWhisparrConsoleExe)
         {
-            StringDictionary envVars = new ();
+            StringDictionary envVars = new();
             if (PostgresOptions?.Host != null)
             {
                 envVars.Add("Whisparr__Postgres__Host", PostgresOptions.Host);

--- a/src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj
@@ -9,6 +9,11 @@
     <PackageReference Include="NLog" Version="4.7.14" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.Test.Dummy/Whisparr.Test.Dummy.csproj
+++ b/src/NzbDrone.Test.Dummy/Whisparr.Test.Dummy.csproj
@@ -3,4 +3,11 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
+  </ItemGroup>
 </Project>

--- a/src/NzbDrone.Update.Test/Whisparr.Update.Test.csproj
+++ b/src/NzbDrone.Update.Test/Whisparr.Update.Test.csproj
@@ -6,4 +6,12 @@
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />
     <ProjectReference Include="..\NzbDrone.Update\Whisparr.Update.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
+  </ItemGroup>
+
 </Project>

--- a/src/NzbDrone.Update/Whisparr.Update.csproj
+++ b/src/NzbDrone.Update/Whisparr.Update.csproj
@@ -7,6 +7,11 @@
     <PackageReference Include="DryIoc.dll" Version="5.4.1" />
     <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.0" />
     <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.Windows.Test/Whisparr.Windows.Test.csproj
+++ b/src/NzbDrone.Windows.Test/Whisparr.Windows.Test.csproj
@@ -7,4 +7,12 @@
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />
     <ProjectReference Include="..\NzbDrone.Windows\Whisparr.Windows.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
+  </ItemGroup>
+
 </Project>

--- a/src/NzbDrone.Windows/Whisparr.Windows.csproj
+++ b/src/NzbDrone.Windows/Whisparr.Windows.csproj
@@ -5,7 +5,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone/Whisparr.csproj
+++ b/src/NzbDrone/Whisparr.csproj
@@ -8,7 +8,12 @@
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Host\Whisparr.Host.csproj" />

--- a/src/ServiceHelpers/ServiceInstall/ServiceInstall.csproj
+++ b/src/ServiceHelpers/ServiceInstall/ServiceInstall.csproj
@@ -4,6 +4,11 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Security.Principal.Windows" Version="6.0.0-preview.5.21301.5" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
 </Project>

--- a/src/ServiceHelpers/ServiceUninstall/ServiceUninstall.csproj
+++ b/src/ServiceHelpers/ServiceUninstall/ServiceUninstall.csproj
@@ -4,6 +4,11 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.Security.Principal.Windows" Version="6.0.0-preview.5.21301.5" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
 </Project>

--- a/src/Whisparr.Api.V3/CustomFormats/CustomFormatBulkResource.cs
+++ b/src/Whisparr.Api.V3/CustomFormats/CustomFormatBulkResource.cs
@@ -4,7 +4,7 @@ namespace Whisparr.Api.V3.CustomFormats
 {
     public class CustomFormatBulkResource
     {
-        public HashSet<int> Ids { get; set; } = new ();
+        public HashSet<int> Ids { get; set; } = new();
         public bool? IncludeCustomFormatWhenRenaming { get; set; }
     }
 }

--- a/src/Whisparr.Api.V3/DownloadClient/DownloadClientController.cs
+++ b/src/Whisparr.Api.V3/DownloadClient/DownloadClientController.cs
@@ -7,8 +7,8 @@ namespace Whisparr.Api.V3.DownloadClient
     [V3ApiController]
     public class DownloadClientController : ProviderControllerBase<DownloadClientResource, DownloadClientBulkResource, IDownloadClient, DownloadClientDefinition>
     {
-        public static readonly DownloadClientResourceMapper ResourceMapper = new ();
-        public static readonly DownloadClientBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly DownloadClientResourceMapper ResourceMapper = new();
+        public static readonly DownloadClientBulkResourceMapper BulkResourceMapper = new();
 
         public DownloadClientController(IBroadcastSignalRMessage signalRBroadcaster, IDownloadClientFactory downloadClientFactory)
             : base(signalRBroadcaster, downloadClientFactory, "downloadclient", ResourceMapper, BulkResourceMapper)

--- a/src/Whisparr.Api.V3/ImportLists/ImportListController.cs
+++ b/src/Whisparr.Api.V3/ImportLists/ImportListController.cs
@@ -10,8 +10,8 @@ namespace Whisparr.Api.V3.ImportLists
     [V3ApiController]
     public class ImportListController : ProviderControllerBase<ImportListResource, ImportListBulkResource, IImportList, ImportListDefinition>
     {
-        public static readonly ImportListResourceMapper ResourceMapper = new ();
-        public static readonly ImportListBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly ImportListResourceMapper ResourceMapper = new();
+        public static readonly ImportListBulkResourceMapper BulkResourceMapper = new();
 
         public ImportListController(IBroadcastSignalRMessage signalRBroadcaster,
             IImportListFactory importListFactory,

--- a/src/Whisparr.Api.V3/Indexers/IndexerController.cs
+++ b/src/Whisparr.Api.V3/Indexers/IndexerController.cs
@@ -8,8 +8,8 @@ namespace Whisparr.Api.V3.Indexers
     [V3ApiController]
     public class IndexerController : ProviderControllerBase<IndexerResource, IndexerBulkResource, IIndexer, IndexerDefinition>
     {
-        public static readonly IndexerResourceMapper ResourceMapper = new ();
-        public static readonly IndexerBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly IndexerResourceMapper ResourceMapper = new();
+        public static readonly IndexerBulkResourceMapper BulkResourceMapper = new();
 
         public IndexerController(IBroadcastSignalRMessage signalRBroadcaster,
             IndexerFactory indexerFactory,

--- a/src/Whisparr.Api.V3/Indexers/ReleasePushController.cs
+++ b/src/Whisparr.Api.V3/Indexers/ReleasePushController.cs
@@ -76,7 +76,7 @@ namespace Whisparr.Api.V3.Indexers
 
             if (decision?.RemoteEpisode.ParsedEpisodeInfo == null)
             {
-                throw new ValidationException(new List<ValidationFailure> { new ("Title", "Unable to parse", release.Title) });
+                throw new ValidationException(new List<ValidationFailure> { new("Title", "Unable to parse", release.Title) });
             }
 
             return MapDecisions(new[] { decision });

--- a/src/Whisparr.Api.V3/Metadata/MetadataController.cs
+++ b/src/Whisparr.Api.V3/Metadata/MetadataController.cs
@@ -9,8 +9,8 @@ namespace Whisparr.Api.V3.Metadata
     [V3ApiController]
     public class MetadataController : ProviderControllerBase<MetadataResource, MetadataBulkResource, IMetadata, MetadataDefinition>
     {
-        public static readonly MetadataResourceMapper ResourceMapper = new ();
-        public static readonly MetadataBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly MetadataResourceMapper ResourceMapper = new();
+        public static readonly MetadataBulkResourceMapper BulkResourceMapper = new();
 
         public MetadataController(IBroadcastSignalRMessage signalRBroadcaster, IMetadataFactory metadataFactory)
             : base(signalRBroadcaster, metadataFactory, "metadata", ResourceMapper, BulkResourceMapper)

--- a/src/Whisparr.Api.V3/Notifications/NotificationController.cs
+++ b/src/Whisparr.Api.V3/Notifications/NotificationController.cs
@@ -9,8 +9,8 @@ namespace Whisparr.Api.V3.Notifications
     [V3ApiController]
     public class NotificationController : ProviderControllerBase<NotificationResource, NotificationBulkResource, INotification, NotificationDefinition>
     {
-        public static readonly NotificationResourceMapper ResourceMapper = new ();
-        public static readonly NotificationBulkResourceMapper BulkResourceMapper = new ();
+        public static readonly NotificationResourceMapper ResourceMapper = new();
+        public static readonly NotificationBulkResourceMapper BulkResourceMapper = new();
 
         public NotificationController(IBroadcastSignalRMessage signalRBroadcaster, NotificationFactory notificationFactory)
             : base(signalRBroadcaster, notificationFactory, "notification", ResourceMapper, BulkResourceMapper)

--- a/src/Whisparr.Api.V3/Series/SeriesController.cs
+++ b/src/Whisparr.Api.V3/Series/SeriesController.cs
@@ -187,7 +187,8 @@ namespace Whisparr.Api.V3.Series
                     SeriesId = series.Id,
                     SourcePath = sourcePath,
                     DestinationPath = destinationPath
-                }, trigger: CommandTrigger.Manual);
+                },
+                    trigger: CommandTrigger.Manual);
             }
 
             var model = seriesResource.ToModel(series);

--- a/src/Whisparr.Api.V3/System/Backup/BackupController.cs
+++ b/src/Whisparr.Api.V3/System/Backup/BackupController.cs
@@ -20,7 +20,7 @@ namespace Whisparr.Api.V3.System.Backup
         private readonly IAppFolderInfo _appFolderInfo;
         private readonly IDiskProvider _diskProvider;
 
-        private static readonly List<string> ValidExtensions = new () { ".zip", ".db", ".xml" };
+        private static readonly List<string> ValidExtensions = new() { ".zip", ".db", ".xml" };
 
         public BackupController(IBackupService backupService,
                             IAppFolderInfo appFolderInfo,

--- a/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
+++ b/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
@@ -6,6 +6,11 @@
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Ical.Net" Version="4.3.1" />
     <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Core\Whisparr.Core.csproj" />

--- a/src/Whisparr.Http/Frontend/Mappers/MediaCoverProxyMapper.cs
+++ b/src/Whisparr.Http/Frontend/Mappers/MediaCoverProxyMapper.cs
@@ -10,7 +10,7 @@ namespace Whisparr.Http.Frontend.Mappers
 {
     public class MediaCoverProxyMapper : IMapHttpRequestsToDisk
     {
-        private readonly Regex _regex = new (@"/MediaCoverProxy/(?<hash>\w+)/(?<filename>(.+)\.(jpg|png|gif))");
+        private readonly Regex _regex = new(@"/MediaCoverProxy/(?<hash>\w+)/(?<filename>(.+)\.(jpg|png|gif))");
 
         private readonly IMediaCoverProxy _mediaCoverProxy;
         private readonly IContentTypeProvider _mimeTypeProvider;

--- a/src/Whisparr.Http/Whisparr.Http.csproj
+++ b/src/Whisparr.Http/Whisparr.Http.csproj
@@ -6,6 +6,11 @@
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="ImpromptuInterface" Version="8.0.6" />
     <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Core\Whisparr.Core.csproj" />

--- a/src/Whisparr.RuntimePatches/Whisparr.RuntimePatches.csproj
+++ b/src/Whisparr.RuntimePatches/Whisparr.RuntimePatches.csproj
@@ -4,5 +4,10 @@
   </PropertyGroup>  
   <ItemGroup>
     <PackageReference Include="Lib.Harmony" Version="2.3.5" />
+    <PackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgrades StyleCop.Analyzers to the Unstable 1.2.0.556 build, matching upstream.
This gates several later March commits, so it lands ahead of the rest of the
month.

- Sonarr/Sonarr@5d7c94f8e — **Upgrade StyleCop.Analyzers to Unstable 1.2.0.556**
- Sonarr/Sonarr@fef00dccf — **Fix uTorrent after stylecop upgrade** (upstream
  shipped the upgrade with one violation still in `UTorrent.cs`; this is their
  follow-up, kept as its own commit)

The code changes are formatting only: `new (` becomes `new(` (SA1000), a few
argument lists are re-wrapped (SA1117), and one `ValueTuple<TNewKey, TNewValue>`
becomes `(TNewKey Item1, TNewValue Item2)` (SA1141) — the same type, written the
way the analyzer now wants.

## Adaptations

**The pick spliced in unrelated content, which was stripped back out.** Because
Whisparr's files have diverged, the cherry-pick's conflict resolution pulled in
whole lines from upstream's *newer* file contents rather than just this commit's
whitespace changes. Two of those broke the build outright — a
`CleansingClefLogLayout` field whose class Whisparr does not have, and an
`ImdbIdRegex` needing a `using` the file lacks — and the rest would have
compiled fine while changing behaviour:

- `HDBitsSettings.cs` — would have dropped `HDBitsSettingsValidator` and `SeedCriteriaSettings`
- `JoinSettings.cs` — would have dropped `JoinSettingsValidator`
- `TorznabSettings.cs` — would have dropped `SeedCriteriaSettings`
- `SeriesStatisticsRepository.cs` — would have added `MAX("AirDate") AS LastAiredString` to the query
- `Parser.cs` — would have added a `MultiRegex` field
- plus test fixtures gaining methods and arguments

Every `.cs` file in the branch was diffed against `v2-develop` with all
whitespace removed, so re-wrapping is invisible and only genuine insertions or
deletions show up. The 13 files that carried real content were reverted, and
then the upgraded analyzer was allowed to say what actually needed fixing —
which is how the formatting fixes in this PR were derived.

**csproj changes are limited to StyleCop.** The pick also rewrote package
versions that have nothing to do with this commit, including a downgrade:

| Package | Pick wanted | Restored |
| --- | --- | --- |
| Selenium.WebDriver.ChromeDriver | 111.0.5563.6400 | 137.0.7151.6800 (**downgrade reverted**) |
| NLog (×4 projects) | 5.3.4 | 4.7.14 |
| DryIoc.dll / DryIoc.Microsoft.DependencyInjection | 5.4.3 / 6.2.0 | 5.4.1 / 6.1.0 |
| Swashbuckle.AspNetCore.Annotations | added 6.6.2 | dropped |

The Swashbuckle addition collided with `Whisparr.Host`'s older Swashbuckle and
failed the build with NU1605. Those upgrades are real gaps, but they belong to
their own upstream bump commits — Whisparr is still on NLog 4.7.14 where
upstream is on 5.3.4.

**Seven projects the pick missed.** Upstream adds the analyzer to all 27 of its
projects; the pick carried it into only 19 of Whisparr's 26, leaving
`Api.Test`, `Common.Test`, `Host.Test`, `Host`, `Libraries.Test`,
`Update.Test` and `Windows.Test` behind. Since `Directory.Build.props` applies
StyleCop 1.1.118 to every project, those seven kept running the **old**
analyzer — and the two versions disagree about SA1000: 1.1 requires `new (`,
1.2 requires `new(`. Fixing the code for 1.2 therefore broke exactly the
projects that had not been upgraded. All 26 now carry the upgrade.

## Verification

Solution builds clean with analyzers on (0 errors). `Whisparr.Core.Test`
3553 passed / 0 failed, `Whisparr.Api.Test` 18 / 0, `Whisparr.Host.Test` 14 / 0.
`Whisparr.Common.Test` has 5 failures, all pre-existing `ServiceProvider` tests
that need an elevated shell ("Access is denied" opening `SCardSvr`) and
unrelated to this branch.
