### PR TITLE
Chore: Sonarr Upstream Sync - Dependency bumps unblocked by .NET 10

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -4,6 +4,5 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="Mono.Posix.NETStandard" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/Mono.Posix.NETStandard/nuget/v3/index.json" />
-    <add key="FFMpegCore" value="https://pkgs.dev.azure.com/Servarr/Servarr/_packaging/FFMpegCore/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
+++ b/src/NzbDrone.Core.Test/MediaFiles/MediaInfo/MediaInfoFormatterTests/FormatAudioCodecFixture.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using NUnit.Framework;
 using NzbDrone.Core.MediaFiles.MediaInfo;
 using NzbDrone.Test.Common;
@@ -8,7 +9,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
     [TestFixture]
     public class FormatAudioCodecFixture : TestBase
     {
-        private static string sceneName = "My.Series.S01E01-Whisparr";
+        private const string SceneName = "My.Series.S01E01-Whisparr";
 
         [TestCase("mp2, ,  ", "droned.s01e03.swedish.720p.hdtv.x264-prince", "MP2")]
         [TestCase("vorbis, ,  ", "DB Super HDTV", "Vorbis")]
@@ -18,25 +19,33 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
         [TestCase("truehd, thd+,  ", "Atmos", "TrueHD Atmos")]
         [TestCase("truehd, thd+,  ", "TrueHD.Atmos.7.1", "TrueHD Atmos")]
         [TestCase("truehd, thd+,  ", "", "TrueHD Atmos")]
+        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "Atmos", "TrueHD Atmos")]
+        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "TrueHD.Atmos.7.1", "TrueHD Atmos")]
+        [TestCase("truehd, , Dolby TrueHD + Dolby Atmos", "", "TrueHD Atmos")]
         [TestCase("wmav1, , ", "Droned.wmv", "WMA")]
         [TestCase("wmav2, , ", "B.N.S04E18.720p.WEB-DL", "WMA")]
         [TestCase("opus, ,  ", "Roadkill Ep3x11 - YouTube.webm", "Opus")]
         [TestCase("mp3, ,  ", "climbing.mp4", "MP3")]
         [TestCase("dts, , DTS-HD MA", "DTS-HD.MA", "DTS-HD MA")]
         [TestCase("dts, , DTS:X", "DTS-X", "DTS-X")]
+        [TestCase("dts, , DTS-HD MA + DTS:X IMAX", "DTS-X", "DTS-X")]
         [TestCase("dts, , DTS-HD MA", "DTS-HD.MA", "DTS-HD MA")]
         [TestCase("dts, , DTS-ES", "DTS-ES", "DTS-ES")]
         [TestCase("dts, , DTS-ES", "DTS", "DTS-ES")]
         [TestCase("dts, , DTS-HD HRA", "DTSHD-HRA", "DTS-HD HRA")]
         [TestCase("dts, , DTS", "DTS", "DTS")]
         [TestCase("eac3, ec+3,  ", "EAC3.Atmos", "EAC3 Atmos")]
+        [TestCase("eac3, , Dolby Digital Plus + Dolby Atmos", "EAC3.Atmos", "EAC3 Atmos")]
         [TestCase("eac3, ,  ", "DDP5.1", "EAC3")]
         [TestCase("ac3, ,  ", "DD5.1", "AC3")]
+        [TestCase("aac, ,  ", "AAC2.0", "AAC")]
+        [TestCase("aac, , HE-AAC", "AAC2.0", "HE-AAC")]
+        [TestCase("aac, , xHE-AAC", "AAC2.0", "xHE-AAC")]
         [TestCase("adpcm_ima_qt, ,  ", "Custom?", "PCM")]
         [TestCase("adpcm_ms, ,  ", "Custom", "PCM")]
         public void should_format_audio_format(string audioFormatPack, string sceneName, string expectedFormat)
         {
-            var split = audioFormatPack.Split(new string[] { ", " }, System.StringSplitOptions.None);
+            var split = audioFormatPack.Split(',', StringSplitOptions.TrimEntries);
             var mediaInfoModel = new MediaInfoModel
             {
                 AudioFormat = split[0],
@@ -44,7 +53,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
                 AudioProfile = split[2]
             };
 
-            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel, sceneName).Should().Be(expectedFormat);
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel, SceneName).Should().Be(expectedFormat);
         }
 
         [Test]
@@ -56,7 +65,7 @@ namespace NzbDrone.Core.Test.MediaFiles.MediaInfo.MediaInfoFormatterTests
                 AudioCodecID = "Other Audio Codec"
             };
 
-            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel, sceneName).Should().Be(mediaInfoModel.AudioFormat);
+            MediaInfoFormatter.FormatAudioCodec(mediaInfoModel, SceneName).Should().Be(mediaInfoModel.AudioFormat);
         }
     }
 }

--- a/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/000_database_engine_version_check.cs
@@ -18,8 +18,8 @@ namespace NzbDrone.Core.Datastore.Migration
 
         public override void Up()
         {
-            IfDatabase(ProcessorId.SQLite).Execute.WithConnection(LogSqliteVersion);
-            IfDatabase(ProcessorId.PostgreSQL).Execute.WithConnection(LogPostgresVersion);
+            IfDatabase(ProcessorIdConstants.SQLite).Execute.WithConnection(LogSqliteVersion);
+            IfDatabase(ProcessorIdConstants.PostgreSQL).Execute.WithConnection(LogPostgresVersion);
         }
 
         private void LogSqliteVersion(IDbConnection conn, IDbTransaction tran)

--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
@@ -34,8 +34,8 @@ namespace NzbDrone.Core.Datastore.Migration.Framework
 
             var db = databaseType switch
             {
-                DatabaseType.SQLite => ProcessorId.SQLite,
-                DatabaseType.PostgreSQL => ProcessorId.PostgreSQL,
+                DatabaseType.SQLite => ProcessorIdConstants.SQLite,
+                DatabaseType.PostgreSQL => ProcessorIdConstants.PostgreSQL,
                 _ => throw new NotImplementedException($"Unknown database type: {databaseType}")
             };
 

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/FFMpegCoreSideDataTypes.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/FFMpegCoreSideDataTypes.cs
@@ -1,0 +1,9 @@
+namespace NzbDrone.Core.MediaFiles.MediaInfo;
+
+internal static class FFMpegCoreSideDataTypes
+{
+    public const string DoviConfigurationRecordSideData = "DOVI configuration record";
+    public const string HdrDynamicMetadataSpmte2094 = "HDR Dynamic Metadata SMPTE2094-40 (HDR10+)";
+    public const string MasteringDisplayMetadata = "Mastering display metadata";
+    public const string ContentLightLevelMetadata = "Content light level metadata";
+}

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoFormatter.cs
@@ -52,7 +52,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat == "truehd")
             {
-                return "TrueHD";
+                return audioProfile switch
+                {
+                    "Dolby TrueHD + Dolby Atmos" => "TrueHD Atmos",
+                    _ => "TrueHD"
+                };
             }
 
             if (audioFormat == "flac")
@@ -62,37 +66,16 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat == "dts")
             {
-                if (audioProfile == "DTS:X")
+                return audioProfile switch
                 {
-                    return "DTS-X";
-                }
-
-                if (audioProfile == "DTS-HD MA")
-                {
-                    return "DTS-HD MA";
-                }
-
-                if (audioProfile == "DTS-ES")
-                {
-                    return "DTS-ES";
-                }
-
-                if (audioProfile == "DTS-HD HRA")
-                {
-                    return "DTS-HD HRA";
-                }
-
-                if (audioProfile == "DTS Express")
-                {
-                    return "DTS Express";
-                }
-
-                if (audioProfile == "DTS 96/24")
-                {
-                    return "DTS 96/24";
-                }
-
-                return "DTS";
+                    "DTS:X" or "DTS-HD MA + DTS:X IMAX" => "DTS-X",
+                    "DTS-HD MA" => "DTS-HD MA",
+                    "DTS-ES" => "DTS-ES",
+                    "DTS-HD HRA" => "DTS-HD HRA",
+                    "DTS Express" => "DTS Express",
+                    "DTS 96/24" => "DTS 96/24",
+                    _ => "DTS"
+                };
             }
 
             if (audioCodecID == "ec+3")
@@ -102,7 +85,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (audioFormat == "eac3")
             {
-                return "EAC3";
+                return audioProfile switch
+                {
+                    "Dolby Digital Plus + Dolby Atmos" => "EAC3 Atmos",
+                    _ => "EAC3"
+                };
             }
 
             if (audioFormat == "ac3")
@@ -117,7 +104,12 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                     return "HE-AAC";
                 }
 
-                return "AAC";
+                return audioProfile switch
+                {
+                    "HE-AAC" => "HE-AAC",
+                    "xHE-AAC" => "xHE-AAC",
+                    _ => "AAC"
+                };
             }
 
             if (audioFormat == "mp3")

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/MediaInfoModel.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using FFMpegCore;
 using NzbDrone.Core.Datastore;
 
 namespace NzbDrone.Core.MediaFiles.MediaInfo
@@ -9,7 +8,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
     public class MediaInfoModel : IEmbeddedDocument
     {
         public string RawStreamData { get; set; }
-        public string RawFrameData { get; set; }
+
         public int SchemaRevision { get; set; }
 
         public string ContainerFormat { get; set; }
@@ -26,8 +25,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
         public string VideoColourPrimaries { get; set; }
 
         public string VideoTransferCharacteristics { get; set; }
-
-        public DoviConfigurationRecordSideData DoviConfigurationRecord { get; set; }
 
         public HdrFormat VideoHdrFormat { get; set; }
 

--- a/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaInfo/VideoFileInfoReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json.Nodes;
 using FFMpegCore;
 using NLog;
 using NzbDrone.Common.Disk;
@@ -19,10 +20,9 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
     {
         private readonly IDiskProvider _diskProvider;
         private readonly Logger _logger;
-        private readonly List<FFProbePixelFormat> _pixelFormats;
 
-        public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 12;
-        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 12;
+        public const int MINIMUM_MEDIA_INFO_SCHEMA_REVISION = 13;
+        public const int CURRENT_MEDIA_INFO_SCHEMA_REVISION = 13;
 
         private static readonly string[] ValidHdrColourPrimaries = { "bt2020" };
         private static readonly string[] HlgTransferFunctions = { "arib-std-b67" };
@@ -36,16 +36,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             // We bundle ffprobe for all platforms
             GlobalFFOptions.Configure(options => options.BinaryFolder = AppDomain.CurrentDomain.BaseDirectory);
-
-            try
-            {
-                _pixelFormats = FFProbe.GetPixelFormats();
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Failed to get supported pixel formats from ffprobe");
-                _pixelFormats = new List<FFProbePixelFormat>();
-            }
         }
 
         public MediaInfoModel GetMediaInfo(string filename)
@@ -65,15 +55,13 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             try
             {
                 _logger.Debug("Getting media info from {0}", filename);
-                var ffprobeOutput = FFProbe.GetStreamJson(filename, ffOptions: new FFOptions { ExtraArguments = "-probesize 50000000" });
 
-                var analysis = FFProbe.AnalyseStreamJson(ffprobeOutput);
+                var analysis = FFProbe.Analyse(filename, customArguments: "-probesize 50000000");
                 var primaryVideoStream = GetPrimaryVideoStream(analysis);
 
                 if (analysis.PrimaryAudioStream?.ChannelLayout.IsNullOrWhiteSpace() ?? true)
                 {
-                    ffprobeOutput = FFProbe.GetStreamJson(filename, ffOptions: new FFOptions { ExtraArguments = "-probesize 150000000 -analyzeduration 150000000" });
-                    analysis = FFProbe.AnalyseStreamJson(ffprobeOutput);
+                    analysis = FFProbe.Analyse(filename, customArguments: "-probesize 150000000 -analyzeduration 150000000");
                 }
 
                 var mediaInfoModel = new MediaInfoModel();
@@ -85,7 +73,6 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 mediaInfoModel.VideoBitDepth = GetPixelFormat(primaryVideoStream?.PixelFormat)?.Components.Min(x => x.BitDepth) ?? 8;
                 mediaInfoModel.VideoColourPrimaries = primaryVideoStream?.ColorPrimaries;
                 mediaInfoModel.VideoTransferCharacteristics = primaryVideoStream?.ColorTransfer;
-                mediaInfoModel.DoviConfigurationRecord = primaryVideoStream?.SideDataList?.Find(x => x.GetType().Name == nameof(DoviConfigurationRecordSideData)) as DoviConfigurationRecordSideData;
                 mediaInfoModel.Height = primaryVideoStream?.Height ?? 0;
                 mediaInfoModel.Width = primaryVideoStream?.Width ?? 0;
                 mediaInfoModel.AudioFormat = analysis.PrimaryAudioStream?.CodecName;
@@ -103,8 +90,12 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 mediaInfoModel.Subtitles = analysis.SubtitleStreams?.Select(x => x.Language)
                     .Where(l => l.IsNotNullOrWhiteSpace())
                     .ToList();
-                mediaInfoModel.ScanType = "Progressive";
-                mediaInfoModel.RawStreamData = ffprobeOutput;
+                mediaInfoModel.ScanType = primaryVideoStream?.FieldOrder switch
+                {
+                    "tt" or "bb" or "tb" or "bt" => "Interlaced",
+                    _ => "Progressive"
+                };
+                mediaInfoModel.RawStreamData = string.Concat(analysis.OutputData);
                 mediaInfoModel.SchemaRevision = CURRENT_MEDIA_INFO_SCHEMA_REVISION;
 
                 if (analysis.Format.Tags?.TryGetValue("title", out var title) ?? false)
@@ -117,14 +108,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
                 // if it looks like PQ10 or similar HDR, do a frame analysis to figure out which type it is
                 if (PqTransferFunctions.Contains(mediaInfoModel.VideoTransferCharacteristics))
                 {
-                    var frameOutput = FFProbe.GetFrameJson(filename, ffOptions: new() { ExtraArguments = "-read_intervals \"%+#1\" -select_streams v" });
-                    mediaInfoModel.RawFrameData = frameOutput;
-
-                    frames = FFProbe.AnalyseFrameJson(frameOutput);
+                    frames = FFProbe.GetFrames(filename, customArguments: $"-read_intervals \"%+#1\" -select_streams v:{primaryVideoStream?.Index ?? 0}");
                 }
 
-                var streamSideData = primaryVideoStream?.SideDataList ?? new();
-                var framesSideData = frames?.Frames?.Count > 0 ? frames?.Frames[0]?.SideDataList ?? new() : new();
+                var streamSideData = primaryVideoStream?.SideData ?? new();
+                var framesSideData = frames?.Frames.FirstOrDefault()?.SideData ?? new();
 
                 var sideData = streamSideData.Concat(framesSideData).ToList();
                 mediaInfoModel.VideoHdrFormat = GetHdrFormat(mediaInfoModel.VideoBitDepth, mediaInfoModel.VideoColourPrimaries, mediaInfoModel.VideoTransferCharacteristics, sideData);
@@ -176,7 +164,7 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             return 0;
         }
 
-        private VideoStream GetPrimaryVideoStream(IMediaAnalysis mediaAnalysis)
+        private static VideoStream GetPrimaryVideoStream(IMediaAnalysis mediaAnalysis)
         {
             if (mediaAnalysis.VideoStreams.Count <= 1)
             {
@@ -189,23 +177,30 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             return mediaAnalysis.VideoStreams.FirstOrDefault(s => !codecFilter.Contains(s.CodecName)) ?? mediaAnalysis.PrimaryVideoStream;
         }
 
-        private FFProbePixelFormat GetPixelFormat(string format)
+        private static FFProbePixelFormat GetPixelFormat(string format)
         {
-            return _pixelFormats.Find(x => x.Name == format);
+            if (format.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            return FFProbe.TryGetPixelFormat(format, out var pixelFormat) ? pixelFormat : null;
         }
 
-        public static HdrFormat GetHdrFormat(int bitDepth, string colorPrimaries, string transferFunction, List<SideData> sideData)
+        public static HdrFormat GetHdrFormat(int bitDepth, string colorPrimaries, string transferFunction, List<Dictionary<string, JsonNode>> sideData)
         {
             if (bitDepth < 10)
             {
                 return HdrFormat.None;
             }
 
-            if (TryGetSideData<DoviConfigurationRecordSideData>(sideData, out var dovi))
+            if (TryGetSideData(sideData, FFMpegCoreSideDataTypes.DoviConfigurationRecordSideData, out var dovi))
             {
-                var hasHdr10Plus = TryGetSideData<HdrDynamicMetadataSpmte2094>(sideData, out _);
+                var hasHdr10Plus = TryGetSideData(sideData, FFMpegCoreSideDataTypes.HdrDynamicMetadataSpmte2094, out _);
 
-                return dovi.DvBlSignalCompatibilityId switch
+                dovi.TryGetValue("dv_bl_signal_compatibility_id", out var dvBlSignalCompatibilityId);
+
+                return dvBlSignalCompatibilityId?.GetValue<int>() switch
                 {
                     1 => hasHdr10Plus ? HdrFormat.DolbyVisionHdr10Plus : HdrFormat.DolbyVisionHdr10,
                     2 => HdrFormat.DolbyVisionSdr,
@@ -227,13 +222,13 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
 
             if (PqTransferFunctions.Contains(transferFunction))
             {
-                if (TryGetSideData<HdrDynamicMetadataSpmte2094>(sideData, out _))
+                if (TryGetSideData(sideData, FFMpegCoreSideDataTypes.HdrDynamicMetadataSpmte2094, out _))
                 {
                     return HdrFormat.Hdr10Plus;
                 }
 
-                if (TryGetSideData<MasteringDisplayMetadata>(sideData, out _) ||
-                    TryGetSideData<ContentLightLevelMetadata>(sideData, out _))
+                if (TryGetSideData(sideData, FFMpegCoreSideDataTypes.MasteringDisplayMetadata, out _) ||
+                    TryGetSideData(sideData, FFMpegCoreSideDataTypes.ContentLightLevelMetadata, out _))
                 {
                     return HdrFormat.Hdr10;
                 }
@@ -244,10 +239,11 @@ namespace NzbDrone.Core.MediaFiles.MediaInfo
             return HdrFormat.None;
         }
 
-        private static bool TryGetSideData<T>(List<SideData> list, out T result)
-        where T : SideData
+        private static bool TryGetSideData(IReadOnlyList<Dictionary<string, JsonNode>> list, string name, out Dictionary<string, JsonNode> result)
         {
-            result = (T)list?.FirstOrDefault(x => x.GetType().Name == typeof(T).Name);
+            result = list?.FirstOrDefault(item =>
+                item.TryGetValue("side_data_type", out var rawSideDataType) &&
+                rawSideDataType.GetValue<string>().Equals(name, StringComparison.OrdinalIgnoreCase));
 
             return result != null;
         }

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -17,9 +17,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
-    <PackageReference Include="FluentMigrator.Runner.Core" Version="6.2.0" />
-    <PackageReference Include="FluentMigrator.Runner.SQLite" Version="6.2.0" />
-    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="6.2.0" />
+    <PackageReference Include="FluentMigrator.Runner.Core" Version="7.2.0" />
+    <PackageReference Include="FluentMigrator.Runner.SQLite" Version="7.2.0" />
+    <PackageReference Include="FluentMigrator.Runner.Postgres" Version="7.2.0" />
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="Semver" Version="3.0.0" />

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NLog" Version="5.5.1" />
     <PackageReference Include="MonoTorrent" Version="3.0.2" />
-    <PackageReference Include="Npgsql" Version="10.0.0" />
+    <PackageReference Include="Npgsql" Version="10.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NzbDrone.Common\Whisparr.Common.csproj" />

--- a/src/NzbDrone.Core/Whisparr.Core.csproj
+++ b/src/NzbDrone.Core/Whisparr.Core.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="MimeKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" />
+    <PackageReference Include="Openur.FFMpegCore" Version="5.4.0.31" />
+    <PackageReference Include="Openur.FFprobeStatic" Version="8.0.1.289" />
     <PackageReference Include="Polly" Version="8.6.5" />
-    <PackageReference Include="Servarr.FFMpegCore" Version="4.7.0-26" />
-    <PackageReference Include="Servarr.FFprobe" Version="5.1.4.112" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />

--- a/src/NzbDrone.Host/Whisparr.Host.csproj
+++ b/src/NzbDrone.Host/Whisparr.Host.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog.Extensions.Logging" Version="5.5.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.1" />
     <PackageReference Include="DryIoc.dll" Version="5.4.3" />

--- a/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
+++ b/src/Whisparr.Api.V3/Whisparr.Api.V3.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="FluentValidation" Version="9.5.4" />
     <PackageReference Include="Ical.Net" Version="4.3.1" />
     <PackageReference Include="NLog" Version="5.5.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The three dependency bumps that .NET 10 (#1197) was blocking. All December commits.

## A trap the .NET 10 work already taught us, repeating

**Sonarr/Sonarr@65cd80a9d bumps Swashbuckle in two files** — `SwaggerGen` in `Sonarr.Host.csproj` and `Annotations` in `Sonarr.Api.V3.csproj`. Only the second conflicted. The first merged "cleanly" and therefore **did not apply at all**, because Whisparr's file is `Whisparr.Host.csproj` — leaving SwaggerGen at 10.0.1 against Annotations 10.1.0.

Same shape as the 26 TargetFrameworks in the .NET 10 PR: on a renamed project file, a clean merge means the change was silently dropped, not that it succeeded. Caught by checking every Swashbuckle reference afterwards rather than trusting the conflict list.

The explicit `Microsoft.OpenApi` 2.7.5 pin from #1197 is kept — Swashbuckle otherwise resolves a version still carrying GHSA-v5pm-xwqc-g5wc.

## A write-only field, retired

**Sonarr/Sonarr@227db9ef3** moves the FFmpeg packages from Servarr to Openur, and the frame API changes: `GetFrameJson` + `AnalyseFrameJson` collapse into one `GetFrames` call that returns parsed frames rather than raw JSON.

Whisparr assigned that raw JSON to `MediaInfoModel.RawFrameData` — **which nothing in the codebase reads.** It's written on every scan and never consumed. Preserving it under the new API would mean a second ffprobe invocation purely to capture text nobody looks at, so the assignment goes. The property stays declared so MediaInfo JSON already stored on episode files still deserialises.

Also confirms the MailKit 4.17.0 pin from #1197 survived this bump — upstream's package block would have pulled it back to the vulnerable 4.14.1 again.

## Not taken, and not because it's blocked

**Sonarr/Sonarr@c3706c3c9 (mini profiler)** is now unblocked, and I've left it out deliberately. It's 19 files: it changes `HtmlMapperBase.GetHtmlText()` to take an `HttpContext` — rippling through every mapper — adds a `ProfiledImplementations` layer, and rewires `Database`, `MainDatabase` and `LogDatabase` to wrap their connections. That's database-layer surgery for a developer diagnostic with no user-facing effect, and it doesn't belong beside three dependency bumps.

The cost of skipping it is one small ongoing divergence: our `IndexHtmlMapper` overrides the parameterless `GetHtmlText()`, so upstream commits touching those mappers will keep needing the one-line adaptation (as Sonarr/Sonarr@91f1b672c did in batch 34). Happy to take it as its own PR if you'd rather close that gap.

## Verification

On .NET 10: build clean with analyzers on, **Core 3736/0**, Host 14/0, Api 18/0, frontend lint and production build clean.
