### PR TITLE
New: Factor the react-query fetch layer out of useApiQuery

### DIFF
--- a/frontend/src/Helpers/Hooks/useApiQuery.ts
+++ b/frontend/src/Helpers/Hooks/useApiQuery.ts
@@ -1,79 +1,49 @@
 import { UndefinedInitialDataOptions, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
+import fetchJson, {
+  ApiError,
+  FetchJsonOptions,
+} from 'Utilities/Fetch/fetchJson';
+import getQueryPath from 'Utilities/Fetch/getQueryPath';
+import getQueryString, { QueryParams } from 'Utilities/Fetch/getQueryString';
 
-interface ApiErrorResponse {
-  message: string;
-  details: string;
-}
-
-export class ApiError extends Error {
-  public statusCode: number;
-  public statusText: string;
-  public statusBody?: ApiErrorResponse;
-
-  public constructor(
-    path: string,
-    statusCode: number,
-    statusText: string,
-    statusBody?: ApiErrorResponse
-  ) {
-    super(`Request Error: (${statusCode}) ${path}`);
-
-    this.statusCode = statusCode;
-    this.statusText = statusText;
-    this.statusBody = statusBody;
-
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-}
-
-interface QueryOptions<T> {
-  path: string;
-  headers?: HeadersInit;
+export interface QueryOptions<T> extends FetchJsonOptions<unknown> {
+  queryParams?: QueryParams;
   queryOptions?:
-    | Omit<UndefinedInitialDataOptions<T, ApiError>, 'queryKey' | 'queryFn'>
+    | Omit<
+        UndefinedInitialDataOptions<Readonly<T>, ApiError>,
+        'queryKey' | 'queryFn'
+      >
     | undefined;
 }
 
-const apiRoot = window.Whisparr.apiRoot;
+const useApiQuery = <T>(options: QueryOptions<T>) => {
+  const { queryKey, requestOptions } = useMemo(() => {
+    const { path: path, queryOptions, queryParams, ...otherOptions } = options;
 
-function useApiQuery<T>(options: QueryOptions<T>) {
-  const { path, headers } = useMemo(() => {
     return {
-      path: apiRoot + options.path,
-      headers: {
-        ...options.headers,
-        'X-Api-Key': window.Whisparr.apiKey,
-        'X-Whisparr-Client': 'Whisparr',
+      queryKey: queryParams ? [path, queryParams] : [path],
+      requestOptions: {
+        ...otherOptions,
+        path: getQueryPath(path) + getQueryString(queryParams),
+        headers: {
+          ...options.headers,
+          'X-Api-Key': window.Whisparr.apiKey,
+          'X-Whisparr-Client': 'Whisparr',
+        },
       },
     };
   }, [options]);
 
-  return useQuery({
-    ...options.queryOptions,
-    queryKey: [path, headers],
-    queryFn: async ({ signal }) => {
-      const response = await fetch(path, {
-        headers,
-        signal,
-      });
-
-      if (!response.ok) {
-        // eslint-disable-next-line init-declarations
-        let body;
-
-        try {
-          body = (await response.json()) as ApiErrorResponse;
-        } catch {
-          throw new ApiError(path, response.status, response.statusText);
-        }
-
-        throw new ApiError(path, response.status, response.statusText, body);
-      }
-
-      return response.json() as T;
-    },
-  });
-}
+  return {
+    queryKey,
+    ...useQuery({
+      ...options.queryOptions,
+      queryKey,
+      queryFn: async ({ signal }) =>
+        fetchJson<Readonly<T>, unknown>({ ...requestOptions, signal }),
+    }),
+  };
+};
 
 export default useApiQuery;

--- a/frontend/src/Helpers/Hooks/useAppPage.ts
+++ b/frontend/src/Helpers/Hooks/useAppPage.ts
@@ -2,7 +2,6 @@ import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import AppState from 'App/State/AppState';
-import { ApiError } from 'Helpers/Hooks/useApiQuery';
 import { useInitializeLanguage } from 'Language/useLanguageName';
 import useIndexerFlags from 'Settings/Indexers/useIndexerFlags';
 import { fetchTranslations } from 'Store/Actions/appActions';
@@ -16,6 +15,7 @@ import {
 } from 'Store/Actions/settingsActions';
 import { fetchStatus } from 'Store/Actions/systemActions';
 import { fetchTags } from 'Store/Actions/tagActions';
+import { ApiError } from 'Utilities/Fetch/fetchJson';
 
 const createErrorsSelector = ({
   indexerFlagsError,

--- a/frontend/src/Utilities/Fetch/anySignal.ts
+++ b/frontend/src/Utilities/Fetch/anySignal.ts
@@ -1,0 +1,24 @@
+const anySignal = (
+  ...signals: (AbortSignal | null | undefined)[]
+): AbortSignal => {
+  const controller = new AbortController();
+
+  for (const signal of signals.filter(Boolean) as AbortSignal[]) {
+    if (signal.aborted) {
+      // Break early if one of the signals is already aborted.
+      controller.abort();
+
+      break;
+    }
+
+    // Listen for abort events on the provided signals and abort the controller.
+    // Automatically removes listeners when the controller is aborted.
+    signal.addEventListener('abort', () => controller.abort(signal.reason), {
+      signal: controller.signal,
+    });
+  }
+
+  return controller.signal;
+};
+
+export default anySignal;

--- a/frontend/src/Utilities/Fetch/fetchJson.ts
+++ b/frontend/src/Utilities/Fetch/fetchJson.ts
@@ -1,0 +1,95 @@
+import anySignal from './anySignal';
+
+export class ApiError extends Error {
+  public statusCode: number;
+  public statusText: string;
+  public statusBody?: ApiErrorResponse;
+
+  public constructor(
+    path: string,
+    statusCode: number,
+    statusText: string,
+    statusBody?: ApiErrorResponse
+  ) {
+    super(`Request Error: (${statusCode}) ${path}`);
+
+    this.statusCode = statusCode;
+    this.statusText = statusText;
+    this.statusBody = statusBody;
+
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export interface ApiErrorResponse {
+  message: string;
+  details: string;
+}
+
+export interface FetchJsonOptions<TData> extends Omit<RequestInit, 'body'> {
+  path: string;
+  headers?: HeadersInit;
+  body?: TData;
+  timeout?: number;
+}
+
+export const urlBase = window.Whisparr.urlBase;
+
+// Upstream hardcodes '/api/v5' here. Whisparr's UI is served by v3, and
+// the react-query hooks work against it unchanged, so keep reading the
+// root the server actually advertises.
+export const apiRoot = window.Whisparr.apiRoot;
+
+async function fetchJson<T, TData>({
+  body,
+  path,
+  signal,
+  timeout,
+  ...options
+}: FetchJsonOptions<TData>): Promise<T> {
+  const abortController = new AbortController();
+
+  let timeoutID: ReturnType<typeof setTimeout> | null = null;
+
+  if (timeout) {
+    timeoutID = setTimeout(() => {
+      abortController.abort();
+    }, timeout);
+  }
+
+  const response = await fetch(path, {
+    ...options,
+    body: body ? JSON.stringify(body) : undefined,
+    headers: {
+      ...options.headers,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    signal: anySignal(abortController.signal, signal),
+  });
+
+  if (timeoutID) {
+    clearTimeout(timeoutID);
+  }
+
+  if (!response.ok) {
+    // eslint-disable-next-line init-declarations
+    let body;
+
+    try {
+      body = (await response.json()) as ApiErrorResponse;
+    } catch {
+      throw new ApiError(path, response.status, response.statusText);
+    }
+
+    throw new ApiError(path, response.status, response.statusText, body);
+  }
+
+  if (response.status === 204) {
+    return {} as T;
+  }
+
+  return response.json() as T;
+}
+
+export default fetchJson;

--- a/frontend/src/Utilities/Fetch/getQueryPath.ts
+++ b/frontend/src/Utilities/Fetch/getQueryPath.ts
@@ -1,0 +1,11 @@
+import { apiRoot } from 'Utilities/Fetch/fetchJson';
+
+const getQueryPath = (path: string) => {
+  // Whisparr's apiRoot comes from the server as "{urlBase}/api/v3", so it
+  // already carries the URL base. Upstream prepends urlBase here because
+  // they hardcode a bare '/api/v5'; doing the same would double the base
+  // for anyone running behind a reverse proxy.
+  return apiRoot + path;
+};
+
+export default getQueryPath;

--- a/frontend/src/Utilities/Fetch/getQueryString.ts
+++ b/frontend/src/Utilities/Fetch/getQueryString.ts
@@ -1,0 +1,57 @@
+import { PropertyFilter } from 'App/State/AppState';
+
+export interface QueryParams {
+  [key: string]:
+    | string
+    | number
+    | boolean
+    | PropertyFilter[]
+    | number[]
+    | string[]
+    | undefined;
+}
+
+const getQueryString = (queryParams?: QueryParams) => {
+  if (!queryParams) {
+    return '';
+  }
+
+  const searchParams = Object.keys(queryParams).reduce<URLSearchParams>(
+    (acc, key) => {
+      const value = queryParams[key];
+
+      if (value == null) {
+        return acc;
+      }
+
+      if (Array.isArray(value)) {
+        if (typeof value[0] === 'object') {
+          (value as PropertyFilter[]).forEach((filter) => {
+            if (Array.isArray(filter.value)) {
+              filter.value.forEach((v: string | number | boolean) =>
+                acc.append(filter.key, String(v))
+              );
+            } else {
+              acc.append(filter.key, String(filter.value));
+            }
+          });
+        } else {
+          value.forEach((item) => {
+            acc.append(key, String(item));
+          });
+        }
+      } else {
+        acc.append(key, String(value));
+      }
+
+      return acc;
+    },
+    new URLSearchParams()
+  );
+
+  const paramsString = searchParams.toString();
+
+  return `?${paramsString}`;
+};
+
+export default getQueryString;

--- a/frontend/src/Utilities/Object/getErrorMessage.ts
+++ b/frontend/src/Utilities/Object/getErrorMessage.ts
@@ -1,5 +1,5 @@
 import { Error } from 'App/State/AppSectionState';
-import { ApiError } from 'Helpers/Hooks/useApiQuery';
+import { ApiError } from 'Utilities/Fetch/fetchJson';
 
 function getErrorMessage(
   error: Error | ApiError | undefined,


### PR DESCRIPTION
Infrastructure step for the redux to react-query migration, following #1211.

Whisparr's `useApiQuery.ts` was a self-contained one-off: it built its URL inline, defined its own `ApiError`, and called `fetch` directly. Upstream factored that same code into a small shared fetch layer that both `useApiQuery` and `useApiMutation` sit on. Without it, every further conversion is a hand-adaptation instead of a near-clean pick.

This ports that layer and moves `useApiQuery` onto it, matching upstream's structure.

Adds `frontend/src/Utilities/Fetch/`

- `fetchJson.ts` and `anySignal.ts`, from Sonarr/Sonarr@591b569bd
- `getQueryPath.ts` and `getQueryString.ts`, from Sonarr/Sonarr@5342416

`useApiQuery.ts` is replaced with upstream's version, which is the same logic this file already had, now delegating to `fetchJson`. `ApiError` moves to `fetchJson`, so its two importers (`useAppPage`, `getErrorMessage`) are repointed. No behaviour change for the existing callers.

Three deliberate differences from upstream

**1. `apiRoot` is not hardcoded.** Upstream has `export const apiRoot = '/api/v5';` with `// window.Sonarr.apiRoot` commented out beside it. This keeps `window.Whisparr.apiRoot`, so the hooks continue to talk to v3.

**2. `getQueryPath` does not prepend `urlBase`.** This one matters. `InitializeJsonController.cs:48` serves `apiRoot` as `"{urlBase}/api/v3"` — it already carries the URL base. Upstream can safely do `urlBase + apiRoot + path` because their `apiRoot` is a bare `/api/v5`; doing the same here would produce `/base/base/api/v3/...` and break every request for anyone running behind a reverse proxy with a URL base set, while looking perfectly fine for everyone else. Verified both cases:

```
urlBase = "/whisparr"  ->  /whisparr/api/v3/indexerFlag
urlBase = ""           ->  /api/v3/indexerFlag
```

**3. `PropertyFilter` is imported from `App/State/AppState`.** Upstream moved it to `Filters/Filter` when it dropped redux; the interface is identical, it just still lives in AppState here. The `forEach` callback also needed an explicit parameter type, since TypeScript will not infer a common element type across the union of array types in `PropertyFilter['value']`.

`useApiMutation` is intentionally not included — nothing would exercise it yet. It comes with the first conversion that needs it.

Verified with a clean solution build (analyzers on), eslint, and the production frontend build.
