### PR TITLE
New: Bump .NET to 10

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash
       if: ${{ startsWith(inputs.runtime, 'freebsd') }}
       run:
-        dotnet nuget add source --configfile src/NuGet.Config --name gh-openur https://nuget.pkg.github.com/openur/index.json --username ${{ github.repository_owner }} --password ${{ github.token }} --store-password-in-clear-text
+        dotnet nuget add source --configfile src/NuGet.config --name gh-openur https://nuget.pkg.github.com/openur/index.json --username ${{ github.repository_owner }} --password ${{ github.token }} --store-password-in-clear-text
 
     - name: Setup Environment Variables
       id: variables

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,7 +23,13 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
+
+    - name: Setup NuGet registry source
+      shell: bash
+      if: ${{ startsWith(inputs.runtime, 'freebsd') }}
+      run:
+        dotnet nuget add source --configfile src/NuGet.Config --name gh-openur https://nuget.pkg.github.com/openur/index.json --username ${{ github.repository_owner }} --password ${{ github.token }} --store-password-in-clear-text
 
     - name: Setup Environment Variables
       id: variables
@@ -94,17 +100,8 @@ runs:
         rm -rf _output
         rm -rf _tests
         echo "Building Whisparr for $runtime, Platform: $platform"
-        SELF_CONTAINED=true
-        MSBUILD_EXTRA=""
-        if [[ "${runtime}" == freebsd* ]]; then
-          echo "FreeBSD target detected - using framework-dependent publish to avoid missing apphost"
-          SELF_CONTAINED=false
-          # The FreeBSD runtime pack comes from the dotnet-bsd-crossbuild feed,
-          # which lags the SDK's own patch level. Without this the restore asks
-          # for the SDK's runtime version and fails with NU1102.
-          MSBUILD_EXTRA="-p:UseAppHost=false -p:RuntimeFrameworkVersion=${FREEBSD_RUNTIME_VERSION:-8.0.27}"
-        fi
-        dotnet msbuild -restore $slnFile -p:SelfContained=${SELF_CONTAINED} -p:Configuration=Release -p:Platform=$platform -p:RuntimeIdentifiers=$runtime -p:EnableWindowsTargeting=true $MSBUILD_EXTRA -t:PublishAllRids
+
+        dotnet msbuild -restore $slnFile -p:SelfContained=true -p:Configuration=Release -p:Platform=$platform -p:RuntimeIdentifiers=$runtime -p:EnableWindowsTargeting=true -t:PublishAllRids
 
     - name: Package
       shell: bash

--- a/.github/actions/package/package.sh
+++ b/.github/actions/package/package.sh
@@ -3,7 +3,7 @@
 outputFolder=_output
 artifactsFolder=_artifacts
 uiFolder="$outputFolder/UI"
-framework="${FRAMEWORK:=net8.0}"
+framework="${FRAMEWORK:=net10.0}"
 
 # Sanitize BRANCH for safe file names (replace / with _)
 safeBranch="${BRANCH//\//_}"

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -31,7 +31,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Setup Postgres
       if: ${{ inputs.use_postgres }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FRAMEWORK: net8.0
+  FRAMEWORK: net10.0
   RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   WHISPARR_MAJOR_VERSION: 2
   VERSION: 2.2.0

--- a/build.sh
+++ b/build.sh
@@ -137,7 +137,7 @@ PackageLinux()
 
     echo "Adding Whisparr.Mono to UpdatePackage"
     cp $folder/Whisparr.Mono.* $folder/Whisparr.Update
-    if [ "$framework" = "net8.0" ]; then
+    if [ "$framework" = "net10.0" ]; then
         cp $folder/Mono.Posix.NETStandard.* $folder/Whisparr.Update
         cp $folder/libMonoPosixHelper.* $folder/Whisparr.Update
     fi
@@ -165,7 +165,7 @@ PackageMacOS()
 
     echo "Adding Whisparr.Mono to UpdatePackage"
     cp $folder/Whisparr.Mono.* $folder/Whisparr.Update
-    if [ "$framework" = "net8.0" ]; then
+    if [ "$framework" = "net10.0" ]; then
         cp $folder/Mono.Posix.NETStandard.* $folder/Whisparr.Update
         cp $folder/libMonoPosixHelper.* $folder/Whisparr.Update
     fi
@@ -377,15 +377,15 @@ then
     Build
     if [[ -z "$RID" || -z "$FRAMEWORK" ]];
     then
-        PackageTests "net8.0" "win-x64"
-        PackageTests "net8.0" "win-x86"
-        PackageTests "net8.0" "linux-x64"
-        PackageTests "net8.0" "linux-musl-x64"
-        PackageTests "net8.0" "osx-x64"
+        PackageTests "net10.0" "win-x64"
+        PackageTests "net10.0" "win-x86"
+        PackageTests "net10.0" "linux-x64"
+        PackageTests "net10.0" "linux-musl-x64"
+        PackageTests "net10.0" "osx-x64"
         if [ "$ENABLE_EXTRA_PLATFORMS" = "YES" ];
         then
-            PackageTests "net8.0" "freebsd-x64"
-            PackageTests "net8.0" "linux-x86"
+            PackageTests "net10.0" "freebsd-x64"
+            PackageTests "net10.0" "linux-x86"
         fi
     else
         PackageTests "$FRAMEWORK" "$RID"
@@ -414,20 +414,20 @@ then
 
     if [[ -z "$RID" || -z "$FRAMEWORK" ]];
     then
-        Package "net8.0" "win-x64"
-        Package "net8.0" "win-x86"
-        Package "net8.0" "linux-x64"
-        Package "net8.0" "linux-musl-x64"
-        Package "net8.0" "linux-arm64"
-        Package "net8.0" "linux-musl-arm64"
-        Package "net8.0" "linux-arm"
-        Package "net8.0" "linux-musl-arm"
-        Package "net8.0" "osx-x64"
-        Package "net8.0" "osx-arm64"
+        Package "net10.0" "win-x64"
+        Package "net10.0" "win-x86"
+        Package "net10.0" "linux-x64"
+        Package "net10.0" "linux-musl-x64"
+        Package "net10.0" "linux-arm64"
+        Package "net10.0" "linux-musl-arm64"
+        Package "net10.0" "linux-arm"
+        Package "net10.0" "linux-musl-arm"
+        Package "net10.0" "osx-x64"
+        Package "net10.0" "osx-arm64"
         if [ "$ENABLE_EXTRA_PLATFORMS" = "YES" ];
         then
-            Package "net8.0" "freebsd-x64"
-            Package "net8.0" "linux-x86"
+            Package "net10.0" "freebsd-x64"
+            Package "net10.0" "linux-x86"
         fi
     else
         Package "$FRAMEWORK" "$RID"
@@ -437,7 +437,7 @@ fi
 if [ "$INSTALLER" = "YES" ];
 then
     InstallInno
-    BuildInstaller "net8.0" "win-x64"
-    BuildInstaller "net8.0" "win-x86"
+    BuildInstaller "net10.0" "win-x64"
+    BuildInstaller "net10.0" "win-x86"
     RemoveInno
 fi

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@fortawesome/free-solid-svg-icons": "7.1.0",
     "@fortawesome/react-fontawesome": "3.1.1",
     "@juggle/resize-observer": "3.4.0",
-    "@microsoft/signalr": "8.0.7",
+    "@microsoft/signalr": "10.0.0",
     "@sentry/browser": "7.119.1",
     "@sentry/integrations": "7.51.2",
     "@tanstack/react-query": "5.61.0",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -105,7 +105,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageReference Include="NunitXml.TestLogger" Version="3.1.20" />
   </ItemGroup>
 

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-bsd-crossbuild" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/dotnet-bsd-crossbuild/nuget/v3/index.json" />
     <add key="Mono.Posix.NETStandard" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/Mono.Posix.NETStandard/nuget/v3/index.json" />
     <add key="FFMpegCore" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/FFMpegCore/nuget/v3/index.json" />
   </packageSources>

--- a/src/NzbDrone.Api.Test/Whisparr.Api.Test.csproj
+++ b/src/NzbDrone.Api.Test/Whisparr.Api.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NBuilder" Version="6.1.0" />

--- a/src/NzbDrone.Automation.Test/Whisparr.Automation.Test.csproj
+++ b/src/NzbDrone.Automation.Test/Whisparr.Automation.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Selenium.Support" Version="3.141.0" />

--- a/src/NzbDrone.Common.Test/Whisparr.Common.Test.csproj
+++ b/src/NzbDrone.Common.Test/Whisparr.Common.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Host\Whisparr.Host.csproj" />

--- a/src/NzbDrone.Common/Http/HttpClient.cs
+++ b/src/NzbDrone.Common/Http/HttpClient.cs
@@ -59,7 +59,6 @@ namespace NzbDrone.Common.Http
             _httpDispatcher = httpDispatcher;
             _logger = logger;
 
-            ServicePointManager.DefaultConnectionLimit = 12;
             _cookieContainerCache = cacheManager.GetCache<CookieContainer>(typeof(HttpClient));
         }
 

--- a/src/NzbDrone.Common/Instrumentation/CleansingFileTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/CleansingFileTarget.cs
@@ -1,13 +1,15 @@
-﻿using NLog;
+using System.Text;
+using NLog;
 using NLog.Targets;
 
 namespace NzbDrone.Common.Instrumentation
 {
     public class CleansingFileTarget : FileTarget
     {
-        protected override string GetFormattedMessage(LogEventInfo logEvent)
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
         {
-            return CleanseLogMessage.Cleanse(Layout.Render(logEvent));
+            var result = CleanseLogMessage.Cleanse(Layout.Render(logEvent));
+            target.Append(result);
         }
     }
 }

--- a/src/NzbDrone.Common/Instrumentation/Extensions/SentryLoggerExtensions.cs
+++ b/src/NzbDrone.Common/Instrumentation/Extensions/SentryLoggerExtensions.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq;
+using System.Collections.Generic;
+using System.Linq;
 using NLog;
-using NLog.Fluent;
 
 namespace NzbDrone.Common.Instrumentation.Extensions
 {
@@ -8,47 +8,46 @@ namespace NzbDrone.Common.Instrumentation.Extensions
     {
         public static readonly Logger SentryLogger = LogManager.GetLogger("Sentry");
 
-        public static LogBuilder SentryFingerprint(this LogBuilder logBuilder, params string[] fingerprint)
+        public static LogEventBuilder SentryFingerprint(this LogEventBuilder logBuilder, params string[] fingerprint)
         {
             return logBuilder.Property("Sentry", fingerprint);
         }
 
-        public static LogBuilder WriteSentryDebug(this LogBuilder logBuilder, params string[] fingerprint)
+        public static LogEventBuilder WriteSentryDebug(this LogEventBuilder logBuilder, params string[] fingerprint)
         {
             return LogSentryMessage(logBuilder, LogLevel.Debug, fingerprint);
         }
 
-        public static LogBuilder WriteSentryInfo(this LogBuilder logBuilder, params string[] fingerprint)
+        public static LogEventBuilder WriteSentryInfo(this LogEventBuilder logBuilder, params string[] fingerprint)
         {
             return LogSentryMessage(logBuilder, LogLevel.Info, fingerprint);
         }
 
-        public static LogBuilder WriteSentryWarn(this LogBuilder logBuilder, params string[] fingerprint)
+        public static LogEventBuilder WriteSentryWarn(this LogEventBuilder logBuilder, params string[] fingerprint)
         {
             return LogSentryMessage(logBuilder, LogLevel.Warn, fingerprint);
         }
 
-        public static LogBuilder WriteSentryError(this LogBuilder logBuilder, params string[] fingerprint)
+        public static LogEventBuilder WriteSentryError(this LogEventBuilder logBuilder, params string[] fingerprint)
         {
             return LogSentryMessage(logBuilder, LogLevel.Error, fingerprint);
         }
 
-        private static LogBuilder LogSentryMessage(LogBuilder logBuilder, LogLevel level, string[] fingerprint)
+        private static LogEventBuilder LogSentryMessage(LogEventBuilder logBuilder, LogLevel level, string[] fingerprint)
         {
-            SentryLogger.Log(level)
-                        .CopyLogEvent(logBuilder.LogEventInfo)
+            SentryLogger.ForLogEvent(level)
+                        .CopyLogEvent(logBuilder.LogEvent)
                         .SentryFingerprint(fingerprint)
-                        .Write();
+                        .Log();
 
-            return logBuilder.Property("Sentry", null);
+            return logBuilder.Property<string>("Sentry", null);
         }
 
-        private static LogBuilder CopyLogEvent(this LogBuilder logBuilder, LogEventInfo logEvent)
+        private static LogEventBuilder CopyLogEvent(this LogEventBuilder logBuilder, LogEventInfo logEvent)
         {
-            return logBuilder.LoggerName(logEvent.LoggerName)
-                             .TimeStamp(logEvent.TimeStamp)
+            return logBuilder.TimeStamp(logEvent.TimeStamp)
                              .Message(logEvent.Message, logEvent.Parameters)
-                             .Properties(logEvent.Properties.ToDictionary(v => v.Key, v => v.Value))
+                             .Properties(logEvent.Properties.Select(p => new KeyValuePair<string, object>(p.Key.ToString(), p.Value)))
                              .Exception(logEvent.Exception);
         }
     }

--- a/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
+++ b/src/NzbDrone.Common/Instrumentation/Sentry/SentryTarget.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Data.SQLite;
@@ -104,8 +104,8 @@ namespace NzbDrone.Common.Instrumentation.Sentry
                                       o.AttachStacktrace = true;
                                       o.MaxBreadcrumbs = 200;
                                       o.Release = $"{BuildInfo.AppName}@{BuildInfo.Release}";
-                                      o.BeforeSend = x => SentryCleanser.CleanseEvent(x);
-                                      o.BeforeBreadcrumb = x => SentryCleanser.CleanseBreadcrumb(x);
+                                      o.SetBeforeSend(x => SentryCleanser.CleanseEvent(x));
+                                      o.SetBeforeBreadcrumb(x => SentryCleanser.CleanseBreadcrumb(x));
                                       o.Environment = BuildInfo.Branch;
 
                                       // Crash free run statistics (sends a ping for healthy and for crashes sessions)
@@ -128,7 +128,7 @@ namespace NzbDrone.Common.Instrumentation.Sentry
         {
             SentrySdk.ConfigureScope(scope =>
             {
-                scope.User = new User
+                scope.User = new SentryUser
                 {
                     Id = HashUtil.AnonymousToken()
                 };

--- a/src/NzbDrone.Common/Whisparr.Common.csproj
+++ b/src/NzbDrone.Common/Whisparr.Common.csproj
@@ -1,27 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <DefineConstants Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64' or '$(RuntimeIdentifier)' == 'linux-musl-arm64'">ISMUSL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="5.4.1" />
-    <PackageReference Include="IPAddressRange" Version="6.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NLog" Version="4.7.14" />
-    <PackageReference Include="NLog.Targets.Syslog" Version="6.0.3" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
-    <PackageReference Include="Sentry" Version="3.23.1" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.3" />
+    <PackageReference Include="IPAddressRange" Version="6.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="NLog" Version="5.5.1" />
+    <PackageReference Include="NLog.Layouts.ClefJsonLayout" Version="1.0.4" />
+    <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
+    <PackageReference Include="Sentry" Version="5.16.2" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.2" />
+    <PackageReference Include="SourceGear.sqlite3" Version="3.50.4.5" />
     <PackageReference Include="System.Data.SQLite" Version="2.0.2" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="10.0.1" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="EnsureThat\Resources\ExceptionMessages.Designer.cs">

--- a/src/NzbDrone.Console/Whisparr.Console.csproj
+++ b/src/NzbDrone.Console/Whisparr.Console.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
 
     <ApplicationIcon>..\NzbDrone.Host\Whisparr.ico</ApplicationIcon>
   </PropertyGroup>

--- a/src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj
+++ b/src/NzbDrone.Core.Test/Whisparr.Core.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />

--- a/src/NzbDrone.Core/Datastore/WhereBuilder.cs
+++ b/src/NzbDrone.Core/Datastore/WhereBuilder.cs
@@ -1,9 +1,25 @@
-﻿using Dapper;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using Dapper;
 
-namespace NzbDrone.Core.Datastore
+namespace NzbDrone.Core.Datastore;
+
+public abstract class WhereBuilder : ExpressionVisitor
 {
-    public abstract class WhereBuilder : ExpressionVisitor
+    public DynamicParameters Parameters { get; protected set; }
+
+    protected static bool TryUnwrapSpanImplicitCast(Expression expression, [NotNullWhen(true)] out Expression result)
     {
-        public DynamicParameters Parameters { get; protected set; }
+        if (expression is MethodCallExpression { Method: { Name: "op_Implicit", DeclaringType: { IsGenericType: true } implicitCastDeclaringType }, Arguments: [var unwrapped] }
+            && implicitCastDeclaringType.GetGenericTypeDefinition() is var genericTypeDefinition
+            && (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>)))
+        {
+            result = unwrapped;
+            return true;
+        }
+
+        result = null;
+        return false;
     }
 }

--- a/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
+++ b/src/NzbDrone.Core/Download/Clients/Transmission/TransmissionBase.cs
@@ -94,7 +94,7 @@ namespace NzbDrone.Core.Download.Clients.Transmission
                     {
                         item.RemainingTime = TimeSpan.FromSeconds(torrent.Eta);
                     }
-                    catch (OverflowException)
+                    catch (Exception ex) when (ex is OverflowException or ArgumentOutOfRangeException)
                     {
                         item.RemainingTime = TimeSpan.FromMilliseconds(torrent.Eta);
                     }

--- a/src/NzbDrone.Core/Download/CompletedDownloadService.cs
+++ b/src/NzbDrone.Core/Download/CompletedDownloadService.cs
@@ -1,9 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NLog;
-using NLog.Fluent;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
@@ -296,14 +295,14 @@ namespace NzbDrone.Core.Download
                 }
                 else
                 {
-                    _logger.Debug()
+                    _logger.ForDebugEvent()
                            .Message("No Episodes were just imported, but all episodes were previously imported, possible issue with download history.")
                            .Property("SeriesId", trackedDownload.RemoteEpisode.Series.Id)
                            .Property("DownloadId", trackedDownload.DownloadItem.DownloadId)
                            .Property("Title", trackedDownload.DownloadItem.Title)
                            .Property("Path", trackedDownload.ImportItem.OutputPath.ToString())
                            .WriteSentryWarn("DownloadHistoryIncomplete")
-                           .Write();
+                           .Log();
                 }
 
                 trackedDownload.State = TrackedDownloadState.Imported;

--- a/src/NzbDrone.Core/Instrumentation/DatabaseTarget.cs
+++ b/src/NzbDrone.Core/Instrumentation/DatabaseTarget.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data;
 using System.Data.SQLite;
 using NLog;
@@ -33,22 +33,25 @@ namespace NzbDrone.Core.Instrumentation
 
             LogManager.Configuration.AddTarget("DbLogger", target);
             LogManager.Configuration.LoggingRules.Add(Rule);
-            LogManager.ConfigurationReloaded += OnLogManagerOnConfigurationReloaded;
+            LogManager.ConfigurationChanged += OnLogManagerOnConfigurationReloaded;
             LogManager.ReconfigExistingLoggers();
         }
 
         public void UnRegister()
         {
-            LogManager.ConfigurationReloaded -= OnLogManagerOnConfigurationReloaded;
+            LogManager.ConfigurationChanged -= OnLogManagerOnConfigurationReloaded;
             LogManager.Configuration.RemoveTarget("DbLogger");
             LogManager.Configuration.LoggingRules.Remove(Rule);
             LogManager.ReconfigExistingLoggers();
             Dispose();
         }
 
-        private void OnLogManagerOnConfigurationReloaded(object sender, LoggingConfigurationReloadedEventArgs args)
+        private void OnLogManagerOnConfigurationReloaded(object sender, LoggingConfigurationChangedEventArgs args)
         {
-            Register();
+            if (args.ActivatedConfiguration != null)
+            {
+                Register();
+            }
         }
 
         public LoggingRule Rule { get; set; }

--- a/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
+++ b/src/NzbDrone.Core/Instrumentation/ReconfigureLogging.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using NLog;
 using NLog.Config;
@@ -117,7 +117,6 @@ namespace NzbDrone.Core.Instrumentation
             syslogTarget.MessageSend.Protocol = ProtocolType.Udp;
             syslogTarget.MessageSend.Udp.Port = syslogPort;
             syslogTarget.MessageSend.Udp.Server = syslogServer;
-            syslogTarget.MessageSend.Udp.ReconnectInterval = 500;
             syslogTarget.MessageCreation.Rfc = RfcNumber.Rfc5424;
             syslogTarget.MessageCreation.Rfc5424.AppName = _configFileProvider.InstanceName;
 

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -1,8 +1,7 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
-using NLog.Fluent;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation;
 using NzbDrone.Common.Instrumentation.Extensions;
@@ -153,10 +152,10 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 return "WMA";
             }
 
-            Logger.Debug()
+            Logger.ForDebugEvent()
                   .Message("Unknown audio format: '{0}' in '{1}'. Streams: {2}", audioFormat, sceneName, mediaInfo.RawStreamData)
                   .WriteSentryWarn("UnknownAudioFormatFFProbe", mediaInfo.ContainerFormat, mediaInfo.AudioFormat, audioCodecID)
-                  .Write();
+                  .Log();
 
             return mediaInfo.AudioFormat;
         }
@@ -268,10 +267,10 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 return "";
             }
 
-            Logger.Debug()
+            Logger.ForDebugEvent()
                   .Message("Unknown video format: '{0}' in '{1}'. Streams: {2}", videoFormat, sceneName, mediaInfo.RawStreamData)
                   .WriteSentryWarn("UnknownVideoFormatFFProbe", mediaInfo.ContainerFormat, videoFormat, videoCodecID)
-                  .Write();
+                  .Log();
 
             return result;
         }

--- a/src/NzbDrone.Core/Parser/ParsingService.cs
+++ b/src/NzbDrone.Core/Parser/ParsingService.cs
@@ -1,7 +1,6 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using NLog;
-using NLog.Fluent;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.IndexerSearch.Definitions;
@@ -270,12 +269,12 @@ namespace NzbDrone.Core.Parser
 
                 if (tvdbId > 0 && tvdbId == searchCriteria.Series.TvdbId)
                 {
-                    _logger.Debug()
+                    _logger.ForDebugEvent()
                            .Message("Found matching series by TVDB ID {0}, an alias may be needed for: {1}", tvdbId, parsedEpisodeInfo.SeriesTitle)
                            .Property("TvdbId", tvdbId)
                            .Property("ParsedEpisodeInfo", parsedEpisodeInfo)
                            .WriteSentryWarn("TvdbIdMatch", tvdbId.ToString(), parsedEpisodeInfo.SeriesTitle)
-                           .Write();
+                           .Log();
 
                     return new FindSeriesResult(searchCriteria.Series, SeriesMatchType.Id);
                 }
@@ -317,12 +316,12 @@ namespace NzbDrone.Core.Parser
 
                 if (series != null)
                 {
-                    _logger.Debug()
+                    _logger.ForDebugEvent()
                            .Message("Found matching series by TVDB ID {0}, an alias may be needed for: {1}", tvdbId, parsedEpisodeInfo.SeriesTitle)
                            .Property("TvdbId", tvdbId)
                            .Property("ParsedEpisodeInfo", parsedEpisodeInfo)
                            .WriteSentryWarn("TvdbIdMatch", tvdbId.ToString(), parsedEpisodeInfo.SeriesTitle)
-                           .Write();
+                           .Log();
 
                     matchType = SeriesMatchType.Id;
                 }

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -1,33 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="Diacritical.Net" Version="1.0.4" />
     <PackageReference Include="Equ" Version="2.3.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.12" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
-    <PackageReference Include="Polly" Version="8.5.2" />
+    <PackageReference Include="MimeKit" Version="4.17.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
+    <PackageReference Include="Polly" Version="8.6.5" />
     <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
     <PackageReference Include="Servarr.FFprobe" Version="5.1.4.112" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.20" />
-    <PackageReference Include="System.Memory" Version="4.6.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
     <PackageReference Include="FluentMigrator.Runner.Core" Version="6.2.0" />
     <PackageReference Include="FluentMigrator.Runner.SQLite" Version="6.2.0" />
     <PackageReference Include="FluentMigrator.Runner.Postgres" Version="6.2.0" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NLog" Version="4.7.14" />
-    <PackageReference Include="MonoTorrent" Version="3.0.2" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="Semver" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="NLog" Version="5.5.1" />
+    <PackageReference Include="MonoTorrent" Version="3.0.2" />
+    <PackageReference Include="Npgsql" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.Host.Test/Whisparr.Host.Test.csproj
+++ b/src/NzbDrone.Host.Test/Whisparr.Host.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Host\Whisparr.Host.csproj" />

--- a/src/NzbDrone.Host/Bootstrap.cs
+++ b/src/NzbDrone.Host/Bootstrap.cs
@@ -265,7 +265,7 @@ namespace NzbDrone.Host
                 }
                 else if (type == X509ContentType.Pkcs12)
                 {
-                    certificate = new X509Certificate2(cert, password, X509KeyStorageFlags.DefaultKeySet);
+                    certificate = X509CertificateLoader.LoadPkcs12FromFile(cert, password, X509KeyStorageFlags.DefaultKeySet);
                 }
                 else
                 {

--- a/src/NzbDrone.Host/Startup.cs
+++ b/src/NzbDrone.Host/Startup.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using NLog.Extensions.Logging;
 using NzbDrone.Common.EnvironmentInfo;
 using NzbDrone.Common.Instrumentation;
@@ -30,7 +30,7 @@ using Whisparr.Http.Authentication;
 using Whisparr.Http.ErrorManagement;
 using Whisparr.Http.Frontend;
 using Whisparr.Http.Middleware;
-using IPNetwork = Microsoft.AspNetCore.HttpOverrides.IPNetwork;
+using IPNetwork = System.Net.IPNetwork;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace NzbDrone.Host
@@ -59,11 +59,11 @@ namespace NzbDrone.Host
             services.Configure<ForwardedHeadersOptions>(options =>
             {
                 options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost;
-                options.KnownNetworks.Add(new IPNetwork(IPAddress.Parse("10.0.0.0"), 8));
-                options.KnownNetworks.Add(new IPNetwork(IPAddress.Parse("172.16.0.0"), 12));
-                options.KnownNetworks.Add(new IPNetwork(IPAddress.Parse("192.168.0.0"), 16));
-                options.KnownNetworks.Add(new IPNetwork(IPAddress.Parse("fc00::"), 7));
-                options.KnownNetworks.Add(new IPNetwork(IPAddress.Parse("fe80::"), 10));
+                options.KnownIPNetworks.Add(new IPNetwork(IPAddress.Parse("10.0.0.0"), 8));
+                options.KnownIPNetworks.Add(new IPNetwork(IPAddress.Parse("172.16.0.0"), 12));
+                options.KnownIPNetworks.Add(new IPNetwork(IPAddress.Parse("192.168.0.0"), 16));
+                options.KnownIPNetworks.Add(new IPNetwork(IPAddress.Parse("fc00::"), 7));
+                options.KnownIPNetworks.Add(new IPNetwork(IPAddress.Parse("fe80::"), 10));
             });
 
             services.AddRouting(options => options.LowercaseUrls = true);
@@ -119,18 +119,13 @@ namespace NzbDrone.Host
                     Scheme = "apiKey",
                     Description = "Apikey passed as header",
                     In = ParameterLocation.Header,
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.SecurityScheme,
-                        Id = "X-Api-Key"
-                    },
                 };
 
                 c.AddSecurityDefinition("X-Api-Key", apiKeyHeader);
 
-                c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
                 {
-                    { apiKeyHeader, Array.Empty<string>() }
+                    [new OpenApiSecuritySchemeReference(apiKeyHeader.Name, document)] = new List<string>(),
                 });
 
                 var apikeyQuery = new OpenApiSecurityScheme
@@ -140,11 +135,6 @@ namespace NzbDrone.Host
                     Scheme = "apiKey",
                     Description = "Apikey passed as query parameter",
                     In = ParameterLocation.Query,
-                    Reference = new OpenApiReference
-                    {
-                        Type = ReferenceType.SecurityScheme,
-                        Id = "apikey"
-                    },
                 };
 
                 c.AddServer(new OpenApiServer
@@ -159,9 +149,9 @@ namespace NzbDrone.Host
 
                 c.AddSecurityDefinition("apikey", apikeyQuery);
 
-                c.AddSecurityRequirement(new OpenApiSecurityRequirement
+                c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
                 {
-                    { apikeyQuery, Array.Empty<string>() }
+                    [new OpenApiSecuritySchemeReference(apikeyQuery.Name, document)] = new List<string>(),
                 });
 
                 c.DescribeAllParametersInCamelCase();

--- a/src/NzbDrone.Host/Whisparr.Host.csproj
+++ b/src/NzbDrone.Host/Whisparr.Host.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.0.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
-    <PackageReference Include="DryIoc.dll" Version="5.4.1" />
-    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.1" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.1" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.3" />
+    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.Integration.Test/Whisparr.Integration.Test.csproj
+++ b/src/NzbDrone.Integration.Test/Whisparr.Integration.Test.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />

--- a/src/NzbDrone.Libraries.Test/Whisparr.Libraries.Test.csproj
+++ b/src/NzbDrone.Libraries.Test/Whisparr.Libraries.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />

--- a/src/NzbDrone.Mono.Test/Whisparr.Mono.Test.csproj
+++ b/src/NzbDrone.Mono.Test/Whisparr.Mono.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <!--
        The netstandard version here doesn't work in net framework

--- a/src/NzbDrone.Mono/Whisparr.Mono.csproj
+++ b/src/NzbDrone.Mono/Whisparr.Mono.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <!--

--- a/src/NzbDrone.SignalR/Whisparr.SignalR.csproj
+++ b/src/NzbDrone.SignalR/Whisparr.SignalR.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/NzbDrone.Test.Common/NzbDroneRunner.cs
+++ b/src/NzbDrone.Test.Common/NzbDroneRunner.cs
@@ -55,7 +55,7 @@ namespace NzbDrone.Test.Common
 
             if (BuildInfo.IsDebug)
             {
-                Start(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "_output", "net8.0", consoleExe));
+                Start(Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "_output", "net10.0", consoleExe));
             }
             else
             {

--- a/src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj
+++ b/src/NzbDrone.Test.Common/Whisparr.Test.Common.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NLog" Version="5.5.1" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
   </ItemGroup>

--- a/src/NzbDrone.Test.Dummy/Whisparr.Test.Dummy.csproj
+++ b/src/NzbDrone.Test.Dummy/Whisparr.Test.Dummy.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/NzbDrone.Update.Test/Whisparr.Update.Test.csproj
+++ b/src/NzbDrone.Update.Test/Whisparr.Update.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Test.Common\Whisparr.Test.Common.csproj" />

--- a/src/NzbDrone.Update/Whisparr.Update.csproj
+++ b/src/NzbDrone.Update/Whisparr.Update.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DryIoc.dll" Version="5.4.1" />
-    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.0" />
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="DryIoc.dll" Version="5.4.3" />
+    <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
+    <PackageReference Include="NLog" Version="5.5.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.Windows.Test/Whisparr.Windows.Test.csproj
+++ b/src/NzbDrone.Windows.Test/Whisparr.Windows.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common.Test\Whisparr.Common.Test.csproj" />

--- a/src/NzbDrone.Windows/Whisparr.Windows.csproj
+++ b/src/NzbDrone.Windows/Whisparr.Windows.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="NLog" Version="5.5.1" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NzbDrone/SysTray/SysTrayApp.cs
+++ b/src/NzbDrone/SysTray/SysTrayApp.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -54,7 +53,7 @@ namespace NzbDrone.SysTray
             return Task.CompletedTask;
         }
 
-        protected override void OnClosing(CancelEventArgs e)
+        protected override void OnFormClosing(FormClosingEventArgs e)
         {
             DisposeTrayIcon();
         }

--- a/src/NzbDrone/Whisparr.csproj
+++ b/src/NzbDrone/Whisparr.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>net10.0-windows</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>..\NzbDrone.Host\Whisparr.ico</ApplicationIcon>
     <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Resources.Extensions" Version="8.0.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Host\Whisparr.Host.csproj" />

--- a/src/ServiceHelpers/ServiceInstall/ServiceInstall.csproj
+++ b/src/ServiceHelpers/ServiceInstall/ServiceInstall.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="6.0.0-preview.5.21301.5" />
-  </ItemGroup>
 </Project>

--- a/src/ServiceHelpers/ServiceUninstall/ServiceUninstall.csproj
+++ b/src/ServiceHelpers/ServiceUninstall/ServiceUninstall.csproj
@@ -1,9 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="6.0.0-preview.5.21301.5" />
-  </ItemGroup>
 </Project>

--- a/src/Whisparr.Api.V3/Config/CertificateValidator.cs
+++ b/src/Whisparr.Api.V3/Config/CertificateValidator.cs
@@ -47,7 +47,7 @@ namespace Whisparr.Api.V3.Config
                 }
                 else if (type == X509ContentType.Pkcs12)
                 {
-                    new X509Certificate2(certPath, certPassword, X509KeyStorageFlags.DefaultKeySet);
+                    X509CertificateLoader.LoadPkcs12FromFile(certPath, certPassword, X509KeyStorageFlags.DefaultKeySet);
                 }
                 else
                 {

--- a/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
+++ b/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Ical.Net" Version="4.3.1" />
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="NLog" Version="5.5.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.1" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Core\Whisparr.Core.csproj" />

--- a/src/Whisparr.Http/Whisparr.Http.csproj
+++ b/src/Whisparr.Http/Whisparr.Http.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="ImpromptuInterface" Version="8.0.6" />
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="NLog" Version="5.5.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Core\Whisparr.Core.csproj" />

--- a/src/Whisparr.RuntimePatches/Whisparr.RuntimePatches.csproj
+++ b/src/Whisparr.RuntimePatches/Whisparr.RuntimePatches.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Lib.Harmony" Version="2.3.5" />
+    <PackageReference Include="Lib.Harmony" Version="2.4.2" />
   </ItemGroup>
 </Project>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1241,16 +1241,16 @@
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
   integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
 
-"@microsoft/signalr@8.0.7":
-  version "8.0.7"
-  resolved "https://registry.yarnpkg.com/@microsoft/signalr/-/signalr-8.0.7.tgz#94419ddbf9418753e493f4ae4c13990316ec2ea5"
-  integrity sha512-PHcdMv8v5hJlBkRHAuKG5trGViQEkPYee36LnJQx4xHOQ5LL4X0nEWIxOp5cCtZ7tu+30quz5V3k0b1YNuc6lw==
+"@microsoft/signalr@10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/signalr/-/signalr-10.0.0.tgz#465837ced767af7f7cc05988ea95afe8bb58d493"
+  integrity sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==
   dependencies:
     abort-controller "^3.0.0"
     eventsource "^2.0.2"
     fetch-cookie "^2.0.3"
     node-fetch "^2.6.7"
-    ws "^7.4.5"
+    ws "^7.5.10"
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -6016,11 +6016,13 @@ prr@~1.0.1:
   integrity sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==
 
 psl@^1.1.33:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
-  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -8082,10 +8084,10 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@^7.4.5:
-  version "7.5.9"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
-  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+ws@^7.5.10:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 xxhashjs@~0.2.2:
   version "0.2.2"


### PR DESCRIPTION
Sonarr/Sonarr@5d655f98f, on its own branch. 53 files.

`v2-develop` moves from .NET 8 to .NET 10. Builds are self-contained on Windows, Linux and macOS, so **users install nothing** — the runtime ships in the package. `v2` stays on .NET 6.

## What the commit doesn't tell you

Almost none of it applied cleanly, because Whisparr's project files are named `Whisparr.*` where upstream's are `Sonarr.*`. All 26 `TargetFramework`s had to be bumped by hand, and upstream's package versions mapped across the projects that merged cleanly — otherwise the solution ends up mixing 8.x and 10.x of the same assemblies.

**The CI SDK pin is not in the workflow.** `dotnet-version: '8.0.x'` lives in `.github/actions/build/action.yml` and `.github/actions/test/action.yml`. Grepping `.github/workflows/` finds nothing; both would have failed the build on the runner.

**Taking upstream's package block for `Whisparr.Core.csproj` silently dropped `Semver`**, a Whisparr-only dependency — caught by the compiler, restored. `System.Text.Json`, `System.Memory`, `System.ValueTuple`, `System.Runtime.Loader` and `System.Text.Encoding.CodePages` went too, but those are in-framework on .NET 10; the last one .NET explicitly reports as redundant (NU1510).

## Two security regressions in upstream's package map

- It **downgrades MailKit 4.17.0 → 4.14.1**, reopening GHSA-9j88-vvj5-vhgr — the advisory we bumped to clear on the v2 branch — and dragging MimeKit 4.14.0 (GHSA-g7hc-96xr-gvvx) with it. Both pinned forward, MimeKit explicitly so the transitive resolve can't walk back.
- Swashbuckle 10 pulls `Microsoft.OpenApi` 2.3.0, which carries a **high** severity advisory (GHSA-v5pm-xwqc-g5wc). Pinned to 2.7.5, the first patched version.

## Migrations this forces

Not obvious from the title, but the framework bump drags three library majors with it:

- **NLog 4.7.14 → 5.5.1.** Earlier batches kept refusing individual NLog bumps because they produced NU1605; this commit moves every project together, which is the only safe way to do it. It obsoletes `LogBuilder` (→ `LogEventBuilder`), `ConfigurationReloaded` (→ `ConfigurationChanged`, and the handler must now check `ActivatedConfiguration != null` because it also fires on deactivation), `FileTarget.GetFormattedMessage` (→ `RenderFormattedMessage`), the fluent `_logger.Debug()` entry points (→ `ForDebugEvent()`) and the `.Write()` terminator (→ `.Log()`).
- **Sentry 3.23.1 → 5.16.2** — the migration deferred in batch 33. `BeforeSend`/`BeforeBreadcrumb` → `SetBeforeSend`/`SetBeforeBreadcrumb`, scope `User` → `SentryUser`. Upstream's `SentryTarget` also gains an offline cache directory and environment detection, but those need an `IAppFolderInfo` constructor argument from a different commit and are **not** taken here.
- **NLog.Targets.Syslog 6 → 7** drops `UdpConfig.ReconnectInterval`.

## FreeBSD — the one unproven part

Whisparr's framework-dependent FreeBSD publish existed because the Servarr `dotnet-bsd-crossbuild` feed lagged the SDK. I checked that feed: it has **nothing above 8.0.27** — no 9.x, no 10.x — so it cannot serve .NET 10 at all.

This commit removes it and adds upstream's `nuget.pkg.github.com/openur` registry, so FreeBSD self-contains like every other runtime and the workaround goes away entirely.

**What I could not verify:** whether this repo's `${{ github.token }}` can read openur's packages. My local check returned 403, but with a token lacking `read:packages` — so it proves nothing either way. The first CI run on the FreeBSD target settles it. If it fails, the fallback is dropping `freebsd-x64`; upstream's own v5 workflow no longer builds it.

## Verification

Built and tested locally on the .NET 10 SDK (10.0.111) and runtime (10.0.11):

- Build clean with analyzers on
- **Core 3728 passed / 0 failed — identical to the .NET 8 count**, so no behaviour changed
- Host 14/0, Api 18/0
- Common has its 5 pre-existing `ServiceProvider` elevation failures, the same 5 as on .NET 8
- Frontend lint and production build clean

## What this unblocks

Four December commits held for exactly this: Sonarr/Sonarr@227db9ef3 (FFMpegCore/FFprobe), Sonarr/Sonarr@bb090a7c4 (FluentMigrator 7.2), Sonarr/Sonarr@65cd80a9d (Npgsql/Swashbuckle), Sonarr/Sonarr@c3706c3c9 (mini profiler) — plus everything after it upstream, which is currently 452 commits through August 2026.
