### PR TITLE
Fixed: Duplicate theme script rendering as text on every page

### DIFF
--- a/frontend/src/index.ejs
+++ b/frontend/src/index.ejs
@@ -65,14 +65,6 @@
       document.documentElement.style.setProperty('--pageBackground', finalTheme === 'dark' ? '#202020' : '#f5f7fa');
     </script>
 
-      var theme = '_THEME_';
-      var defaultDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      var finalTheme =
-        theme === 'dark' || (theme === 'auto' && defaultDark) ? 'dark' : 'light';
-
-      document.documentElement.style.setProperty('--pageBackground', finalTheme === 'dark' ? '#202020' : '#f5f7fa');
-    </script>
-
     <% for (key in htmlWebpackPlugin.files.js) { %><script type="text/javascript" src="<%= htmlWebpackPlugin.files.js[key] %>" data-no-hash></script><% } %>
     <% for (key in htmlWebpackPlugin.files.css) { %><link href="<%= htmlWebpackPlugin.files.css[key] %>" rel="stylesheet"></link><% } %>
 


### PR DESCRIPTION
The theme bootstrap script in `index.ejs` is duplicated, and the second copy has no opening `<script>` tag. The browser paints it as text at the top of every page:

```
var theme = 'auto'; var defaultDark = window.matchMedia('(prefers-color-scheme: dark)').matches; ...
```

The trailing `</script>` on that second copy also closes nothing, leaving the file with two opening tags and three closing tags.

Introduced by #1195 (Batch 34), which applied the body of Sonarr/Sonarr@91f1b672c twice. The `<style>` block below it — including `html { background-color: var(--pageBackground); }` — was applied correctly and is untouched here.

Removes the orphaned copy. The remaining block keeps the `_THEME_` placeholder for server-side substitution, and the built `_output/UI/index.html` now has balanced `<script>` tags with a single theme block.
