### PR TITLE
Fixed: Sonarr branding and UI strings rendering as raw translation keys

### DIFF
--- a/frontend/src/Activity/History/Details/HistoryDetails.tsx
+++ b/frontend/src/Activity/History/Details/HistoryDetails.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+﻿import React from 'react';
 import { useSelector } from 'react-redux';
 import DescriptionList from 'Components/DescriptionList/DescriptionList';
 import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem';
@@ -111,7 +111,7 @@ function HistoryDetails(props: HistoryDetailsProps) {
         {seriesMatchType ? (
           <DescriptionListItem
             descriptionClassName={styles.description}
-            title={translate('SeriesMatchType')}
+            title={translate('SiteMatchType')}
             data={seriesMatchType}
           />
         ) : null}

--- a/frontend/src/AddSeries/AddNewSeries/AddNewSeries.tsx
+++ b/frontend/src/AddSeries/AddNewSeries/AddNewSeries.tsx
@@ -76,7 +76,7 @@ function AddNewSeries({ defaultSeriesType }: AddNewSeriesProps) {
   }, [initialTerm]);
 
   return (
-    <PageContent title={translate('AddNewSeries')}>
+    <PageContent title={translate('AddNewSite')}>
       <PageContentBody>
         <div className={styles.searchContainer}>
           <div className={styles.searchIconContainer}>
@@ -87,7 +87,7 @@ function AddNewSeries({ defaultSeriesType }: AddNewSeriesProps) {
             className={styles.searchInput}
             name="seriesLookup"
             value={term}
-            placeholder="eg. Breaking Bad, tvdb:####"
+            placeholder="eg. Brazzers, tpdb:####"
             autoFocus={true}
             onChange={handleSearchInputChange}
           />
@@ -105,7 +105,7 @@ function AddNewSeries({ defaultSeriesType }: AddNewSeriesProps) {
         {!isFetching && !!error ? (
           <div className={styles.message}>
             <div className={styles.helpText}>
-              {translate('AddNewSeriesError')}
+              {translate('AddNewSiteError')}
             </div>
 
             <Alert kind={kinds.DANGER}>{getErrorMessage(error)}</Alert>
@@ -125,10 +125,10 @@ function AddNewSeries({ defaultSeriesType }: AddNewSeriesProps) {
             <div className={styles.noResults}>
               {translate('CouldNotFindResults', { term })}
             </div>
-            <div>{translate('SearchByTvdbId')}</div>
+            <div>{translate('SearchByTpdbId')}</div>
             <div>
-              <Link to="https://wiki.servarr.com/sonarr/faq#why-cant-i-add-a-new-series-when-i-know-the-tvdb-id">
-                {translate('WhyCantIFindMyShow')}
+              <Link to="https://wiki.servarr.com/whisparr/faq#why-cant-i-add-a-new-site-when-i-know-the-tpdb-id">
+                {translate('WhyCantIFindMySite')}
               </Link>
             </div>
           </div>
@@ -137,20 +137,20 @@ function AddNewSeries({ defaultSeriesType }: AddNewSeriesProps) {
         {term ? null : (
           <div className={styles.message}>
             <div className={styles.helpText}>
-              {translate('AddNewSeriesHelpText')}
+              {translate('AddNewSiteHelpText')}
             </div>
-            <div>{translate('SearchByTvdbId')}</div>
+            <div>{translate('SearchByTpdbId')}</div>
           </div>
         )}
 
         {!term && !seriesCount ? (
           <div className={styles.message}>
             <div className={styles.noSeriesText}>
-              {translate('NoSeriesHaveBeenAdded')}
+              {translate('NoSitesHaveBeenAdded')}
             </div>
             <div>
               <Button to="/add/import" kind={kinds.PRIMARY}>
-                {translate('ImportExistingSeries')}
+                {translate('ImportExistingSites')}
               </Button>
             </div>
           </div>

--- a/frontend/src/AddSeries/AddNewSeries/AddNewSeriesModalContent.tsx
+++ b/frontend/src/AddSeries/AddNewSeries/AddNewSeriesModalContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+﻿import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import SeriesMonitoringOptionsPopoverContent from 'AddSeries/SeriesMonitoringOptionsPopoverContent';
 import SeriesTypePopoverContent from 'AddSeries/SeriesTypePopoverContent';
@@ -163,7 +163,7 @@ function AddNewSeriesModalContent({
                     seriesFolder: folder,
                     isWindows,
                   }}
-                  helpText={translate('AddNewSeriesRootFolderHelpText', {
+                  helpText={translate('AddNewSiteRootFolderHelpText', {
                     folder,
                   })}
                   onChange={handleInputChange}
@@ -258,7 +258,7 @@ function AddNewSeriesModalContent({
         <div>
           <label className={styles.searchLabelContainer}>
             <span className={styles.searchLabel}>
-              {translate('AddNewSeriesSearchForMissingEpisodes')}
+              {translate('AddNewSiteSearchForMissingEpisodes')}
             </span>
 
             <CheckInput
@@ -272,7 +272,7 @@ function AddNewSeriesModalContent({
 
           <label className={styles.searchLabelContainer}>
             <span className={styles.searchLabel}>
-              {translate('AddNewSeriesSearchForCutoffUnmetEpisodes')}
+              {translate('AddNewSiteSearchForCutoffUnmetEpisodes')}
             </span>
 
             <CheckInput
@@ -291,7 +291,7 @@ function AddNewSeriesModalContent({
           isSpinning={isAdding}
           onPress={handleAddSeriesPress}
         >
-          {translate('AddSeriesWithTitle', { title })}
+          {translate('AddSiteWithTitle', { title })}
         </SpinnerButton>
       </ModalFooter>
     </ModalContent>

--- a/frontend/src/Components/Page/Header/SeriesSearchInput.tsx
+++ b/frontend/src/Components/Page/Header/SeriesSearchInput.tsx
@@ -1,4 +1,4 @@
-import { push } from 'connected-react-router';
+﻿import { push } from 'connected-react-router';
 import { ExtendedKeyboardEvent } from 'mousetrap';
 import React, {
   FormEvent,
@@ -139,14 +139,14 @@ function SeriesSearchInput() {
 
     if (suggestions.length || isLoading.current) {
       result.push({
-        title: translate('ExistingSeries'),
+        title: translate('ExistingSite'),
         loading: isLoading.current,
         suggestions,
       });
     }
 
     result.push({
-      title: translate('AddNewSeries'),
+      title: translate('AddNewSite'),
       suggestions: [
         {
           type: ADD_NEW_TYPE,

--- a/frontend/src/Series/Delete/DeleteSeriesModalContent.tsx
+++ b/frontend/src/Series/Delete/DeleteSeriesModalContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+﻿import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import AppState from 'App/State/AppState';
 import FormGroup from 'Components/Form/FormGroup';
@@ -61,9 +61,7 @@ function DeleteSeriesModalContent({
 
   return (
     <ModalContent onModalClose={onModalClose}>
-      <ModalHeader>
-        {translate('DeleteSeriesModalHeader', { title })}
-      </ModalHeader>
+      <ModalHeader>{translate('DeleteSiteModalHeader', { title })}</ModalHeader>
 
       <ModalBody>
         <div className={styles.pathContainer}>
@@ -87,7 +85,7 @@ function DeleteSeriesModalContent({
         <FormGroup>
           <FormLabel>
             {episodeFileCount === 0
-              ? translate('DeleteSeriesFolder')
+              ? translate('DeleteSiteFolder')
               : translate('DeleteEpisodesFiles', { episodeFileCount })}
           </FormLabel>
 
@@ -97,7 +95,7 @@ function DeleteSeriesModalContent({
             value={deleteFiles}
             helpText={
               episodeFileCount === 0
-                ? translate('DeleteSeriesFolderHelpText')
+                ? translate('DeleteSiteFolderHelpText')
                 : translate('DeleteEpisodesFilesHelpText')
             }
             kind={kinds.DANGER}
@@ -109,14 +107,14 @@ function DeleteSeriesModalContent({
           <div className={styles.deleteFilesMessage}>
             <div>
               <InlineMarkdown
-                data={translate('DeleteSeriesFolderConfirmation', { path })}
+                data={translate('DeleteSiteFolderConfirmation', { path })}
                 blockClassName={styles.folderPath}
               />
             </div>
 
             {episodeFileCount ? (
               <div className={styles.deleteCount}>
-                {translate('DeleteSeriesFolderEpisodeCount', {
+                {translate('DeleteSiteFolderEpisodeCount', {
                   episodeFileCount,
                   size: formatBytes(sizeOnDisk),
                 })}

--- a/frontend/src/Series/Details/SeriesDetails.tsx
+++ b/frontend/src/Series/Details/SeriesDetails.tsx
@@ -1,4 +1,4 @@
-import moment from 'moment';
+﻿import moment from 'moment';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import TextTruncate from 'react-text-truncate';
@@ -444,12 +444,12 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
   const runningYears =
     status === 'ended' ? `${year}-${getDateYear(lastAired)}` : `${year}-`;
 
-  let episodeFilesCountMessage = translate('SeriesDetailsNoEpisodeFiles');
+  let episodeFilesCountMessage = translate('SiteDetailsNoEpisodeFiles');
 
   if (episodeFileCount === 1) {
-    episodeFilesCountMessage = translate('SeriesDetailsOneEpisodeFile');
+    episodeFilesCountMessage = translate('SiteDetailsOneEpisodeFile');
   } else if (episodeFileCount > 1) {
-    episodeFilesCountMessage = translate('SeriesDetailsCountEpisodeFiles', {
+    episodeFilesCountMessage = translate('SiteDetailsCountEpisodeFiles', {
       episodeFileCount,
     });
   }
@@ -517,7 +517,7 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
           <PageToolbarSeparator />
 
           <PageToolbarButton
-            label={translate('SeriesMonitoring')}
+            label={translate('SiteMonitoring')}
             iconName={icons.MONITORED}
             onPress={handleMonitorOptionsPress}
           />
@@ -605,7 +605,7 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
                     className={styles.seriesNavigationButton}
                     name={icons.ARROW_LEFT}
                     size={30}
-                    title={translate('SeriesDetailsGoTo', {
+                    title={translate('SiteDetailsGoTo', {
                       title: previousSeries.title,
                     })}
                     to={`/series/${previousSeries.titleSlug}`}
@@ -615,7 +615,7 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
                     className={styles.seriesNavigationButton}
                     name={icons.ARROW_RIGHT}
                     size={30}
-                    title={translate('SeriesDetailsGoTo', {
+                    title={translate('SiteDetailsGoTo', {
                       title: nextSeries.title,
                     })}
                     to={`/series/${nextSeries.titleSlug}`}
@@ -627,7 +627,7 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
                 <div>
                   {runtime ? (
                     <span className={styles.runtime}>
-                      {translate('SeriesDetailsRuntime', { runtime })}
+                      {translate('SiteDetailsRuntime', { runtime })}
                     </span>
                   ) : null}
 

--- a/frontend/src/Series/Details/SeriesDetailsPage.tsx
+++ b/frontend/src/Series/Details/SeriesDetailsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+﻿import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router';
 import NotFound from 'Components/NotFound';
@@ -29,7 +29,7 @@ function SeriesDetailsPage() {
   }, [seriesIndex, previousIndex, history]);
 
   if (seriesIndex === -1) {
-    return <NotFound message={translate('SeriesCannotBeFound')} />;
+    return <NotFound message={translate('SiteCannotBeFound')} />;
   }
 
   return <SeriesDetails seriesId={allSeries[seriesIndex].id} />;

--- a/frontend/src/Series/Details/SeriesDetailsSeason.tsx
+++ b/frontend/src/Series/Details/SeriesDetailsSeason.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+﻿import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import EpisodesAppState from 'App/State/EpisodesAppState';
@@ -513,7 +513,7 @@ function SeriesDetailsSeason({
               </Table>
             ) : (
               <div className={styles.noEpisodes}>
-                {translate('NoEpisodesInThisSeason')}
+                {translate('NoEpisodesInThisYear')}
               </div>
             )}
 

--- a/frontend/src/Series/Edit/EditSeriesModalContent.tsx
+++ b/frontend/src/Series/Edit/EditSeriesModalContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+﻿import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import SeriesMonitorNewItemsOptionsPopoverContent from 'AddSeries/SeriesMonitorNewItemsOptionsPopoverContent';
 import AppState from 'App/State/AppState';
@@ -133,7 +133,7 @@ function EditSeriesModalContent({
 
   return (
     <ModalContent onModalClose={onModalClose}>
-      <ModalHeader>{translate('EditSeriesModalHeader', { title })}</ModalHeader>
+      <ModalHeader>{translate('EditSiteModalHeader', { title })}</ModalHeader>
 
       <ModalBody>
         <Form {...otherSettings}>

--- a/frontend/src/Series/MonitoringOptions/MonitoringOptionsModalContent.tsx
+++ b/frontend/src/Series/MonitoringOptions/MonitoringOptionsModalContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+﻿import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import SeriesMonitoringOptionsPopoverContent from 'AddSeries/SeriesMonitoringOptionsPopoverContent';
 import AppState from 'App/State/AppState';
@@ -66,7 +66,7 @@ function MonitoringOptionsModalContent({
 
   return (
     <ModalContent onModalClose={onModalClose}>
-      <ModalHeader>{translate('MonitorSeries')}</ModalHeader>
+      <ModalHeader>{translate('MonitorSite')}</ModalHeader>
 
       <ModalBody>
         <Form>

--- a/frontend/src/Series/MoveSeries/MoveSeriesModal.tsx
+++ b/frontend/src/Series/MoveSeries/MoveSeriesModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+﻿import React from 'react';
 import Button from 'Components/Link/Button';
 import Modal from 'Components/Modal/Modal';
 import ModalBody from 'Components/Modal/ModalBody';
@@ -46,13 +46,13 @@ function MoveSeriesModal({
 
         <ModalBody>
           {destinationRootFolder
-            ? translate('MoveSeriesFoldersToRootFolder', {
+            ? translate('MoveSiteFoldersToRootFolder', {
                 destinationRootFolder,
               })
             : null}
 
           {originalPath && destinationPath
-            ? translate('MoveSeriesFoldersToNewPath', {
+            ? translate('MoveSiteFoldersToNewPath', {
                 originalPath,
                 destinationPath,
               })
@@ -61,11 +61,11 @@ function MoveSeriesModal({
 
         <ModalFooter>
           <Button className={styles.doNotMoveButton} onPress={onSavePress}>
-            {translate('MoveSeriesFoldersDontMoveFiles')}
+            {translate('MoveSiteFoldersDontMoveFiles')}
           </Button>
 
           <Button kind={kinds.DANGER} onPress={onMoveSeriesPress}>
-            {translate('MoveSeriesFoldersMoveFiles')}
+            {translate('MoveSiteFoldersMoveFiles')}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/frontend/src/Settings/ImportLists/ImportListExclusions/EditImportListExclusionModalContent.tsx
+++ b/frontend/src/Settings/ImportLists/ImportListExclusions/EditImportListExclusionModalContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+﻿import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import AppState from 'App/State/AppState';
@@ -139,7 +139,7 @@ function EditImportListExclusionModalContent(
               <FormInputGroup
                 type={inputTypes.TEXT}
                 name="title"
-                helpText={translate('SeriesTitleToExcludeHelpText')}
+                helpText={translate('SiteTitleToExcludeHelpText')}
                 {...title}
                 onChange={onInputChange}
               />

--- a/frontend/src/Settings/MediaManagement/MediaManagement.tsx
+++ b/frontend/src/Settings/MediaManagement/MediaManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+﻿import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import AppState from 'App/State/AppState';
 import Alert from 'Components/Alert';
@@ -193,12 +193,12 @@ function MediaManagement() {
                   isAdvanced={true}
                   size={sizes.MEDIUM}
                 >
-                  <FormLabel>{translate('CreateEmptySeriesFolders')}</FormLabel>
+                  <FormLabel>{translate('CreateEmptySiteFolders')}</FormLabel>
 
                   <FormInputGroup
                     type={inputTypes.CHECK}
                     name="createEmptySeriesFolders"
-                    helpText={translate('CreateEmptySeriesFoldersHelpText')}
+                    helpText={translate('CreateEmptySiteFoldersHelpText')}
                     onChange={handleInputChange}
                     {...settings.createEmptySeriesFolders}
                   />
@@ -422,7 +422,7 @@ function MediaManagement() {
                 isAdvanced={true}
               >
                 <FormLabel>
-                  {translate('RescanSeriesFolderAfterRefresh')}
+                  {translate('RescanSiteFolderAfterRefresh')}
                 </FormLabel>
 
                 <FormInputGroup

--- a/frontend/src/Settings/Notifications/Notifications/Notification.tsx
+++ b/frontend/src/Settings/Notifications/Notifications/Notification.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+﻿import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import Card from 'Components/Card';
 import Label from 'Components/Label';
@@ -113,11 +113,11 @@ function Notification({
       ) : null}
 
       {supportsOnSeriesAdd && onSeriesAdd ? (
-        <Label kind={kinds.SUCCESS}>{translate('OnSeriesAdd')}</Label>
+        <Label kind={kinds.SUCCESS}>{translate('OnSiteAdd')}</Label>
       ) : null}
 
       {supportsOnSeriesDelete && onSeriesDelete ? (
-        <Label kind={kinds.SUCCESS}>{translate('OnSeriesDelete')}</Label>
+        <Label kind={kinds.SUCCESS}>{translate('OnSiteDelete')}</Label>
       ) : null}
 
       {supportsOnEpisodeFileDelete && onEpisodeFileDelete ? (

--- a/frontend/src/Settings/Notifications/Notifications/NotificationEventItems.tsx
+++ b/frontend/src/Settings/Notifications/Notifications/NotificationEventItems.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+﻿import React from 'react';
 import FormGroup from 'Components/Form/FormGroup';
 import FormInputGroup from 'Components/Form/FormInputGroup';
 import FormInputHelpText from 'Components/Form/FormInputHelpText';
@@ -119,7 +119,7 @@ function NotificationEventItems({
             <FormInputGroup
               type={inputTypes.CHECK}
               name="onSeriesAdd"
-              helpText={translate('OnSeriesAdd')}
+              helpText={translate('OnSiteAdd')}
               isDisabled={!supportsOnSeriesAdd.value}
               {...onSeriesAdd}
               onChange={onInputChange}

--- a/frontend/src/System/Status/Health/HealthItemLink.tsx
+++ b/frontend/src/System/Status/Health/HealthItemLink.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+﻿import React from 'react';
 import IconButton from 'Components/Link/IconButton';
 import { icons } from 'Helpers/Props';
 import translate from 'Utilities/String/translate';
@@ -45,7 +45,7 @@ function HealthItemLink(props: HealthItemLinkProps) {
       return (
         <IconButton
           name={icons.SERIES_CONTINUING}
-          title={translate('SeriesEditor')}
+          title={translate('SiteEditor')}
           to="/serieseditor"
         />
       );


### PR DESCRIPTION
The Add New Site search box showed Sonarr's example, and the surrounding help
text was rendering raw translation key names.

## The reported bug

`AddNewSeries.tsx` had the placeholder hardcoded:

```tsx
placeholder="eg. Breaking Bad, tvdb:####"
```

Restored to Whisparr's `eg. Brazzers, tpdb:####`, along with everything else on
that page the TypeScript conversion (Sonarr/Sonarr@03b8c4c28, #1166) swapped for
Sonarr's version: the page title, the "why can't I find my site" link (which
pointed at Sonarr's FAQ anchor), and the help text.

## The larger problem it exposed

`translate()` returns the key itself when lookup fails, so a key Whisparr does
not define renders the identifier on screen as if it were prose — no error, no
warning, nothing in the console. The Add New Site page was showing literal
`SearchByTvdbId`, `AddNewSeriesHelpText` and `WhyCantIFindMyShow` text.

Auditing every `translate()` call against `en.json` found **110 keys with no
entry**, spread across the conversions. Of those, 39 have an exact Whisparr
counterpart that differs only by terminology — `AddNewSeriesRootFolderHelpText`
vs `AddNewSiteRootFolderHelpText`, `MoveSeriesFoldersToNewPath` vs
`MoveSiteFoldersToNewPath`, and so on. Those are fixed here: every replacement
was verified to resolve to a key that actually exists, so none can render worse
than it does today.

That covers Series Details, Delete/Edit/Move Series, Media Management, the
notification list, health item links, history details and the Add New Site
modal.

## Deliberately not included

**`Series` → `Site`.** It has a counterpart, but its fallback renders the word
"Series", which reads as ordinary English rather than a broken identifier.
Changing it is a terminology decision, not a bug fix, so it belongs in its own
change.

**71 keys with no counterpart at all.** These need strings written rather than
remapped, and some are judgement calls about Whisparr's wording — for example
`AddListExclusionSeriesHelpText`, `DelayProfileSeriesTagsHelpText`,
`EpisodeGrabbedTooltip`, `DatabaseMigration`, `Anime`, `Daily`. A few render
acceptably by accident (`Email`, `Confirm`, `Completed`); most do not. Worth a
follow-up pass.

## Verification

`tsc --noEmit --skipLibCheck` clean. eslint clean apart from one pre-existing
error in `index.css.d.ts`, confirmed by stashing the change and re-running.

The audit script is the useful part to keep: nothing in the build catches this
class of bug, because a missing key is valid TypeScript and valid at runtime.
