### PR TITLE
Fixed: Profiles page error, missing episode naming settings, and JAV sidebar entry

### DIFF
--- a/frontend/src/Components/Page/Sidebar/PageSidebar.tsx
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.tsx
@@ -62,6 +62,18 @@ const LINKS: SidebarItem[] = [
   },
 
   {
+    iconName: icons.SERIES_CONTINUING,
+    title: () => translate('Jav'),
+    to: '/jav',
+    children: [
+      {
+        title: () => translate('AddNew'),
+        to: '/jav/add/new',
+      },
+    ],
+  },
+
+  {
     iconName: icons.CALENDAR,
     title: () => translate('Calendar'),
     to: '/calendar',

--- a/frontend/src/Settings/MediaManagement/MediaManagement.tsx
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.tsx
@@ -26,7 +26,7 @@ import useIsWindows from 'System/useIsWindows';
 import { InputChanged } from 'typings/inputs';
 import isEmpty from 'Utilities/Object/isEmpty';
 import translate from 'Utilities/String/translate';
-import Naming from './Naming/Naming';
+import NamingConnector from './Naming/NamingConnector';
 import AddRootFolder from './RootFolder/AddRootFolder';
 
 const SECTION = 'mediaManagement';
@@ -164,7 +164,7 @@ function MediaManagement() {
       />
 
       <PageContentBody>
-        <Naming />
+        <NamingConnector />
 
         {isFetching ? (
           <FieldSet legend={translate('NamingSettings')}>

--- a/frontend/src/Settings/Profiles/Profiles.tsx
+++ b/frontend/src/Settings/Profiles/Profiles.tsx
@@ -7,7 +7,7 @@ import SettingsToolbar from 'Settings/SettingsToolbar';
 import translate from 'Utilities/String/translate';
 import DelayProfiles from './Delay/DelayProfiles';
 import QualityProfiles from './Quality/QualityProfiles';
-import ReleaseProfiles from './Release/ReleaseProfiles';
+import ReleaseProfilesConnector from './Release/ReleaseProfilesConnector';
 
 // Only a single DragDrop Context can exist so it's done here to allow editing
 // quality profiles and reordering delay profiles to work.
@@ -21,7 +21,7 @@ function Profiles() {
         <DndProvider options={HTML5toTouch}>
           <QualityProfiles />
           <DelayProfiles />
-          <ReleaseProfiles />
+          <ReleaseProfilesConnector />
         </DndProvider>
       </PageContentBody>
     </PageContent>


### PR DESCRIPTION
Three regressions from the TypeScript conversion batches.

## Profiles settings page fails to load

```
Cannot read properties of undefined (reading 'map')
  at ReleaseProfiles.js:69
```

`Profiles.tsx` came from upstream, where `ReleaseProfiles` is a TypeScript
component that fetches its own data. Whisparr still has the older
connector-based `ReleaseProfiles.js`, so the page rendered `<ReleaseProfiles />`
instead of `<ReleaseProfilesConnector />` and redux never injected `items`,
`tagList` or `indexerList` — hence `items.map` on undefined.

`QualityProfiles` and `DelayProfiles` on the same page were both converted to
`.tsx` and are self-sufficient, which is why only the release section broke.

## Episode naming settings do not render

Same cause in `MediaManagement.tsx`: `<Naming />` rendered without
`NamingConnector`. This one fails silently rather than throwing, because
`Naming.js` guards its output on `hasSettings && !isFetching && !error` — with
no connector, `hasSettings` is `undefined`, so the section renders nothing at
all and the page looks fine apart from the missing content.

To confirm these were the only two, every `XConnector` in the frontend was
checked for a sibling component being rendered directly instead of the
connector. Those two were the complete set, and the scan is clean after the fix.

## JAV entry missing from the sidebar

`9bc0e4e58f` (New: Make JAV Tab) added the entry to `PageSidebar.js`; converting
that file to TypeScript dropped it. Re-added to the TypeScript sidebar rather
than reverting the conversion.

It now uses `translate('Jav')` — the key that actually exists in `en.json`. The
original called `translate('JAV')`, which is not a key, so it was relying on
`translate` returning the key itself when lookup fails. It displayed correctly
by accident and could never be translated.

The `/jav` route, `javSeriesIndex` store section and `SeriesIndex`
`seriesType="jav"` handling were all still intact — only the sidebar link was
missing.

## Verification

`tsc --noEmit --skipLibCheck` and eslint clean. Worth noting that neither would
have caught any of these: a `.tsx` file rendering an untyped `.js` component
gets no prop checking, which is the same blind spot that let the signalR default
import through in #1169.
