### PR TITLE
Fixed: Release installs being updated to develop builds (forward-port of #1174)

### DIFF
--- a/src/NzbDrone.Core.Test/UpdateTests/UpdatePackageProviderFixture.cs
+++ b/src/NzbDrone.Core.Test/UpdateTests/UpdatePackageProviderFixture.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using FluentAssertions;
 using Moq;
@@ -58,6 +58,44 @@ namespace NzbDrone.Core.Test.UpdateTests
         public void should_get_nothing_if_branch_doesnt_exit()
         {
             Subject.GetLatestUpdate("invalid_branch", new Version(3, 0)).Should().BeNull();
+        }
+
+        // Installs created before the branch default was corrected persisted Sonarr's
+        // branch names. Those matched neither arm of the old filter, so nothing was
+        // filtered and a stable install was offered the newest build overall -- always
+        // a develop one. An unknown branch must be treated as stable.
+        [TestCase("nightly")]
+        [TestCase("master")]
+        [TestCase("")]
+        public void should_not_offer_develop_builds_to_unrecognised_branches(string branch)
+        {
+            var recent = Subject.GetRecentUpdates(branch, new Version(1, 0), null);
+
+            recent.Should().NotBeEmpty();
+            recent.Should().OnlyContain(c => !c.FileName.Contains("develop"));
+        }
+
+        // A branch that names the develop channel still selects pre-releases, even
+        // though it is not one of Whisparr's own branch names. ConfigFileProvider
+        // normalises stored values before they reach here, so this only covers a
+        // branch passed in directly.
+        [TestCase("develop")]
+        [TestCase("v2-develop")]
+        public void should_offer_develop_builds_to_develop_branches(string branch)
+        {
+            var recent = Subject.GetRecentUpdates(branch, new Version(1, 0), null);
+
+            recent.Should().NotBeEmpty();
+            recent.Should().OnlyContain(c => c.FileName.Contains("develop"));
+        }
+
+        [Test]
+        public void should_not_offer_a_develop_build_as_the_latest_update_for_a_legacy_branch()
+        {
+            var update = Subject.GetLatestUpdate("nightly", new Version(1, 0));
+
+            update.Should().NotBeNull();
+            update.FileName.Should().NotContain("develop");
         }
 
         [Test]

--- a/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
+++ b/src/NzbDrone.Core/Configuration/ConfigFileProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -232,7 +232,27 @@ namespace NzbDrone.Core.Configuration
 
         public bool AnalyticsEnabled => GetValueBoolean("AnalyticsEnabled", true, persist: false);
 
-        public string Branch => GetValue("Branch", "nightly").ToLowerInvariant();
+        private static readonly Regex ValidBranchRegex = new Regex(@"^v\d+(-develop)?$", RegexOptions.Compiled);
+
+        public string Branch
+        {
+            get
+            {
+                var branch = GetValue("Branch", BuildInfo.Branch).ToLowerInvariant();
+
+                // Older installs persisted Sonarr's branch names ("nightly", "develop",
+                // "master"), which match none of Whisparr's release channels. Left alone
+                // they disable update filtering entirely, so a stable install is offered
+                // develop builds. CI stamps the originating branch into the assembly, so
+                // fall back to the channel this build actually came from.
+                if (!ValidBranchRegex.IsMatch(branch))
+                {
+                    return BuildInfo.Branch.ToLowerInvariant();
+                }
+
+                return branch;
+            }
+        }
 
         public string LogLevel => GetValue("LogLevel", "info").ToLowerInvariant();
         public int LogSizeLimit => GetValueInt("LogSizeLimit", 1);

--- a/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
+++ b/src/NzbDrone.Core/Configuration/DeploymentInfoProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Text.RegularExpressions;
 using NzbDrone.Common.Disk;
@@ -34,7 +34,12 @@ namespace NzbDrone.Core.Configuration
             var releaseInfoPath = Path.Combine(bin, "release_info");
 
             PackageUpdateMechanism = UpdateMechanism.BuiltIn;
-            DefaultBranch = "nightly";
+
+            // Only the Debian packaging writes a package_info file, so every other
+            // install (Windows installer, zip, tarball) lands on this default. It must
+            // name a real Whisparr channel; CI stamps the originating branch into the
+            // assembly, so use that rather than a hardcoded guess.
+            DefaultBranch = BuildInfo.Branch;
 
             if (Path.GetFileName(bin) == "bin" && diskProvider.FileExists(packageInfoPath))
             {

--- a/src/NzbDrone.Core/Update/GithubUpdatePackageProvider.cs
+++ b/src/NzbDrone.Core/Update/GithubUpdatePackageProvider.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -117,28 +117,30 @@ namespace NzbDrone.Core.Update
 
             var packages = new List<UpdatePackage>();
 
+            // An unrecognised branch is treated as stable, so a bad value can never
+            // fall through to offering pre-releases.
+            var wantsPrerelease = branch != null &&
+                                  branch.Contains("develop", StringComparison.OrdinalIgnoreCase);
+
             foreach (var release in releases)
             {
-                // Filter out releases that do not match the requested branch
-                // For v2, skip tags with 'develop'; for v2-develop, skip tags without 'develop'
-                if (!string.IsNullOrEmpty(branch))
+                // Whisparr publishes stable builds from 'v2' and pre-releases from
+                // 'v2-develop'. Compare channels rather than testing for specific branch
+                // names: the previous check only filtered when the branch was exactly
+                // "v2" or contained "develop", so any other value (older installs
+                // persisted Sonarr's "nightly") matched neither test and filtered
+                // nothing, leaving a stable install to take the newest release overall,
+                // which is always a develop build.
+                var isPrerelease = release.prerelease ||
+                                   release.tag_name.Contains("develop", StringComparison.OrdinalIgnoreCase);
+
+                if (isPrerelease != wantsPrerelease)
                 {
-                    var tagLower = release.tag_name.ToLowerInvariant();
-                    var branchLower = branch.ToLowerInvariant();
-
-                    // If branch is exactly 'v2', skip develop tags
-                    if (branchLower == "v2" && tagLower.Contains("develop"))
-                    {
-                        _logger.Debug($"Skipping prerelease {release.tag_name} for stable branch {branch}.");
-                        continue;
-                    }
-
-                    // If branch contains 'develop', skip tags without 'develop'
-                    if (branchLower.Contains("develop") && !tagLower.Contains("develop"))
-                    {
-                        _logger.Debug($"Skipping release {release.tag_name} because it is a release tag and branch is {branch}.");
-                        continue;
-                    }
+                    _logger.Debug("Skipping {0} ({1}) for branch {2}.",
+                        release.tag_name,
+                        isPrerelease ? "pre-release" : "release",
+                        branch);
+                    continue;
                 }
 
                 if (release.assets == null)
@@ -254,6 +256,9 @@ namespace NzbDrone.Core.Update
         {
             /// <summary>The tag name of the release.</summary>
             public string tag_name { get; set; }
+
+            /// <summary>Whether GitHub marked this release as a pre-release.</summary>
+            public bool prerelease { get; set; }
 
             /// <summary>The body/description of the release.</summary>
             public string body { get; set; }


### PR DESCRIPTION
Forward-ports the update-channel fix from `v2` (#1174) so the next release cut
from this branch does not reintroduce it.

Cherry-picked cleanly with no conflicts — `GithubUpdatePackageProvider.cs` and
`DeploymentInfoProvider.cs` were byte-identical between the branches, and
`ConfigFileProvider.cs` differed only in areas this change does not touch.

## Recap of the fix

Release installs were being auto-updated to develop builds:

- `ConfigFileProvider.Branch` and `DeploymentInfoProvider.DefaultBranch`
  defaulted to `"nightly"`, a Sonarr channel name that matches neither of
  Whisparr's. Only the Debian packaging writes a `package_info` file with the
  real branch, so Windows, zip and tarball installs all landed on that default —
  and it was persisted into `config.xml`.
- `GithubUpdatePackageProvider` only filtered when the branch was exactly `"v2"`
  or contained `"develop"`. Any other value matched neither test, so nothing was
  filtered and the newest release overall won — always a develop pre-release.

Now both defaults come from `BuildInfo.Branch` (CI stamps the originating branch
into the assembly), installs that already persisted an unrecognised branch fall
back to that same value, and the filter compares channels so an unexpected
branch can never disable filtering again.

The MailKit bump from #1174 is not included: this branch is already on 4.17.0.

## Verification

Solution builds clean on net8.0 with analyzers on. `UpdateTests` 29 passed / 0
failed, full `Whisparr.Core.Test` 3559 passed / 0 failed.
