### PR TITLE
Fixed: Interactive search looping until the browser runs out of connections

### DIFF
--- a/frontend/src/Episode/Search/EpisodeSearch.tsx
+++ b/frontend/src/Episode/Search/EpisodeSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import AppState from 'App/State/AppState';
 import * as commandNames from 'Commands/commandNames';
@@ -45,13 +45,15 @@ function EpisodeSearch({
     setIsInteractiveSearchOpen(true);
   }, []);
 
+  // Must keep a stable identity: InteractiveSearch refetches whenever this
+  // changes, so a fresh object each render loops the search forever.
+  const searchPayload = useMemo(
+    () => ({ episodeId, seriesId }),
+    [episodeId, seriesId]
+  );
+
   if (isInteractiveSearchOpen) {
-    return (
-      <InteractiveSearch
-        type="episode"
-        searchPayload={{ episodeId, seriesId }}
-      />
-    );
+    return <InteractiveSearch type="episode" searchPayload={searchPayload} />;
   }
 
   return (

--- a/frontend/src/Series/Search/SeasonInteractiveSearchModalContent.tsx
+++ b/frontend/src/Series/Search/SeasonInteractiveSearchModalContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Button from 'Components/Link/Button';
 import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
@@ -20,6 +20,13 @@ function SeasonInteractiveSearchModalContent(
 ) {
   const { seriesId, seasonNumber, onModalClose } = props;
 
+  // Must keep a stable identity: InteractiveSearch refetches whenever this
+  // changes, so a fresh object each render loops the search forever.
+  const searchPayload = useMemo(
+    () => ({ seriesId, seasonNumber }),
+    [seriesId, seasonNumber]
+  );
+
   return (
     <ModalContent onModalClose={onModalClose}>
       <ModalHeader>
@@ -31,13 +38,7 @@ function SeasonInteractiveSearchModalContent(
       </ModalHeader>
 
       <ModalBody scrollDirection={scrollDirections.BOTH}>
-        <InteractiveSearch
-          type="season"
-          searchPayload={{
-            seriesId,
-            seasonNumber,
-          }}
-        />
+        <InteractiveSearch type="season" searchPayload={searchPayload} />
       </ModalBody>
 
       <ModalFooter>


### PR DESCRIPTION
Interactive search fired its request in an endless loop until the browser
refused new connections, showing "Unable to load results for this episode
search" and taking the page down with it.

```
GET /api/v3/release?episodeId=898740&seriesId=1042  net::ERR_INSUFFICIENT_RESOURCES
  at releaseActions.js:320
  at InteractiveSearch.tsx:168
```

## Cause

`InteractiveSearch` fetches from an effect keyed on the search payload:

```tsx
useEffect(() => {
  if (!isPopulated) {
    dispatch(fetchReleases(searchPayload));
  }
}, [isPopulated, searchPayload, dispatch]);
```

Both call sites built that payload inline, so it was a **new object on every
render**:

```tsx
<InteractiveSearch type="episode" searchPayload={{ episodeId, seriesId }} />
```

Dispatching the fetch updates the store, which re-renders, which creates a new
payload object, which changes the effect's dependencies, which dispatches
again. Each pass leaves another request in flight, and once enough pile up the
browser starts rejecting them with `ERR_INSUFFICIENT_RESOURCES`. The individual
requests were succeeding with 200 and valid data — the backend was never the
problem.

This came in with Sonarr/Sonarr@03b8c4c28 (#1148), which converted
`InteractiveSearch` from a class component to a function. The class fetched once
in `componentDidMount`; the conversion turned that into an effect and added
`searchPayload` to its dependencies. Upstream does not hit this because their
`InteractiveSearch` uses React Query, which dedupes and caches requests, so they
have no such effect — Whisparr kept the redux fetch.

## Fix

Memoise the payload at both call sites so its identity is stable:

```tsx
const searchPayload = useMemo(
  () => ({ episodeId, seriesId }),
  [episodeId, seriesId]
);
```

The effect then re-runs only when `isPopulated` actually changes. On a
successful search it fires once on mount and once when results arrive (where the
guard stops it); on a failed search `isPopulated` stays false and the
dependencies never change, so it does not retry in a loop.

Fixing it at the call sites rather than by dropping `searchPayload` from the
dependency array keeps the array honest — the effect genuinely does depend on
the payload, and a future caller passing a different episode still refetches
correctly.

Both call sites are covered: `EpisodeSearch` and
`SeasonInteractiveSearchModalContent`.

## Verification

`tsc --noEmit --skipLibCheck` and eslint clean, including
`react-hooks/exhaustive-deps`, which is what would flag the dependency array if
the payload had been removed from it instead.

Worth confirming by watching the Network panel during an interactive search:
there should be exactly one `/api/v3/release` request.
