### PR TITLE
Fixed: Year episode count pushed to the far side of the site details header

### DIFF
--- a/frontend/src/Series/Details/SeriesDetailsSeason.css
+++ b/frontend/src/Series/Details/SeriesDetailsSeason.css
@@ -30,7 +30,6 @@
   display: flex;
   align-items: flex-end;
   flex-direction: column;
-  margin-left: auto;
   gap: 2px;
 }
 


### PR DESCRIPTION
One line of CSS.

## What's happening

Sonarr/Sonarr@0f562800e (taken in #1165) wrapped the year's progress label and size in a new `.seasonStats` element carrying `margin-left: auto`. That element lives inside `.left`, a flex box with a fixed `flex: 0 1 350px` basis — so the auto margin absorbs every pixel of leftover space and pins the count to the right edge of that column.

It reads fine in Sonarr, where the label is "Season 1" or "Specials" and fills most of the 350px. Whisparr's label is a four-digit year, so about **190px of empty space** opens up between the year and its count.

Measured on a live instance before the change:

```
year ends at x=326
count starts at x=527      <- 190px of nothing
```

The CSS is identical to upstream's, so this isn't a bad merge — it's upstream's layout meeting a much shorter label.

## The change

Drop `margin-left: auto`. The count then sits directly after the year, separated by the 10px right margin `.seasonInfo` already has:

```
year ends at x=326
count starts at x=336
```

`.seasonStats` keeps `flex-direction: column` and `align-items: flex-end`, so where a year has both a count and a size they still stack and right-align to each other — just next to the year instead of across the header.

## Verification

Checked against a live instance with real data, both cases:

- a year with only a count (`0 / 0`, no size)
- a year with both (`14 / 15` over `34 GiB`)

stylelint clean, production frontend build clean.
