### PR TITLE
Fixed: Postgres air date parsing and invalid path validation

### DIFF
--- a/src/NzbDrone.Core/SeriesStats/SeasonStatistics.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeasonStatistics.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Datastore;
@@ -29,7 +30,7 @@ namespace NzbDrone.Core.SeriesStats
 
                 try
                 {
-                    if (!DateTime.TryParse(NextAiringString, out nextAiring))
+                    if (!DateTime.TryParse(NextAiringString, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out nextAiring))
                     {
                         return null;
                     }
@@ -52,7 +53,7 @@ namespace NzbDrone.Core.SeriesStats
 
                 try
                 {
-                    if (!DateTime.TryParse(PreviousAiringString, out previousAiring))
+                    if (!DateTime.TryParse(PreviousAiringString, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out previousAiring))
                     {
                         return null;
                     }

--- a/src/NzbDrone.Core/SeriesStats/SeriesStatistics.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeriesStatistics.cs
@@ -8,8 +8,8 @@ namespace NzbDrone.Core.SeriesStats
     public class SeriesStatistics : ResultSet
     {
         public int SeriesId { get; set; }
-        public string NextAiringString { get; set; }
-        public string PreviousAiringString { get; set; }
+        public DateTime? NextAiring { get; set; }
+        public DateTime? PreviousAiring { get; set; }
         public int EpisodeFileCount { get; set; }
         public int EpisodeCount { get; set; }
         public int TotalEpisodeCount { get; set; }
@@ -17,51 +17,5 @@ namespace NzbDrone.Core.SeriesStats
         public List<string> ReleaseGroups { get; set; }
         public List<Quality> EpisodeFileQualities { get; set; }
         public List<SeasonStatistics> SeasonStatistics { get; set; }
-
-        public DateTime? NextAiring
-        {
-            get
-            {
-                DateTime nextAiring;
-
-                try
-                {
-                    if (!DateTime.TryParse(NextAiringString, out nextAiring))
-                    {
-                        return null;
-                    }
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    // GHI 3518: Can throw on mono (6.x?) despite being a Try*
-                    return null;
-                }
-
-                return nextAiring;
-            }
-        }
-
-        public DateTime? PreviousAiring
-        {
-            get
-            {
-                DateTime previousAiring;
-
-                try
-                {
-                    if (!DateTime.TryParse(PreviousAiringString, out previousAiring))
-                    {
-                        return null;
-                    }
-                }
-                catch (ArgumentOutOfRangeException)
-                {
-                    // GHI 3518: Can throw on mono (6.x?) despite being a Try*
-                    return null;
-                }
-
-                return previousAiring;
-            }
-        }
     }
 }

--- a/src/NzbDrone.Core/SeriesStats/SeriesStatisticsService.cs
+++ b/src/NzbDrone.Core/SeriesStats/SeriesStatisticsService.cs
@@ -75,8 +75,8 @@ namespace NzbDrone.Core.SeriesStats
             var nextAiring = seasonStatistics.Where(s => s.NextAiring != null).MinBy(s => s.NextAiring);
             var previousAiring = seasonStatistics.Where(s => s.PreviousAiring != null).MaxBy(s => s.PreviousAiring);
 
-            seriesStatistics.NextAiringString = nextAiring?.NextAiringString;
-            seriesStatistics.PreviousAiringString = previousAiring?.PreviousAiringString;
+            seriesStatistics.NextAiring = nextAiring?.NextAiring;
+            seriesStatistics.PreviousAiring = previousAiring?.PreviousAiring;
 
             return seriesStatistics;
         }

--- a/src/NzbDrone.Core/Tv/MoveSeriesService.cs
+++ b/src/NzbDrone.Core/Tv/MoveSeriesService.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using NLog;
 using NzbDrone.Common.Disk;
+using NzbDrone.Common.Extensions;
 using NzbDrone.Common.Instrumentation.Extensions;
 using NzbDrone.Core.Messaging.Commands;
 using NzbDrone.Core.Messaging.Events;
@@ -36,6 +37,12 @@ namespace NzbDrone.Core.Tv
 
         private void MoveSingleSeries(Series series, string sourcePath, string destinationPath, int? index = null, int? total = null)
         {
+            if (!sourcePath.IsPathValid(PathValidationType.CurrentOs))
+            {
+                _logger.Warn("Folder '{0}' for '{1}' is invalid, unable to move series. Try moving files manually", sourcePath, series.Title);
+                return;
+            }
+
             if (!_diskProvider.FolderExists(sourcePath))
             {
                 _logger.Debug("Folder '{0}' for '{1}' does not exist, not moving.", sourcePath, series.Title);

--- a/src/NzbDrone.Core/Validation/Paths/RootFolderValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/RootFolderValidator.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation.Validators;
+using FluentValidation.Validators;
+using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.RootFolders;
 
@@ -24,7 +25,7 @@ namespace NzbDrone.Core.Validation.Paths
 
             context.MessageFormatter.AppendArgument("path", context.PropertyValue.ToString());
 
-            return !_rootFolderService.All().Exists(r => r.Path.PathEquals(context.PropertyValue.ToString()));
+            return !_rootFolderService.All().Exists(r => r.Path.IsPathValid(PathValidationType.CurrentOs) && r.Path.PathEquals(context.PropertyValue.ToString()));
         }
     }
 }

--- a/src/NzbDrone.Core/Validation/Paths/SeriesPathValidator.cs
+++ b/src/NzbDrone.Core/Validation/Paths/SeriesPathValidator.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using FluentValidation.Validators;
+using NzbDrone.Common.Disk;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Tv;
 
@@ -28,7 +29,10 @@ namespace NzbDrone.Core.Validation.Paths
             dynamic instance = context.ParentContext.InstanceToValidate;
             var instanceId = (int)instance.Id;
 
-            return !_seriesService.GetAllSeriesPaths().Any(s => s.Value.PathEquals(context.PropertyValue.ToString()) && s.Key != instanceId);
+            // Skip the path for this series and any invalid paths
+            return !_seriesService.GetAllSeriesPaths().Any(s => s.Key != instanceId &&
+                                                                s.Value.IsPathValid(PathValidationType.CurrentOs) &&
+                                                                s.Value.PathEquals(context.PropertyValue.ToString()));
         }
     }
 }


### PR DESCRIPTION
Two upstream fixes that were skipped in earlier batches for reasons that have since stopped being true.

Applied Commits (2)

Sonarr/Sonarr@7e8d8500f - Fixed: Next/previous/last air dates with Postgres DB
Sonarr/Sonarr@378fedcd9 - Fixed: Skip invalid series paths during validation

Why they were skipped, and why that no longer holds

**Sonarr/Sonarr@7e8d8500f** was skipped as "Whisparr doesn't use LastAired". That was true of `LastAired` alone. `SeriesStatistics` carried the identical bug on `NextAiring` and `PreviousAiring`: `DateTime.TryParse` with no invariant culture, against date strings the database hands back. Whisparr runs Postgres in CI on 16, 17 and 18, so this was live.

Adapted rather than taken wholesale — Whisparr has no `LastAired` on `SeriesStatistics`:
- `SeasonStatistics` keeps its string columns and parsing getters, now with `DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal`.
- `SeriesStatistics` stops parsing strings of its own and takes plain `DateTime?` properties, which the service fills from the already-parsed season rows.
- The `LastAired` third of the commit is dropped.

**Sonarr/Sonarr@378fedcd9** was skipped as "requires IsPathValid extension". That extension exists now, at `NzbDrone.Common/Extensions/PathExtensions.cs:153`. It applied with no conflicts; only `MoveSeriesService.cs` needed `using NzbDrone.Common.Extensions;`, which upstream's copy already had.

Verified with a clean solution build (analyzers on), eslint, the production frontend build, and the Core test suite (3858 passed).
