### PR TITLE
Fixed: Broken table views on Events, Wanted and Site details

### DIFF
--- a/frontend/src/Calendar/Agenda/Agenda.tsx
+++ b/frontend/src/Calendar/Agenda/Agenda.tsx
@@ -11,10 +11,10 @@ function Agenda() {
   return (
     <div className={styles.agenda}>
       {items.map((item, index) => {
-        const momentDate = moment(item.airDateUtc);
+        const momentDate = moment(item.releaseDate);
         const showDate =
           index === 0 ||
-          !moment(items[index - 1].airDateUtc).isSame(momentDate, 'day');
+          !moment(items[index - 1].releaseDate).isSame(momentDate, 'day');
 
         return <AgendaEvent key={item.id} showDate={showDate} {...item} />;
       })}

--- a/frontend/src/Calendar/CalendarPage.tsx
+++ b/frontend/src/Calendar/CalendarPage.tsx
@@ -44,13 +44,13 @@ function createMissingEpisodeIdsSelector() {
     (state: AppState) => state.queue.details.items,
     (start, end, episodes, queueDetails) => {
       return episodes.reduce<number[]>((acc, episode) => {
-        const airDateUtc = episode.airDateUtc;
+        const releaseDate = episode.releaseDate;
 
         if (
           !episode.episodeFileId &&
-          moment(airDateUtc).isAfter(start) &&
-          moment(airDateUtc).isBefore(end) &&
-          isBefore(episode.airDateUtc) &&
+          moment(releaseDate).isAfter(start) &&
+          moment(releaseDate).isBefore(end) &&
+          isBefore(episode.releaseDate) &&
           !queueDetails.some(
             (details) => !!details.episode && details.episode.id === episode.id
           )

--- a/frontend/src/Components/Link/Link.tsx
+++ b/frontend/src/Components/Link/Link.tsx
@@ -78,7 +78,11 @@ export default function Link<C extends ElementType = 'button'>({
 
   return (
     <Component
-      type={type || 'button'}
+      type={
+        component === 'button' || component === 'input'
+          ? type || 'button'
+          : type
+      }
       target={target}
       className={linkClass}
       disabled={isDisabled}

--- a/frontend/src/Episode/Episode.ts
+++ b/frontend/src/Episode/Episode.ts
@@ -15,8 +15,6 @@ interface Episode extends ModelBase {
   seasonNumber: number;
   episodeNumber: number;
   releaseDate?: string;
-  airDate: string;
-  airDateUtc?: string;
   actors: Actor[];
   lastSearchTime?: string;
   runtime: number;

--- a/frontend/src/Series/Details/EpisodeRow.tsx
+++ b/frontend/src/Series/Details/EpisodeRow.tsx
@@ -7,6 +7,7 @@ import Column from 'Components/Table/Column';
 import TableRow from 'Components/Table/TableRow';
 import Popover from 'Components/Tooltip/Popover';
 import Tooltip from 'Components/Tooltip/Tooltip';
+import { Actor } from 'Episode/Episode';
 import EpisodeFormats from 'Episode/EpisodeFormats';
 import EpisodeSearchCell from 'Episode/EpisodeSearchCell';
 import EpisodeStatus from 'Episode/EpisodeStatus';
@@ -36,7 +37,8 @@ interface EpisodeRowProps {
   sceneSeasonNumber?: number;
   sceneEpisodeNumber?: number;
   sceneAbsoluteEpisodeNumber?: number;
-  airDateUtc?: string;
+  releaseDate?: string;
+  actors?: Actor[];
   runtime?: number;
   finaleType?: string;
   title: string;
@@ -63,7 +65,8 @@ function EpisodeRow({
   seriesId,
   episodeFileId,
   monitored,
-  airDateUtc,
+  releaseDate,
+  actors = [],
   runtime,
   finaleType,
   title,
@@ -138,8 +141,21 @@ function EpisodeRow({
           );
         }
 
-        if (name === 'airDateUtc') {
-          return <RelativeDateCell key={name} date={airDateUtc} />;
+        if (name === 'actors') {
+          const joinedPerformers = actors
+            .map((a) => a.character)
+            .slice(0, 4)
+            .join(', ');
+
+          return (
+            <TableRowCell key={name} className={styles.actors}>
+              <span title={joinedPerformers}>{joinedPerformers}</span>
+            </TableRowCell>
+          );
+        }
+
+        if (name === 'releaseDate') {
+          return <RelativeDateCell key={name} date={releaseDate} />;
         }
 
         if (name === 'runtime') {

--- a/frontend/src/Series/Details/SeriesDetailsSeason.tsx
+++ b/frontend/src/Series/Details/SeriesDetailsSeason.tsx
@@ -59,7 +59,7 @@ function getSeasonStatistics(episodes: Episode[]) {
   episodes.forEach((episode) => {
     if (
       episode.episodeFileId ||
-      (episode.monitored && isBefore(episode.airDateUtc))
+      (episode.monitored && isBefore(episode.releaseDate))
     ) {
       episodeCount++;
     }
@@ -280,8 +280,8 @@ function SeriesDetailsSeason({
     const expand =
       itemsRef.current.some(
         (item) =>
-          isAfter(item.airDateUtc) || isAfter(item.airDateUtc, { days: -30 })
-      ) || itemsRef.current.every((item) => !item.airDateUtc);
+          isAfter(item.releaseDate) || isAfter(item.releaseDate, { days: -30 })
+      ) || itemsRef.current.every((item) => !item.releaseDate);
 
     onExpandPress(seasonNumber, expand && seasonNumber > 0);
   }, [seriesId, seasonNumber, onExpandPress]);

--- a/frontend/src/Store/Actions/wantedActions.js
+++ b/frontend/src/Store/Actions/wantedActions.js
@@ -41,7 +41,7 @@ export const defaultState = {
       },
       {
         name: 'actors',
-        label: 'Performers',
+        label: () => translate('Performers'),
         isVisible: true
       },
       {
@@ -119,7 +119,7 @@ export const defaultState = {
       },
       {
         name: 'actors',
-        label: 'Performers',
+        label: () => translate('Performers'),
         isVisible: true
       },
       {

--- a/frontend/src/Wanted/CutoffUnmet/CutoffUnmetRow.tsx
+++ b/frontend/src/Wanted/CutoffUnmet/CutoffUnmetRow.tsx
@@ -4,6 +4,7 @@ import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableSelectCell from 'Components/Table/Cells/TableSelectCell';
 import Column from 'Components/Table/Column';
 import TableRow from 'Components/Table/TableRow';
+import { Actor } from 'Episode/Episode';
 import EpisodeSearchCell from 'Episode/EpisodeSearchCell';
 import EpisodeStatus from 'Episode/EpisodeStatus';
 import EpisodeTitleLink from 'Episode/EpisodeTitleLink';
@@ -25,7 +26,8 @@ interface CutoffUnmetRowProps {
   sceneEpisodeNumber?: number;
   sceneAbsoluteEpisodeNumber?: number;
   unverifiedSceneNumbering: boolean;
-  airDateUtc?: string;
+  releaseDate?: string;
+  actors?: Actor[];
   lastSearchTime?: string;
   title: string;
   isSelected?: boolean;
@@ -44,7 +46,8 @@ function CutoffUnmetRow({
   sceneEpisodeNumber,
   sceneAbsoluteEpisodeNumber,
   unverifiedSceneNumbering,
-  airDateUtc,
+  releaseDate,
+  actors = [],
   lastSearchTime,
   title,
   isSelected,
@@ -115,8 +118,21 @@ function CutoffUnmetRow({
           );
         }
 
+        if (name === 'actors') {
+          const joinedPerformers = actors
+            .map((a) => a.character)
+            .slice(0, 4)
+            .join(', ');
+
+          return (
+            <TableRowCell key={name} className={styles.actors}>
+              <span title={joinedPerformers}>{joinedPerformers}</span>
+            </TableRowCell>
+          );
+        }
+
         if (name === 'episodes.airDateUtc') {
-          return <RelativeDateCell key={name} date={airDateUtc} />;
+          return <RelativeDateCell key={name} date={releaseDate} />;
         }
 
         if (name === 'episodes.lastSearchTime') {

--- a/frontend/src/Wanted/Missing/MissingRow.tsx
+++ b/frontend/src/Wanted/Missing/MissingRow.tsx
@@ -4,6 +4,7 @@ import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableSelectCell from 'Components/Table/Cells/TableSelectCell';
 import Column from 'Components/Table/Column';
 import TableRow from 'Components/Table/TableRow';
+import { Actor } from 'Episode/Episode';
 import EpisodeSearchCell from 'Episode/EpisodeSearchCell';
 import EpisodeStatus from 'Episode/EpisodeStatus';
 import EpisodeTitleLink from 'Episode/EpisodeTitleLink';
@@ -24,7 +25,8 @@ interface MissingRowProps {
   sceneEpisodeNumber?: number;
   sceneAbsoluteEpisodeNumber?: number;
   unverifiedSceneNumbering: boolean;
-  airDateUtc?: string;
+  releaseDate?: string;
+  actors?: Actor[];
   lastSearchTime?: string;
   title: string;
   isSelected?: boolean;
@@ -43,7 +45,8 @@ function MissingRow({
   sceneEpisodeNumber,
   sceneAbsoluteEpisodeNumber,
   unverifiedSceneNumbering,
-  airDateUtc,
+  releaseDate,
+  actors = [],
   lastSearchTime,
   title,
   isSelected,
@@ -114,8 +117,21 @@ function MissingRow({
           );
         }
 
+        if (name === 'actors') {
+          const joinedPerformers = actors
+            .map((a) => a.character)
+            .slice(0, 4)
+            .join(', ');
+
+          return (
+            <TableRowCell key={name} className={styles.actors}>
+              <span title={joinedPerformers}>{joinedPerformers}</span>
+            </TableRowCell>
+          );
+        }
+
         if (name === 'episodes.airDateUtc') {
-          return <RelativeDateCell key={name} date={airDateUtc} />;
+          return <RelativeDateCell key={name} date={releaseDate} />;
         }
 
         if (name === 'episodes.lastSearchTime') {

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1497,6 +1497,7 @@
   "RelativePath": "Relative Path",
   "Release": "Release",
   "Releases": "Releases(s)",
+  "ReleaseDate": "Release Date",
   "ReleaseGroup": "Release Group",
   "ReleaseGroups": "Release Groups",
   "ReleaseHash": "Release Hash",


### PR DESCRIPTION
Fixes #1183.

Two unrelated regressions from the TypeScript conversions landed on the same pages, which is why the tables looked both mis-laid-out *and* missing data.

## 1. `type="button"` leaking onto `<th>`, `<tr>`, `<td>` and `<div>`

`Link` is polymorphic — `component="th"`, `component={TableRow}`, `component="div"` and so on. Since Sonarr/Sonarr@a2e06e9e6 it set `type={type || 'button'}` unconditionally, so every one of those elements rendered with `type="button"`.

normalize.css matches on the attribute, not the tag:

```css
button,
[type="button"],
[type="reset"],
[type="submit"] {
  -webkit-appearance: button;
}
```

So sortable header cells and clickable rows stopped being table cells and rows and started laying out as buttons. That is the whole visual breakage in the screenshots: header labels stacking vertically on the interactive search, three log entries per line on Events, and columns crammed to the left everywhere.

Upstream hit the same symptom and fixed it in Sonarr/Sonarr@cfa2f4d4c ("Fixed: Queue header") — only `button` and `input` get a default `type` now. That commit is cherry-picked here as-is; it was a one-file follow-up to the polymorphic-Link commit and slipped past the batch that took the original.

It reaches further than the four screenshots — `TableRowCellButton`, `VirtualTableHeaderCell`, `EnhancedSelectInputOption`, `CalendarEventGroup` and the import-series folder picker were all rendering `type="button"` on non-form elements too.

## 2. Whisparr's Performers and Release Date cells were dropped

The converted rows came straight from Sonarr, which has neither concept:

* Whisparr's episode resource has **no `airDateUtc`** — it exposes `releaseDate` — so every converted date cell read an undefined field and rendered blank.
* The `actors` column had no branch at all, so those rows emitted no `<td>`. A missing cell doesn't leave a gap, it shifts every later column one to the left, which is why the body cells on the site details page didn't line up under their headers even before the layout problem above.

Restored in `EpisodeRow`, `MissingRow` and `CutoffUnmetRow`. The matching `.actors` CSS classes were still in the stylesheets untouched — only the JSX that used them was lost.

The same `airDateUtc` slip was in three more places the issue doesn't mention, all reading a field that is never populated:

* `Calendar/Agenda` — the per-day date separators
* `CalendarPage` — which episodes count as missing
* `SeriesDetailsSeason` — the episode count, and which years auto-expand

`airDate` and `airDateUtc` are gone from the `Episode` model now, since the API never returns either. That is what let this compile in the first place.

## 3. `ReleaseDate` had no translation

The column header read `ReleaseDate` because `translate()` returns the key when the lookup fails, and `en.json` had no such key. Added, and the two `Performers` labels in `wantedActions` now go through `translate()` like every other column label.

This is one of 71 missing keys currently in the frontend; the rest are tracked separately and left alone here.

## Verification

`tsc --noEmit` and eslint clean on the changed files, production frontend build clean.
