### PR TITLE
Fixed: Sidebar showing 'Series', and explain where quality size limits went

### DIFF
--- a/frontend/src/Components/Page/Sidebar/PageSidebar.tsx
+++ b/frontend/src/Components/Page/Sidebar/PageSidebar.tsx
@@ -46,7 +46,7 @@ interface SidebarItem {
 const LINKS: SidebarItem[] = [
   {
     iconName: icons.SERIES_CONTINUING,
-    title: () => translate('Series'),
+    title: () => translate('Sites'),
     to: '/',
     alias: '/series',
     children: [

--- a/frontend/src/Settings/Quality/Definition/QualityDefinitions.tsx
+++ b/frontend/src/Settings/Quality/Definition/QualityDefinitions.tsx
@@ -3,9 +3,11 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import AppState from 'App/State/AppState';
+import Alert from 'Components/Alert';
 import FieldSet from 'Components/FieldSet';
 import PageSectionContent from 'Components/Page/PageSectionContent';
 import usePrevious from 'Helpers/Hooks/usePrevious';
+import { kinds } from 'Helpers/Props';
 import {
   fetchQualityDefinitions,
   saveQualityDefinitions,
@@ -85,6 +87,10 @@ function QualityDefinitions({
         isPopulated={isPopulated}
         error={error}
       >
+        <Alert className={styles.notice} kind={kinds.INFO}>
+          {translate('QualitySizeLimitsMovedToProfiles')}
+        </Alert>
+
         <div className={styles.header}>
           <div className={styles.quality}>{translate('Quality')}</div>
           <div className={styles.title}>{translate('Title')}</div>

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1481,6 +1481,7 @@
   "QualityProfiles": "Quality Profiles",
   "QualityProfilesLoadError": "Unable to load Quality Profiles",
   "QualitySettings": "Quality Settings",
+  "QualitySizeLimitsMovedToProfiles": "Size limits are now set per quality profile. Open a quality profile and choose Edit Sizes to change them.",
   "QualitySettingsSummary": "Quality sizes and naming",
   "Queue": "Queue",
   "QueueFilterHasNoItems": "Selected queue filter has no items",


### PR DESCRIPTION
Addresses #1186.

## The size controls were not lost, they moved

Sonarr/Sonarr@572bdc979, taken in #1162, moved size limits off Settings → Quality and into each quality profile, and migration 217 carried existing values across. Upstream's Quality Definitions page is Quality + Title only too, so this part matches Sonarr exactly.

I ran the build and drove the UI to confirm the profile side actually works rather than reading the code: open a quality profile → **Edit Sizes** gives a slider plus Minimum / Preferred / Maximum MiB/m per quality, populated from the migrated values.

What is missing is any hint that this happened. The page now shows two columns and a large empty area where the sliders used to be, which is indistinguishable from the feature being broken — which is how it was reported. So this adds a one-line notice pointing at quality profiles. The `notice` class was already sitting unused in `QualityDefinitions.css` for a message like this (it is unused upstream too).

This is a Whisparr-only addition. It is one JSX block and one key, so it should not complicate future picks of that file.

## Sidebar regression

Separately, the sidebar has been reading **Series** instead of **Sites** since the TypeScript conversion in Sonarr/Sonarr@16a66c8709 took upstream's `translate('Series')`. Whisparr has no `Series` key, and `translate()` returns the key when the lookup fails, so it rendered the raw word — visible in both screenshots on #1186. Restored to `translate('Sites')`.

## Verification

Ran the patched build and confirmed both in the UI: the sidebar reads Sites, and the notice renders above the definitions. `tsc --noEmit` and eslint clean, production build clean.
