### PR TITLE
Chore: Sonarr Upstream Sync - Batch 25 (March 2025)

### DIFF
--- a/frontend/build/webpack.config.js
+++ b/frontend/build/webpack.config.js
@@ -65,7 +65,7 @@ module.exports = (env) => {
 
     output: {
       path: distFolder,
-      publicPath: '/',
+      publicPath: 'auto',
       filename: isProduction ? '[name]-[contenthash].js' : '[name].js',
       sourceMapFilename: '[file].map'
     },

--- a/frontend/src/Activity/History/Details/HistoryDetails.tsx
+++ b/frontend/src/Activity/History/Details/HistoryDetails.tsx
@@ -174,7 +174,7 @@ function HistoryDetails(props: HistoryDetailsProps) {
   }
 
   if (eventType === 'downloadFailed') {
-    const { message } = data as DownloadFailedHistory;
+    const { message, indexer } = data as DownloadFailedHistory;
 
     return (
       <DescriptionList>
@@ -186,6 +186,10 @@ function HistoryDetails(props: HistoryDetailsProps) {
 
         {downloadId ? (
           <DescriptionListItem title={translate('GrabId')} data={downloadId} />
+        ) : null}
+
+        {indexer ? (
+          <DescriptionListItem title={translate('Indexer')} data={indexer} />
         ) : null}
 
         {message ? (

--- a/frontend/src/Components/Modal/Modal.css
+++ b/frontend/src/Components/Modal/Modal.css
@@ -88,13 +88,6 @@
 }
 
 @media only screen and (max-width: $breakpointMedium) {
-  .modal.small,
-  .modal.medium {
-    width: 90%;
-  }
-}
-
-@media only screen and (max-width: $breakpointSmall) {
   .modalContainer {
     position: fixed;
   }

--- a/frontend/src/Components/Table/Cells/TableRowCell.css
+++ b/frontend/src/Components/Table/Cells/TableRowCell.css
@@ -4,7 +4,7 @@
   line-height: 1.52857143;
 }
 
-@media only screen and (max-width: $breakpointSmall) {
+@media only screen and (max-width: $breakpointMedium) {
   .cell {
     white-space: nowrap;
   }

--- a/frontend/src/Components/Table/Cells/VirtualTableRowCell.css
+++ b/frontend/src/Components/Table/Cells/VirtualTableRowCell.css
@@ -7,7 +7,7 @@
   white-space: nowrap;
 }
 
-@media only screen and (max-width: $breakpointSmall) {
+@media only screen and (max-width: $breakpointMedium) {
   .cell {
     white-space: nowrap;
   }

--- a/frontend/src/Components/Table/Table.css
+++ b/frontend/src/Components/Table/Table.css
@@ -10,7 +10,7 @@
   border-collapse: collapse;
 }
 
-@media only screen and (max-width: $breakpointSmall) {
+@media only screen and (max-width: $breakpointMedium) {
   .tableContainer {
     min-width: 100%;
     width: fit-content;

--- a/frontend/src/Components/Table/TableHeaderCell.css
+++ b/frontend/src/Components/Table/TableHeaderCell.css
@@ -9,7 +9,7 @@
   margin-left: 10px;
 }
 
-@media only screen and (max-width: $breakpointSmall) {
+@media only screen and (max-width: $breakpointMedium) {
   .headerCell {
     white-space: nowrap;
   }

--- a/frontend/src/Components/Table/TablePager.css
+++ b/frontend/src/Components/Table/TablePager.css
@@ -60,7 +60,7 @@
   height: 25px;
 }
 
-@media only screen and (max-width: $breakpointSmall) {
+@media only screen and (max-width: $breakpointMedium) {
   .pager {
     flex-wrap: wrap;
   }

--- a/frontend/src/Components/Table/VirtualTableHeaderCell.css
+++ b/frontend/src/Components/Table/VirtualTableHeaderCell.css
@@ -9,7 +9,7 @@
   margin-left: 10px;
 }
 
-@media only screen and (max-width: $breakpointSmall) {
+@media only screen and (max-width: $breakpointMedium) {
   .headerCell {
     white-space: nowrap;
   }

--- a/frontend/src/Series/Delete/DeleteSeriesModalContent.tsx
+++ b/frontend/src/Series/Delete/DeleteSeriesModalContent.tsx
@@ -50,7 +50,9 @@ function DeleteSeriesModalContent({
     dispatch(
       deleteSeries({ id: seriesId, deleteFiles, addImportListExclusion })
     );
-  }, [seriesId, addImportListExclusion, deleteFiles, dispatch]);
+
+    onModalClose();
+  }, [seriesId, addImportListExclusion, deleteFiles, dispatch, onModalClose]);
 
   const handleDeleteOptionChange = useCallback(
     ({ name, value }: CheckInputChanged) => {

--- a/frontend/src/Series/Details/SeriesDetails.css
+++ b/frontend/src/Series/Details/SeriesDetails.css
@@ -153,6 +153,13 @@
   padding: 20px;
 }
 
+.seriesProgressLabel {
+  composes: label from '~Components/Label.css';
+
+  margin: 0;
+  font-size: 17px;
+}
+
 @media only screen and (max-width: $breakpointSmall) {
   .contentContainer {
     padding: 20px 0;

--- a/frontend/src/Series/Details/SeriesDetails.css.d.ts
+++ b/frontend/src/Series/Details/SeriesDetails.css.d.ts
@@ -24,6 +24,7 @@ interface CssExports {
   'runtime': string;
   'seriesNavigationButton': string;
   'seriesNavigationButtons': string;
+  'seriesProgressLabel': string;
   'sizeOnDisk': string;
   'statusName': string;
   'tags': string;

--- a/frontend/src/Series/Details/SeriesDetails.tsx
+++ b/frontend/src/Series/Details/SeriesDetails.tsx
@@ -70,6 +70,7 @@ import toggleSelected from 'Utilities/Table/toggleSelected';
 import SeriesAlternateTitles from './SeriesAlternateTitles';
 import SeriesDetailsLinks from './SeriesDetailsLinks';
 import SeriesDetailsSeason from './SeriesDetailsSeason';
+import SeriesProgressLabel from './SeriesProgressLabel';
 import SeriesTags from './SeriesTags';
 import styles from './SeriesDetails.css';
 
@@ -438,7 +439,12 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
     isSaving = false,
   } = series;
 
-  const { episodeFileCount = 0, sizeOnDisk = 0, lastAired } = statistics;
+  const {
+    episodeCount = 0,
+    episodeFileCount = 0,
+    sizeOnDisk = 0,
+    lastAired,
+  } = statistics;
 
   const statusDetails = getSeriesStatusDetails(status);
   const runningYears =
@@ -769,6 +775,14 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
                     position={tooltipPositions.BOTTOM}
                   />
                 ) : null}
+
+                <SeriesProgressLabel
+                  className={styles.seriesProgressLabel}
+                  seriesId={seriesId}
+                  monitored={monitored}
+                  episodeCount={episodeCount}
+                  episodeFileCount={episodeFileCount}
+                />
               </div>
 
               <div ref={overviewRef} className={styles.overview}>

--- a/frontend/src/Series/Details/SeriesDetails.tsx
+++ b/frontend/src/Series/Details/SeriesDetails.tsx
@@ -41,6 +41,7 @@ import { Image, Statistics } from 'Series/Series';
 import SeriesGenres from 'Series/SeriesGenres';
 import SeriesPoster from 'Series/SeriesPoster';
 import { getSeriesStatusDetails } from 'Series/SeriesStatus';
+import useSeries from 'Series/useSeries';
 import QualityProfileName from 'Settings/Profiles/Quality/QualityProfileName';
 import { executeCommand } from 'Store/Actions/commandActions';
 import { clearEpisodes, fetchEpisodes } from 'Store/Actions/episodeActions';
@@ -125,40 +126,6 @@ function createEpisodeFilesSelector() {
   );
 }
 
-function createSeriesSelector(seriesId: number) {
-  return createSelector(createAllSeriesSelector(), (allSeries) => {
-    const sortedSeries = [...allSeries].sort(sortByProp('sortTitle'));
-    const seriesIndex = sortedSeries.findIndex(
-      (series) => series.id === seriesId
-    );
-
-    if (seriesIndex === -1) {
-      return {
-        series: undefined,
-        nextSeries: undefined,
-        previousSeries: undefined,
-      };
-    }
-
-    const series = sortedSeries[seriesIndex];
-    const nextSeries = sortedSeries[seriesIndex + 1] ?? sortedSeries[0];
-    const previousSeries =
-      sortedSeries[seriesIndex - 1] ?? sortedSeries[sortedSeries.length - 1];
-
-    return {
-      series,
-      nextSeries: {
-        title: nextSeries.title,
-        titleSlug: nextSeries.titleSlug,
-      },
-      previousSeries: {
-        title: previousSeries.title,
-        titleSlug: previousSeries.titleSlug,
-      },
-    };
-  });
-}
-
 interface ExpandedState {
   allExpanded: boolean;
   allCollapsed: boolean;
@@ -171,9 +138,10 @@ interface SeriesDetailsProps {
 
 function SeriesDetails({ seriesId }: SeriesDetailsProps) {
   const dispatch = useDispatch();
-  const { series, nextSeries, previousSeries } = useSelector(
-    createSeriesSelector(seriesId)
-  );
+
+  const series = useSeries(seriesId);
+  const allSeries = useSelector(createAllSeriesSelector());
+
   const {
     isEpisodesFetching,
     isEpisodesPopulated,
@@ -235,6 +203,35 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
       isSearching: isSearchingExecuting,
     };
   }, [seriesId, commands]);
+
+  const { nextSeries, previousSeries } = useMemo(() => {
+    const sortedSeries = [...allSeries].sort(sortByProp('sortTitle'));
+    const seriesIndex = sortedSeries.findIndex(
+      (series) => series.id === seriesId
+    );
+
+    if (seriesIndex === -1) {
+      return {
+        nextSeries: undefined,
+        previousSeries: undefined,
+      };
+    }
+
+    const nextSeries = sortedSeries[seriesIndex + 1] ?? sortedSeries[0];
+    const previousSeries =
+      sortedSeries[seriesIndex - 1] ?? sortedSeries[sortedSeries.length - 1];
+
+    return {
+      nextSeries: {
+        title: nextSeries.title,
+        titleSlug: nextSeries.titleSlug,
+      },
+      previousSeries: {
+        title: previousSeries.title,
+        titleSlug: previousSeries.titleSlug,
+      },
+    };
+  }, [seriesId, allSeries]);
 
   const [isOrganizeModalOpen, setIsOrganizeModalOpen] = useState(false);
   const [isManageEpisodesOpen, setIsManageEpisodesOpen] = useState(false);
@@ -607,25 +604,29 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
                 </div>
 
                 <div className={styles.seriesNavigationButtons}>
-                  <IconButton
-                    className={styles.seriesNavigationButton}
-                    name={icons.ARROW_LEFT}
-                    size={30}
-                    title={translate('SiteDetailsGoTo', {
-                      title: previousSeries.title,
-                    })}
-                    to={`/series/${previousSeries.titleSlug}`}
-                  />
+                  {previousSeries ? (
+                    <IconButton
+                      className={styles.seriesNavigationButton}
+                      name={icons.ARROW_LEFT}
+                      size={30}
+                      title={translate('SiteDetailsGoTo', {
+                        title: previousSeries.title,
+                      })}
+                      to={`/series/${previousSeries.titleSlug}`}
+                    />
+                  ) : null}
 
-                  <IconButton
-                    className={styles.seriesNavigationButton}
-                    name={icons.ARROW_RIGHT}
-                    size={30}
-                    title={translate('SiteDetailsGoTo', {
-                      title: nextSeries.title,
-                    })}
-                    to={`/series/${nextSeries.titleSlug}`}
-                  />
+                  {nextSeries ? (
+                    <IconButton
+                      className={styles.seriesNavigationButton}
+                      name={icons.ARROW_RIGHT}
+                      size={30}
+                      title={translate('SiteDetailsGoTo', {
+                        title: nextSeries.title,
+                      })}
+                      to={`/series/${nextSeries.titleSlug}`}
+                    />
+                  ) : null}
                 </div>
               </div>
 

--- a/frontend/src/Series/Details/SeriesDetails.tsx
+++ b/frontend/src/Series/Details/SeriesDetails.tsx
@@ -188,7 +188,6 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
   } = useSelector(createEpisodeFilesSelector());
 
   const commands = useSelector(createCommandsSelector());
-  const isSaving = useSelector((state: AppState) => state.series.isSaving);
 
   const { isRefreshing, isRenaming, isSearching } = useMemo(() => {
     const seriesRefreshingCommand = findCommand(commands, {
@@ -436,6 +435,7 @@ function SeriesDetails({ seriesId }: SeriesDetailsProps) {
     genres,
     tags,
     year,
+    isSaving = false,
   } = series;
 
   const { episodeFileCount = 0, sizeOnDisk = 0, lastAired } = statistics;

--- a/frontend/src/Series/Details/SeriesProgressLabel.tsx
+++ b/frontend/src/Series/Details/SeriesProgressLabel.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import Label from 'Components/Label';
+import { kinds, sizes } from 'Helpers/Props';
+import createSeriesQueueItemsDetailsSelector, {
+  SeriesQueueDetails,
+} from 'Series/Index/createSeriesQueueDetailsSelector';
+
+function getEpisodeCountKind(
+  monitored: boolean,
+  episodeFileCount: number,
+  episodeCount: number,
+  isDownloading: boolean
+) {
+  if (isDownloading) {
+    return kinds.PURPLE;
+  }
+
+  if (episodeFileCount === episodeCount && episodeCount > 0) {
+    return kinds.SUCCESS;
+  }
+
+  if (!monitored) {
+    return kinds.WARNING;
+  }
+
+  return kinds.DANGER;
+}
+
+interface SeriesProgressLabelProps {
+  className: string;
+  seriesId: number;
+  monitored: boolean;
+  episodeCount: number;
+  episodeFileCount: number;
+}
+
+function SeriesProgressLabel({
+  className,
+  seriesId,
+  monitored,
+  episodeCount,
+  episodeFileCount,
+}: SeriesProgressLabelProps) {
+  const queueDetails: SeriesQueueDetails = useSelector(
+    createSeriesQueueItemsDetailsSelector(seriesId)
+  );
+
+  const newDownloads = queueDetails.count - queueDetails.episodesWithFiles;
+  const text = newDownloads
+    ? `${episodeFileCount} + ${newDownloads} / ${episodeCount}`
+    : `${episodeFileCount} / ${episodeCount}`;
+
+  return (
+    <Label
+      className={className}
+      kind={getEpisodeCountKind(
+        monitored,
+        episodeFileCount,
+        episodeCount,
+        queueDetails.count > 0
+      )}
+      size={sizes.LARGE}
+    >
+      <span>{text}</span>
+    </Label>
+  );
+}
+
+export default SeriesProgressLabel;

--- a/frontend/src/Settings/CustomFormats/CustomFormats/Manage/ManageCustomFormatsModalContent.tsx
+++ b/frontend/src/Settings/CustomFormats/CustomFormats/Manage/ManageCustomFormatsModalContent.tsx
@@ -10,11 +10,11 @@ import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
 import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
+import Column from 'Components/Table/Column';
 import Table from 'Components/Table/Table';
 import TableBody from 'Components/Table/TableBody';
 import useSelectState from 'Helpers/Hooks/useSelectState';
 import { kinds } from 'Helpers/Props';
-import { SortDirection } from 'Helpers/Props/sortDirections';
 import {
   bulkDeleteCustomFormats,
   bulkEditCustomFormats,
@@ -34,7 +34,7 @@ type OnSelectedChangeCallback = React.ComponentProps<
   typeof ManageCustomFormatsModalRow
 >['onSelectedChange'];
 
-const COLUMNS = [
+const COLUMNS: Column[] = [
   {
     name: 'name',
     label: () => translate('Name'),
@@ -51,8 +51,6 @@ const COLUMNS = [
 
 interface ManageCustomFormatsModalContentProps {
   onModalClose(): void;
-  sortKey?: string;
-  sortDirection?: SortDirection;
 }
 
 function ManageCustomFormatsModalContent(

--- a/frontend/src/Settings/DownloadClients/DownloadClients/Manage/ManageDownloadClientsModalContent.tsx
+++ b/frontend/src/Settings/DownloadClients/DownloadClients/Manage/ManageDownloadClientsModalContent.tsx
@@ -10,11 +10,11 @@ import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
 import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
+import Column from 'Components/Table/Column';
 import Table from 'Components/Table/Table';
 import TableBody from 'Components/Table/TableBody';
 import useSelectState from 'Helpers/Hooks/useSelectState';
 import { kinds } from 'Helpers/Props';
-import { SortDirection } from 'Helpers/Props/sortDirections';
 import {
   bulkDeleteDownloadClients,
   bulkEditDownloadClients,
@@ -35,7 +35,7 @@ type OnSelectedChangeCallback = React.ComponentProps<
   typeof ManageDownloadClientsModalRow
 >['onSelectedChange'];
 
-const COLUMNS = [
+const COLUMNS: Column[] = [
   {
     name: 'name',
     label: () => translate('Name'),
@@ -82,8 +82,6 @@ const COLUMNS = [
 
 interface ManageDownloadClientsModalContentProps {
   onModalClose(): void;
-  sortKey?: string;
-  sortDirection?: SortDirection;
 }
 
 function ManageDownloadClientsModalContent(

--- a/frontend/src/Settings/Indexers/Indexers/Manage/Edit/ManageIndexersEditModalContent.tsx
+++ b/frontend/src/Settings/Indexers/Indexers/Manage/Edit/ManageIndexersEditModalContent.tsx
@@ -17,6 +17,7 @@ interface SavePayload {
   enableAutomaticSearch?: boolean;
   enableInteractiveSearch?: boolean;
   priority?: number;
+  seasonSearchMaximumSingleEpisodeAge?: number;
 }
 
 interface ManageIndexersEditModalContentProps {
@@ -59,6 +60,10 @@ function ManageIndexersEditModalContent(
   const [enableInteractiveSearch, setEnableInteractiveSearch] =
     useState(NO_CHANGE);
   const [priority, setPriority] = useState<null | number>(null);
+  const [
+    seasonSearchMaximumSingleEpisodeAge,
+    setSeasonSearchMaximumSingleEpisodeAge,
+  ] = useState<null | number>(null);
 
   const save = useCallback(() => {
     let hasChanges = false;
@@ -84,6 +89,12 @@ function ManageIndexersEditModalContent(
       payload.priority = priority as number;
     }
 
+    if (seasonSearchMaximumSingleEpisodeAge !== null) {
+      hasChanges = true;
+      payload.seasonSearchMaximumSingleEpisodeAge =
+        seasonSearchMaximumSingleEpisodeAge as number;
+    }
+
     if (hasChanges) {
       onSavePress(payload);
     }
@@ -94,6 +105,7 @@ function ManageIndexersEditModalContent(
     enableAutomaticSearch,
     enableInteractiveSearch,
     priority,
+    seasonSearchMaximumSingleEpisodeAge,
     onSavePress,
     onModalClose,
   ]);
@@ -111,6 +123,9 @@ function ManageIndexersEditModalContent(
         break;
       case 'priority':
         setPriority(value as number);
+        break;
+      case 'seasonSearchMaximumSingleEpisodeAge':
+        setSeasonSearchMaximumSingleEpisodeAge(value as number);
         break;
       default:
         console.warn(`EditIndexersModalContent Unknown Input: '${name}'`);
@@ -169,6 +184,20 @@ function ManageIndexersEditModalContent(
             value={priority}
             min={1}
             max={50}
+            onChange={onInputChange}
+          />
+        </FormGroup>
+
+        <FormGroup>
+          <FormLabel>{translate('MaximumSingleEpisodeAge')}</FormLabel>
+
+          <FormInputGroup
+            type={inputTypes.NUMBER}
+            name="seasonSearchMaximumSingleEpisodeAge"
+            helpText={translate('MaximumSingleEpisodeAgeHelpText')}
+            value={seasonSearchMaximumSingleEpisodeAge}
+            min={0}
+            unit="days"
             onChange={onInputChange}
           />
         </FormGroup>

--- a/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalContent.tsx
+++ b/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalContent.tsx
@@ -73,6 +73,12 @@ const COLUMNS = [
     isVisible: true,
   },
   {
+    name: 'seasonSearchMaximumSingleEpisodeAge',
+    label: () => translate('MaximumSingleEpisodeAge'),
+    isSortable: true,
+    isVisible: true,
+  },
+  {
     name: 'tags',
     label: () => translate('Tags'),
     isSortable: true,

--- a/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalContent.tsx
+++ b/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalContent.tsx
@@ -10,11 +10,11 @@ import ModalBody from 'Components/Modal/ModalBody';
 import ModalContent from 'Components/Modal/ModalContent';
 import ModalFooter from 'Components/Modal/ModalFooter';
 import ModalHeader from 'Components/Modal/ModalHeader';
+import Column from 'Components/Table/Column';
 import Table from 'Components/Table/Table';
 import TableBody from 'Components/Table/TableBody';
 import useSelectState from 'Helpers/Hooks/useSelectState';
 import { kinds } from 'Helpers/Props';
-import { SortDirection } from 'Helpers/Props/sortDirections';
 import {
   bulkDeleteIndexers,
   bulkEditIndexers,
@@ -35,7 +35,7 @@ type OnSelectedChangeCallback = React.ComponentProps<
   typeof ManageIndexersModalRow
 >['onSelectedChange'];
 
-const COLUMNS = [
+const COLUMNS: Column[] = [
   {
     name: 'name',
     label: () => translate('Name'),
@@ -88,8 +88,6 @@ const COLUMNS = [
 
 interface ManageIndexersModalContentProps {
   onModalClose(): void;
-  sortKey?: string;
-  sortDirection?: SortDirection;
 }
 
 function ManageIndexersModalContent(props: ManageIndexersModalContentProps) {

--- a/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalRow.css
+++ b/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalRow.css
@@ -4,6 +4,7 @@
 .enableAutomaticSearch,
 .enableInteractiveSearch,
 .priority,
+.seasonSearchMaximumSingleEpisodeAge,
 .implementation {
   composes: cell from '~Components/Table/Cells/TableRowCell.css';
 

--- a/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalRow.css.d.ts
+++ b/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalRow.css.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'implementation': string;
   'name': string;
   'priority': string;
+  'seasonSearchMaximumSingleEpisodeAge': string;
   'tags': string;
 }
 export const cssExports: CssExports;

--- a/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalRow.tsx
+++ b/frontend/src/Settings/Indexers/Indexers/Manage/ManageIndexersModalRow.tsx
@@ -17,6 +17,7 @@ interface ManageIndexersModalRowProps {
   enableAutomaticSearch: boolean;
   enableInteractiveSearch: boolean;
   priority: number;
+  seasonSearchMaximumSingleEpisodeAge: number;
   implementation: string;
   tags: number[];
   columns: Column[];
@@ -33,6 +34,7 @@ function ManageIndexersModalRow(props: ManageIndexersModalRowProps) {
     enableAutomaticSearch,
     enableInteractiveSearch,
     priority,
+    seasonSearchMaximumSingleEpisodeAge,
     implementation,
     tags,
     onSelectedChange,
@@ -89,6 +91,10 @@ function ManageIndexersModalRow(props: ManageIndexersModalRowProps) {
       </TableRowCell>
 
       <TableRowCell className={styles.priority}>{priority}</TableRowCell>
+
+      <TableRowCell className={styles.seasonSearchMaximumSingleEpisodeAge}>
+        {seasonSearchMaximumSingleEpisodeAge}
+      </TableRowCell>
 
       <TableRowCell className={styles.tags}>
         <SeriesTagList tags={tags} />

--- a/frontend/src/typings/History.ts
+++ b/frontend/src/typings/History.ts
@@ -36,6 +36,7 @@ export interface GrabbedHistoryData {
 
 export interface DownloadFailedHistory {
   message: string;
+  indexer?: string;
 }
 
 export interface DownloadFolderImportedHistory {

--- a/frontend/src/typings/Indexer.ts
+++ b/frontend/src/typings/Indexer.ts
@@ -7,6 +7,7 @@ interface Indexer extends Provider {
   enableInteractiveSearch: boolean;
   supportsRss: boolean;
   supportsSearch: boolean;
+  seasonSearchMaximumSingleEpisodeAge: number;
   protocol: DownloadProtocol;
   priority: number;
   downloadClientId: number;

--- a/src/NzbDrone.Common/Disk/DiskProviderBase.cs
+++ b/src/NzbDrone.Common/Disk/DiskProviderBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using NLog;
 using NzbDrone.Common.EnsureThat;
 using NzbDrone.Common.EnvironmentInfo;
@@ -316,9 +317,26 @@ namespace NzbDrone.Common.Disk
         {
             Ensure.That(path, () => path).IsValidPath(PathValidationType.CurrentOs);
 
-            var files = GetFiles(path, recursive);
+            var files = GetFiles(path, recursive).ToList();
 
-            files.ToList().ForEach(RemoveReadOnly);
+            files.ForEach(RemoveReadOnly);
+
+            var attempts = 0;
+
+            while (attempts < 3 && files.Any())
+            {
+                EmptyFolder(path);
+
+                if (GetFiles(path, recursive).Any())
+                {
+                    // Wait for IO operations to complete  after emptying the folder since they aren't always
+                    // instantly removed and it can lead to false positives that files are still present.
+                    Thread.Sleep(3000);
+                }
+
+                attempts++;
+                files = GetFiles(path, recursive).ToList();
+            }
 
             Directory.Delete(path, recursive);
         }

--- a/src/NzbDrone.Core.Test/ParserTests/DailyEpisodeParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/DailyEpisodeParserFixture.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Common.Expansive;
@@ -77,6 +77,18 @@ namespace NzbDrone.Core.Test.ParserTests
             var title = string.Format("{0:yyyy.MM.dd} - A Talk Show - HD TV.mkv", DateTime.Now.AddDays(2));
 
             Parser.Parser.ParseTitle(title).Should().BeNull();
+        }
+
+        [TestCase("Series 5th Mar 2025 1080 (Deep61)", "Series", 2025, 3, 5)]
+        [TestCase("Series 31st Jan 2025 1080 (Deep61)", "Series", 2025, 1, 31)]
+        [TestCase("Series 23rd Feb 2024 (Deep61)", "Series", 2024, 2, 23)]
+        public void should_parse_daily_episode_using_short_month_format(string postTitle, string title, int year, int month, int day)
+        {
+            var result = Parser.Parser.ParseTitle(postTitle);
+            var airDate = new DateTime(year, month, day);
+            result.Should().NotBeNull();
+            result.SeriesTitle.Should().Be(title);
+            result.AirDate.Should().Be(airDate.ToString(Episode.AIR_DATE_FORMAT));
         }
     }
 }

--- a/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
+++ b/src/NzbDrone.Core.Test/ParserTests/ReleaseGroupParserFixture.cs
@@ -31,7 +31,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Red Series S01 E01-E02 1080p AMZN WEBRip DDP5.1 x264 monkee", null)]
         [TestCase("Series.Title.S01E05.The-Aniversary.WEBDL-1080p.mkv", null)]
         [TestCase("Series.Title.S01E05.The-Aniversary.HDTV-1080p.mkv", null)]
-        [TestCase("Series US (2010) S04 (1080p BDRip x265 10bit DTS-HD MA 5 1 - WEM)[TAoE]", null)]
+        [TestCase("Series US (2010) S04 (1080p BDRip x265 10bit DTS-HD MA 5 1 - WEM)[TAoE]", "TAoE")]
         [TestCase("The.Series.S03E04.2160p.Amazon.WEBRip.DTS-HD.MA.5.1.x264", null)]
         [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-X.MA.5.1.x264", null)]
         [TestCase("SomeShow.S20E13.1080p.BluRay.DTS-MA.5.1.x264", null)]
@@ -41,7 +41,7 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("SomeShow S01E168 1080p WEB-DL AAC 2.0 x264-Erai-raws", "Erai-raws")]
         [TestCase("The.Good.Series.S05E03.Series.of.Intelligence.1080p.10bit.AMZN.WEB-DL.DDP5.1.HEVC-Vyndros", "Vyndros")]
         [TestCase("Series.Title.S01E09.1080p.DSNP.WEB-DL.DDP2.0.H.264-VARYG", "VARYG")]
-        [TestCase("Stargate SG-1 (1997) - S01E01-02 - Children of the Gods (Showtime) (1080p.BD.DD5.1.x265-TheSickle[TAoE])", "TheSickle")]
+        [TestCase("Series (1997) - S01E01-02 - Children of the Gods (Showtime) (1080p.BD.DD5.1.x265-TheSickle[TAoE])", "TAoE")]
         [TestCase("Series Title S01 [2160p REMUX] [HEVC DV HYBRID HDR10+ Dolby TrueHD Atmos 7 1 24-bit Audio English] [Data Lass]", null)]
         [TestCase("Series Title S01 [2160p REMUX] [HEVC DV HYBRID HDR10+ Dolby TrueHD Atmos 7 1 24-bit Audio English]-DataLass", "DataLass")]
         [TestCase("Series Title S01 REMUX Dual Audio AVC 1080p 8-Bit-ZR-", "ZR")]
@@ -90,6 +90,8 @@ namespace NzbDrone.Core.Test.ParserTests
         [TestCase("Series Title S02E05 2160p WEB-DL DV HDR ENG DDP5.1 Atmos H265 MP4-BEN THE MEN", "BEN THE MEN")]
         [TestCase("Series Title S02E05 2160p AMZN WEB-DL DV HDR10 PLUS DDP5 1 Atmos H265 MKV-BEN THE MEN-xpost", "BEN THE MEN")]
         [TestCase("Series.S01E05.1080p.WEB-DL.DDP5.1.H264-BEN.THE.MEN", "BEN.THE.MEN")]
+        [TestCase("Series (2022) S01 (1080p BluRay x265 SDR DDP 5.1 English - JBENT TAoE)", "TAoE")]
+        [TestCase("Series (2005) S21E12 (1080p AMZN WEB-DL x265 SDR DDP 5.1 English - Goki TAoE)", "TAoE")]
         public void should_parse_exception_release_group(string title, string expected)
         {
             Parser.Parser.ParseReleaseGroup(title).Should().Be(expected);

--- a/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
+++ b/src/NzbDrone.Core/Extras/Metadata/Consumers/Xbmc/XbmcMetadata.cs
@@ -318,6 +318,23 @@ namespace NzbDrone.Core.Extras.Metadata.Consumers.Xbmc
                         video.Add(new XElement("duration", episodeFile.MediaInfo.RunTime.TotalMinutes));
                         video.Add(new XElement("durationinseconds", Math.Round(episodeFile.MediaInfo.RunTime.TotalSeconds)));
 
+                        if (episodeFile.MediaInfo.VideoHdrFormat is HdrFormat.DolbyVision or HdrFormat.DolbyVisionHdr10 or HdrFormat.DolbyVisionHdr10Plus or HdrFormat.DolbyVisionHlg or HdrFormat.DolbyVisionSdr)
+                        {
+                            video.Add(new XElement("hdrtype", "dolbyvision"));
+                        }
+                        else if (episodeFile.MediaInfo.VideoHdrFormat is HdrFormat.Hdr10 or HdrFormat.Hdr10Plus or HdrFormat.Pq10)
+                        {
+                            video.Add(new XElement("hdrtype", "hdr10"));
+                        }
+                        else if (episodeFile.MediaInfo.VideoHdrFormat == HdrFormat.Hlg10)
+                        {
+                            video.Add(new XElement("hdrtype", "hlg"));
+                        }
+                        else if (episodeFile.MediaInfo.VideoHdrFormat == HdrFormat.None)
+                        {
+                            video.Add(new XElement("hdrtype", ""));
+                        }
+
                         streamDetails.Add(video);
 
                         var audio = new XElement("audio");

--- a/src/NzbDrone.Core/History/EpisodeHistory.cs
+++ b/src/NzbDrone.Core/History/EpisodeHistory.cs
@@ -12,6 +12,9 @@ namespace NzbDrone.Core.History
         public const string DOWNLOAD_CLIENT = "downloadClient";
         public const string SERIES_MATCH_TYPE = "seriesMatchType";
         public const string RELEASE_SOURCE = "releaseSource";
+        public const string RELEASE_GROUP = "releaseGroup";
+        public const string SIZE = "size";
+        public const string INDEXER = "indexer";
 
         public EpisodeHistory()
         {

--- a/src/NzbDrone.Core/History/HistoryService.cs
+++ b/src/NzbDrone.Core/History/HistoryService.cs
@@ -249,8 +249,9 @@ namespace NzbDrone.Core.History
                 history.Data.Add("DownloadClient", message.DownloadClient);
                 history.Data.Add("DownloadClientName", message.TrackedDownload?.DownloadItem.DownloadClientInfo.Name);
                 history.Data.Add("Message", message.Message);
-                history.Data.Add("ReleaseGroup", message.TrackedDownload?.RemoteEpisode?.ParsedEpisodeInfo?.ReleaseGroup);
-                history.Data.Add("Size", message.TrackedDownload?.DownloadItem.TotalSize.ToString());
+                history.Data.Add("ReleaseGroup", message.TrackedDownload?.RemoteEpisode?.ParsedEpisodeInfo?.ReleaseGroup ?? message.Data.GetValueOrDefault(EpisodeHistory.RELEASE_GROUP));
+                history.Data.Add("Size", message.TrackedDownload?.DownloadItem.TotalSize.ToString() ?? message.Data.GetValueOrDefault(EpisodeHistory.SIZE));
+                history.Data.Add("Indexer", message.TrackedDownload?.RemoteEpisode?.Release?.Indexer ?? message.Data.GetValueOrDefault(EpisodeHistory.INDEXER));
 
                 _historyRepository.Insert(history);
             }
@@ -346,6 +347,7 @@ namespace NzbDrone.Core.History
                 history.Data.Add("Message", message.Message);
                 history.Data.Add("ReleaseGroup", message.TrackedDownload?.RemoteEpisode?.ParsedEpisodeInfo?.ReleaseGroup);
                 history.Data.Add("Size", message.TrackedDownload?.DownloadItem.TotalSize.ToString());
+                history.Data.Add("Indexer", message.TrackedDownload?.RemoteEpisode?.Release?.Indexer);
 
                 historyToAdd.Add(history);
             }

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -125,6 +125,10 @@ namespace NzbDrone.Core.Parser
 
                 // Episodes with airdate before title (2018-10-12, 20181012) (Strict pattern to avoid false matches)
                 new Regex(@"^(?<airyear>19[6-9]\d|20\d{2})[-_]?(?<airmonth>[0-1][0-9])[-_]?(?<airday>[0-3][0-9])",
+                    RegexOptions.IgnoreCase | RegexOptions.Compiled),
+
+                // Daily episodes that use short month format instead of number
+                new Regex(@"^(?<title>.+?)[-_. ]+(?<airday>[1-2]\d|3[01]|[1-9])(?:th|st|rd)[-_. ](?<shortairmonth>jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[-_. ](?<airyear>(19|20)\d{2})",
                     RegexOptions.IgnoreCase | RegexOptions.Compiled)
             };
 
@@ -252,6 +256,22 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex RequestInfoRegex = new Regex(@"^(?:\[.+?\])+", RegexOptions.Compiled);
 
         private static readonly string[] Numbers = new[] { "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine" };
+
+        private static readonly Dictionary<string, int> ShortMonths = new()
+        {
+            { "jan", 1 },
+            { "feb", 2 },
+            { "mar", 3 },
+            { "apr", 4 },
+            { "may", 5 },
+            { "jun", 6 },
+            { "jul", 7 },
+            { "aug", 8 },
+            { "sep", 9 },
+            { "oct", 10 },
+            { "nov", 11 },
+            { "dec", 12 },
+        };
 
         public static ParsedEpisodeInfo ParsePath(string path)
         {
@@ -786,6 +806,19 @@ namespace NzbDrone.Core.Parser
                     // Convert month name to number
                     var monthName = matchCollection[0].Groups["airmonthname"].Value;
                     airmonth = DateTime.ParseExact(monthName, "MMMM", CultureInfo.InvariantCulture).Month;
+                }
+                else if (matchCollection[0].Groups["shortairmonth"].Success)
+                {
+                    var shortMonthValue = matchCollection[0].Groups["shortairmonth"].Value;
+
+                    if (ShortMonths.TryGetValue(shortMonthValue.ToLowerInvariant(), out var shortMonth))
+                    {
+                        airmonth = shortMonth;
+                    }
+                    else
+                    {
+                        throw new InvalidDateException("Unable to determine air month from month: {0}", shortMonthValue);
+                    }
                 }
                 else
                 {

--- a/src/NzbDrone.Core/Parser/Parser.cs
+++ b/src/NzbDrone.Core/Parser/Parser.cs
@@ -240,7 +240,7 @@ namespace NzbDrone.Core.Parser
         private static readonly Regex ExceptionReleaseGroupRegexExact = new Regex(@"(?<releasegroup>(?:D\-Z0N3|Fight-BB|VARYG|E\.N\.D|KRaLiMaRKo|BluDragon|DarQ|KCRT|BEN[_. ]THE[_. ]MEN)\b)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         // groups whose releases end with RlsGroup) or RlsGroup]
-        private static readonly Regex ExceptionReleaseGroupRegex = new Regex(@"(?<=[._ \[])(?<releasegroup>(Silence|afm72|Panda|Ghost|MONOLITH|Tigole|Joy|ImE|UTR|t3nzin|Anime Time|Project Angel|Hakata Ramen|HONE|Vyndros|SEV|Garshasp|Kappa|Natty|RCVR|SAMPA|YOGI|r00t|EDGE2020|RZeroX)(?=\]|\)))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex ExceptionReleaseGroupRegex = new Regex(@"(?<=[._ \[])(?<releasegroup>(Silence|afm72|Panda|Ghost|MONOLITH|Tigole|Joy|ImE|UTR|t3nzin|Anime Time|Project Angel|Hakata Ramen|HONE|Vyndros|SEV|Garshasp|Kappa|Natty|RCVR|SAMPA|YOGI|r00t|EDGE2020|RZeroX|TAoE)(?=\]|\)))", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         private static readonly Regex YearInTitleRegex = new Regex(@"^(?<title>.+?)[-_. ]+?[\(\[]?(?<year>\d{4})[\]\)]?",
                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);

--- a/src/Whisparr.Api.V3/DownloadClient/DownloadClientController.cs
+++ b/src/Whisparr.Api.V3/DownloadClient/DownloadClientController.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using NzbDrone.Core.Download;
 using NzbDrone.SignalR;
 using Whisparr.Http;
@@ -13,6 +14,7 @@ namespace Whisparr.Api.V3.DownloadClient
         public DownloadClientController(IBroadcastSignalRMessage signalRBroadcaster, IDownloadClientFactory downloadClientFactory)
             : base(signalRBroadcaster, downloadClientFactory, "downloadclient", ResourceMapper, BulkResourceMapper)
         {
+            SharedValidator.RuleFor(c => c.Priority).InclusiveBetween(1, 50);
         }
     }
 }

--- a/src/Whisparr.Api.V3/EpisodeFiles/EpisodeFileController.cs
+++ b/src/Whisparr.Api.V3/EpisodeFiles/EpisodeFileController.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
@@ -109,6 +110,7 @@ namespace Whisparr.Api.V3.EpisodeFiles
             return Accepted(episodeFile.Id);
         }
 
+        [Obsolete("Use bulk endpoint instead")]
         [HttpPut("editor")]
         [Consumes("application/json")]
         public object SetQuality([FromBody] EpisodeFileListResource resource)

--- a/src/Whisparr.Api.V3/EpisodeFiles/EpisodeFileController.cs
+++ b/src/Whisparr.Api.V3/EpisodeFiles/EpisodeFileController.cs
@@ -1,11 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Core.CustomFormats;
 using NzbDrone.Core.Datastore.Events;
 using NzbDrone.Core.DecisionEngine.Specifications;
 using NzbDrone.Core.Exceptions;
+using NzbDrone.Core.Languages;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
@@ -154,7 +156,7 @@ namespace Whisparr.Api.V3.EpisodeFiles
 
             if (episodeFile == null)
             {
-                throw new NzbDroneClientException(global::System.Net.HttpStatusCode.NotFound, "Episode file not found");
+                throw new NzbDroneClientException(HttpStatusCode.NotFound, "Episode file not found");
             }
 
             var series = _seriesService.GetSeries(episodeFile.SeriesId);
@@ -189,7 +191,8 @@ namespace Whisparr.Api.V3.EpisodeFiles
 
                 if (resourceEpisodeFile.Languages != null)
                 {
-                    episodeFile.Languages = resourceEpisodeFile.Languages;
+                    // Don't allow user to set files with 'Original' language
+                    episodeFile.Languages = resourceEpisodeFile.Languages.Where(l => l != null && l != Language.Original).ToList();
                 }
 
                 if (resourceEpisodeFile.Quality != null)
@@ -214,7 +217,9 @@ namespace Whisparr.Api.V3.EpisodeFiles
             }
 
             _mediaFileService.Update(episodeFiles);
+
             var series = _seriesService.GetSeries(episodeFiles.First().SeriesId);
+
             return Accepted(episodeFiles.ConvertAll(f => f.ToResource(series, _upgradableSpecification, _formatCalculator)));
         }
 

--- a/src/Whisparr.Api.V3/Indexers/IndexerBulkResource.cs
+++ b/src/Whisparr.Api.V3/Indexers/IndexerBulkResource.cs
@@ -9,6 +9,7 @@ namespace Whisparr.Api.V3.Indexers
         public bool? EnableAutomaticSearch { get; set; }
         public bool? EnableInteractiveSearch { get; set; }
         public int? Priority { get; set; }
+        public int? SeasonSearchMaximumSingleEpisodeAge { get; set; }
     }
 
     public class IndexerBulkResourceMapper : ProviderBulkResourceMapper<IndexerBulkResource, IndexerDefinition>
@@ -26,6 +27,7 @@ namespace Whisparr.Api.V3.Indexers
                 existing.EnableAutomaticSearch = resource.EnableAutomaticSearch ?? existing.EnableAutomaticSearch;
                 existing.EnableInteractiveSearch = resource.EnableInteractiveSearch ?? existing.EnableInteractiveSearch;
                 existing.Priority = resource.Priority ?? existing.Priority;
+                existing.SeasonSearchMaximumSingleEpisodeAge = resource.SeasonSearchMaximumSingleEpisodeAge ?? existing.SeasonSearchMaximumSingleEpisodeAge;
             });
 
             return existingDefinitions;

--- a/src/Whisparr.Api.V3/Indexers/IndexerController.cs
+++ b/src/Whisparr.Api.V3/Indexers/IndexerController.cs
@@ -1,3 +1,4 @@
+using FluentValidation;
 using NzbDrone.Core.Indexers;
 using NzbDrone.Core.Validation;
 using NzbDrone.SignalR;
@@ -16,6 +17,7 @@ namespace Whisparr.Api.V3.Indexers
             DownloadClientExistsValidator downloadClientExistsValidator)
             : base(signalRBroadcaster, indexerFactory, "indexer", ResourceMapper, BulkResourceMapper)
         {
+            SharedValidator.RuleFor(c => c.Priority).InclusiveBetween(1, 50);
             SharedValidator.RuleFor(c => c.DownloadClientId).SetValidator(downloadClientExistsValidator);
         }
     }

--- a/src/Whisparr.Api.V3/Indexers/IndexerController.cs
+++ b/src/Whisparr.Api.V3/Indexers/IndexerController.cs
@@ -18,6 +18,7 @@ namespace Whisparr.Api.V3.Indexers
             : base(signalRBroadcaster, indexerFactory, "indexer", ResourceMapper, BulkResourceMapper)
         {
             SharedValidator.RuleFor(c => c.Priority).InclusiveBetween(1, 50);
+            SharedValidator.RuleFor(c => c.SeasonSearchMaximumSingleEpisodeAge).GreaterThanOrEqualTo(0);
             SharedValidator.RuleFor(c => c.DownloadClientId).SetValidator(downloadClientExistsValidator);
         }
     }

--- a/src/Whisparr.Api.V3/ManualImport/ManualImportController.cs
+++ b/src/Whisparr.Api.V3/ManualImport/ManualImportController.cs
@@ -25,7 +25,7 @@ namespace Whisparr.Api.V3.ManualImport
         [Produces("application/json")]
         public List<ManualImportResource> GetMediaFiles(string folder, string downloadId, int? seriesId, int? seasonNumber, bool filterExistingFiles = true)
         {
-            if (seriesId.HasValue)
+            if (seriesId.HasValue && downloadId.IsNullOrWhiteSpace())
             {
                 return _manualImportService.GetMediaFiles(seriesId.Value, seasonNumber).ToResource().Select(AddQualityWeight).ToList();
             }

--- a/src/Whisparr.Http/Authentication/AuthenticationController.cs
+++ b/src/Whisparr.Http/Authentication/AuthenticationController.cs
@@ -1,9 +1,14 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
+using System.Xml;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using NLog;
+using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Authentication;
 using NzbDrone.Core.Configuration;
@@ -16,11 +21,15 @@ namespace Whisparr.Http.Authentication
     {
         private readonly IAuthenticationService _authService;
         private readonly IConfigFileProvider _configFileProvider;
+        private readonly IAppFolderInfo _appFolderInfo;
+        private readonly Logger _logger;
 
-        public AuthenticationController(IAuthenticationService authService, IConfigFileProvider configFileProvider)
+        public AuthenticationController(IAuthenticationService authService, IConfigFileProvider configFileProvider, IAppFolderInfo appFolderInfo, Logger logger)
         {
             _authService = authService;
             _configFileProvider = configFileProvider;
+            _appFolderInfo = appFolderInfo;
+            _logger = logger;
         }
 
         [HttpPost("login")]
@@ -45,7 +54,23 @@ namespace Whisparr.Http.Authentication
                 IsPersistent = resource.RememberMe == "on"
             };
 
-            await HttpContext.SignInAsync(AuthenticationType.Forms.ToString(), new ClaimsPrincipal(new ClaimsIdentity(claims, "Cookies", "user", "identifier")), authProperties);
+            try
+            {
+                await HttpContext.SignInAsync(AuthenticationType.Forms.ToString(), new ClaimsPrincipal(new ClaimsIdentity(claims, "Cookies", "user", "identifier")), authProperties);
+            }
+            catch (CryptographicException e)
+            {
+                if (e.InnerException is XmlException)
+                {
+                    _logger.Error(e, "Failed to authenticate user due to corrupt XML. Please remove all XML files from {0} and restart Sonarr", Path.Combine(_appFolderInfo.AppDataFolder, "asp"));
+                }
+                else
+                {
+                    _logger.Error(e, "Failed to authenticate user. {0}", e.Message);
+                }
+
+                return Unauthorized();
+            }
 
             if (returnUrl.IsNullOrWhiteSpace() || !Url.IsLocalUrl(returnUrl))
             {


### PR DESCRIPTION
Continues March 2025 with 19 commits — fixes, parser improvements and bulk
manage additions.

## Commits

- Sonarr/Sonarr@144994147 — Improve logging when login fails due to CryptographicException
- Sonarr/Sonarr@e08c9d550 — Fixed: Inherit indexer, size and release group for marked as failed history
- Sonarr/Sonarr@a324052de — New: Display indexer in download failed details
- Sonarr/Sonarr@94f64435f — Fixed: Spinning icon on toggling series monitoring
- Sonarr/Sonarr@64956d7be — New: Add HDR Type to XBMC metadata video stream details
- Sonarr/Sonarr@08c0c5aa3 — Fixed: Manual importing queued items with seriesId to avoid title parsing
- Sonarr/Sonarr@9f29b06ca — Fixed: Close modal when deleting series from index
- Sonarr/Sonarr@f0e320f3a — Fixed: Priority validation for indexers and download clients
- Sonarr/Sonarr@7ff8c9e18 — New: Bulk manage Maximum Single Episode Age for indexers
- Sonarr/Sonarr@6115236d3 — Cleanup unused sorting fields for bulk manage providers
- Sonarr/Sonarr@2e66cd2a1 — New: Add series progress to details header
- Sonarr/Sonarr@1a8ba5126 — Improve Series Details loading
- Sonarr/Sonarr@20c2d59e9 — Deprecate `/api/v3/episodefile/editor`
- Sonarr/Sonarr@6aee9c7fd — Don't allow to set episode files with 'Original' language
- Sonarr/Sonarr@095126bfe — New: Parse UK date based release format
- Sonarr/Sonarr@83b2c9e97 — New: Parse TAoE as release group exception
- Sonarr/Sonarr@5fb632eb4 — Fixed: Allow tables to scroll on tablets in portrait mode
- Sonarr/Sonarr@08d1bcb35 — Fixed: Series search input when URL base is configured
- Sonarr/Sonarr@c84699ed5 — Fixed: Deleting series folder fails when files/folders aren't instantly removed

Weblate translation commits in this range were already present against
Whisparr's `en.json`.

## Whisparr adaptations

**`Indexer` typing gained a missing field.** Sonarr/Sonarr@7ff8c9e18's row
component requires `seasonSearchMaximumSingleEpisodeAge`. The backend has had
that column since the initial migration, but Whisparr's frontend `Indexer`
interface never declared it, so spreading an indexer did not satisfy the row's
props. Added, matching upstream.

**`SiteDetailsGoTo` kept.** Sonarr/Sonarr@1a8ba5126 adds null guards around the
series navigation buttons — a real fix — but calls `translate('SeriesDetailsGoTo')`.
The guards are taken; the key stays `SiteDetailsGoTo`, which is the one that
exists in Whisparr's `en.json` (see #1176).

**`using System;` added to `EpisodeFileController`.** Sonarr/Sonarr@20c2d59e9 uses
`[Obsolete]` and relies on `ImplicitUsings`, which Whisparr's Api.V3 project does
not enable.

**UK date parsing merged rather than replaced.** Upstream's side of the
`Parser.cs` conflict is Sonarr's entire `ReportTitleRegex` array — anime,
seasons, multi-episode patterns Whisparr does not have — so taking it would have
replaced Whisparr's parser wholesale. Only the commit's own additions were
applied: the short-month pattern, the `ShortMonths` lookup and the parsing
branch. `MultiRegex`, which sits in the same hunk, belongs to a different
upstream commit and was left out. The branch also does not assign `airday`,
because Whisparr assigns it unconditionally below the month branches.

## Found while picking: Whisparr mis-parses two-digit years

`095126bfe` carried a test asserting ambiguous dates are rejected. It failed —
but for a Whisparr-specific reason, not upstream's. This pattern allows a
two-digit year:

```
(?<airyear>\d{2}|\d{4})[-_. ]+(?<airmonth>[0-1][0-9])[-_. ]+(?<airday>[0-3][0-9])
```

So `Series.Title.12.02.2025.1080i.HDTV` parses as year 12, month 02, day 20 —
air date `2012-02-20`, and `Tmc - Quotidien - 05-06-2024` becomes `2005-06-20`.
Any release naming a date as `DD.MM.YYYY` is mis-parsed.

Sonarr/Sonarr@5cb649e9d (*reject ambiguous dates*) does **not** fix it: it works
by renaming groups in upstream's `MM-DD-YYYY` and `DD-MM-YYYY` patterns, and
Whisparr has neither — all its date regexes put the year first. Skipped, and the
ambiguous test cases dropped. The two-digit year needs its own fix with real
release names as test cases, since some scene releases genuinely use `YY.MM.DD`.

## Deferred

Sonarr/Sonarr@b103005aa (*Kodi metadata cleanup*) rewrites `XbmcMetadata` from
`StringBuilder`/`XmlWriter` to `XElement`. Whisparr's version of that block is
184 lines against upstream's 17, carrying Actors, AudioBitrate, AudioChannels,
AudioLanguages and Certification. Porting rewrites all of it and changes the
`.nfo` files users' Kodi installs consume — worth its own PR with a before/after
comparison.

## Verification

`Whisparr.Core.Test` 3564 passed / 0 failed, `Whisparr.Api.Test` 18 / 0,
`Whisparr.Host.Test` 14 / 0, frontend lint + production build clean, solution
builds with analyzers on. `Whisparr.Common.Test` has 5 failures, all pre-existing
`ServiceProvider` tests needing an elevated shell.
