### PR TITLE
New: Use react-query for translations

### DIFF
--- a/frontend/src/App/State/AppState.ts
+++ b/frontend/src/App/State/AppState.ts
@@ -2,7 +2,6 @@ import ModelBase from 'App/ModelBase';
 import { FilterBuilderTypes } from 'Helpers/Props/filterBuilderTypes';
 import { DateFilterValue, FilterType } from 'Helpers/Props/filterTypes';
 import AddSeriesAppState from './AddSeriesAppState';
-import { Error } from './AppSectionState';
 import BlocklistAppState from './BlocklistAppState';
 import CalendarAppState from './CalendarAppState';
 import CaptchaAppState from './CaptchaAppState';
@@ -74,10 +73,6 @@ export interface AppSectionState {
     isLargeScreen: boolean;
     width: number;
     height: number;
-  };
-  translations: {
-    error?: Error;
-    isPopulated: boolean;
   };
   messages: MessagesAppState;
 }

--- a/frontend/src/App/useTranslations.ts
+++ b/frontend/src/App/useTranslations.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import useApiQuery from 'Helpers/Hooks/useApiQuery';
+import { setTranslations } from 'Utilities/String/translate';
+
+interface TranslationsResponse {
+  strings: Record<string, string>;
+}
+
+export function useTranslations() {
+  const { data, ...result } = useApiQuery<TranslationsResponse>({
+    path: '/localization',
+    queryOptions: {
+      staleTime: Infinity,
+      gcTime: Infinity,
+    },
+  });
+
+  useEffect(() => {
+    if (data) {
+      setTranslations(data.strings);
+    }
+  }, [data]);
+
+  return {
+    ...result,
+    data,
+  };
+}

--- a/frontend/src/Components/Page/ErrorPage.tsx
+++ b/frontend/src/Components/Page/ErrorPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Error } from 'App/State/AppSectionState';
+import { ApiError } from 'Utilities/Fetch/fetchJson';
 import getErrorMessage from 'Utilities/Object/getErrorMessage';
 import translate from 'Utilities/String/translate';
 import styles from './ErrorPage.css';
@@ -7,7 +8,7 @@ import styles from './ErrorPage.css';
 interface ErrorPageProps {
   version: string;
   isLocalStorageSupported: boolean;
-  translationsError?: Error;
+  translationsError?: ApiError | null;
   seriesError?: Error;
   customFiltersError?: Error;
   tagsError?: Error;

--- a/frontend/src/Helpers/Hooks/useAppPage.ts
+++ b/frontend/src/Helpers/Hooks/useAppPage.ts
@@ -2,10 +2,10 @@ import { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { createSelector } from 'reselect';
 import AppState from 'App/State/AppState';
+import { useTranslations } from 'App/useTranslations';
 import { useInitializeLanguage } from 'Language/useLanguageName';
 import { useLanguages } from 'Language/useLanguages';
 import useIndexerFlags from 'Settings/Indexers/useIndexerFlags';
-import { fetchTranslations } from 'Store/Actions/appActions';
 import { fetchCustomFilters } from 'Store/Actions/customFilterActions';
 import { fetchSeries } from 'Store/Actions/seriesActions';
 import {
@@ -20,9 +20,11 @@ import { ApiError } from 'Utilities/Fetch/fetchJson';
 const createErrorsSelector = ({
   indexerFlagsError,
   languagesError,
+  translationsError,
 }: {
   indexerFlagsError: ApiError | null;
   languagesError: ApiError | null;
+  translationsError: ApiError | null;
 }) =>
   createSelector(
     (state: AppState) => state.series.error,
@@ -32,7 +34,6 @@ const createErrorsSelector = ({
     (state: AppState) => state.settings.qualityProfiles.error,
     (state: AppState) => state.settings.importLists.error,
     (state: AppState) => state.system.status.error,
-    (state: AppState) => state.app.translations.error,
     (
       seriesError,
       customFiltersError,
@@ -40,8 +41,7 @@ const createErrorsSelector = ({
       uiSettingsError,
       qualityProfilesError,
       importListsError,
-      systemStatusError,
-      translationsError
+      systemStatusError
     ) => {
       const hasError = !!(
         seriesError ||
@@ -87,8 +87,7 @@ const useAppPage = () => {
       state.settings.ui.isPopulated &&
       state.settings.qualityProfiles.isPopulated &&
       state.settings.importLists.isPopulated &&
-      state.system.status.isPopulated &&
-      state.app.translations.isPopulated
+      state.system.status.isPopulated
   );
 
   const { isFetched: isIndexerFlagsFetched, error: indexerFlagsError } =
@@ -97,11 +96,21 @@ const useAppPage = () => {
   const { isFetched: isLanguagesFetched, error: languagesError } =
     useLanguages();
 
+  const { isFetched: isTranslationsFetched, error: translationsError } =
+    useTranslations();
+
   const isPopulated =
-    isReduxPopulated && isIndexerFlagsFetched && isLanguagesFetched;
+    isReduxPopulated &&
+    isIndexerFlagsFetched &&
+    isLanguagesFetched &&
+    isTranslationsFetched;
 
   const { hasError, errors } = useSelector(
-    createErrorsSelector({ indexerFlagsError, languagesError })
+    createErrorsSelector({
+      indexerFlagsError,
+      languagesError,
+      translationsError,
+    })
   );
 
   const isLocalStorageSupported = useMemo(() => {
@@ -125,7 +134,6 @@ const useAppPage = () => {
     dispatch(fetchImportLists());
     dispatch(fetchUISettings());
     dispatch(fetchStatus());
-    dispatch(fetchTranslations());
   }, [dispatch]);
 
   return useMemo(() => {

--- a/frontend/src/Store/Actions/appActions.js
+++ b/frontend/src/Store/Actions/appActions.js
@@ -4,7 +4,6 @@ import { createThunk, handleThunks } from 'Store/thunks';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
 import getSectionState from 'Utilities/State/getSectionState';
 import updateSectionState from 'Utilities/State/updateSectionState';
-import { fetchTranslations as fetchAppTranslations } from 'Utilities/String/translate';
 import createHandleActions from './Creators/createHandleActions';
 
 function getDimensions(width, height) {
@@ -42,12 +41,7 @@ export const defaultState = {
   isReconnecting: false,
   isDisconnected: false,
   isRestarting: false,
-  isSidebarVisible: !getDimensions(window.innerWidth, window.innerHeight).isSmallScreen,
-  translations: {
-    isFetching: true,
-    isPopulated: false,
-    error: null
-  }
+  isSidebarVisible: !getDimensions(window.innerWidth, window.innerHeight).isSmallScreen
 };
 
 //
@@ -59,7 +53,6 @@ export const SAVE_DIMENSIONS = 'app/saveDimensions';
 export const SET_VERSION = 'app/setVersion';
 export const SET_APP_VALUE = 'app/setAppValue';
 export const SET_IS_SIDEBAR_VISIBLE = 'app/setIsSidebarVisible';
-export const FETCH_TRANSLATIONS = 'app/fetchTranslations';
 
 export const PING_SERVER = 'app/pingServer';
 
@@ -73,7 +66,6 @@ export const setAppValue = createAction(SET_APP_VALUE);
 export const showMessage = createAction(SHOW_MESSAGE);
 export const hideMessage = createAction(HIDE_MESSAGE);
 export const pingServer = createThunk(PING_SERVER);
-export const fetchTranslations = createThunk(FETCH_TRANSLATIONS);
 
 //
 // Helpers
@@ -135,17 +127,6 @@ function pingServerAfterTimeout(getState, dispatch) {
 export const actionHandlers = handleThunks({
   [PING_SERVER]: function(getState, payload, dispatch) {
     pingServerAfterTimeout(getState, dispatch);
-  },
-  [FETCH_TRANSLATIONS]: async function(getState, payload, dispatch) {
-    const isFetchingComplete = await fetchAppTranslations();
-
-    dispatch(setAppValue({
-      translations: {
-        isFetching: false,
-        isPopulated: isFetchingComplete,
-        error: isFetchingComplete ? null : 'Failed to load translations from API'
-      }
-    }));
   }
 });
 

--- a/frontend/src/Utilities/Object/getErrorMessage.ts
+++ b/frontend/src/Utilities/Object/getErrorMessage.ts
@@ -2,7 +2,7 @@ import { Error } from 'App/State/AppSectionState';
 import { ApiError } from 'Utilities/Fetch/fetchJson';
 
 function getErrorMessage(
-  error: Error | ApiError | undefined,
+  error: Error | ApiError | undefined | null,
   fallbackErrorMessage = ''
 ) {
   if (!error) {

--- a/frontend/src/Utilities/String/translate.ts
+++ b/frontend/src/Utilities/String/translate.ts
@@ -1,29 +1,10 @@
-import createAjaxRequest from 'Utilities/createAjaxRequest';
-
-function getTranslations() {
-  return createAjaxRequest({
-    global: false,
-    dataType: 'json',
-    url: '/localization',
-  }).request;
-}
-
 let translations: Record<string, string> = {};
 
-export async function fetchTranslations(): Promise<boolean> {
-  return new Promise(async (resolve) => {
-    try {
-      const data = await getTranslations();
-      translations = data.strings;
-
-      resolve(true);
-    } catch {
-      resolve(false);
-    }
-  });
+export function setTranslations(translationData: Record<string, string>) {
+  translations = translationData;
 }
 
-export default function translate(
+export function translate(
   key: string,
   tokens: Record<string, string | number | boolean> = { appName: 'Whisparr' }
 ) {
@@ -37,3 +18,5 @@ export default function translate(
 
   return translation;
 }
+
+export default translate;


### PR DESCRIPTION
Sonarr/Sonarr@66efb904f - Use react-query for translations

Third slice of the redux to react-query migration, after #1211, #1212 and #1213. Against **v3**: the hook queries `/localization`, which `Whisparr.Api.V3/Localization/LocalizationController.cs` serves and which `translate.ts` already fetched directly.

`translate.ts` previously did its own `createAjaxRequest` call and owned the fetch. It now just exposes `setTranslations`, and the hook drives it. Whisparr's `appName: 'Whisparr'` token default is unchanged.

Mixed error types in ErrorPage

`ErrorPage` is the first place the half-migrated state is visible in a type. `translationsError` now comes from a hook and is `ApiError | null`, while `seriesError`, `customFiltersError`, `tagsError`, `qualityProfilesError`, `uiSettingsError` and `systemStatusError` are still redux `Error`. Upstream types all of them as `ApiError` because everything on their side is converted; taking that verbatim would have broken the six redux-backed props. So only `translationsError` changed.

`getErrorMessage` needed `| null` added to its parameter — it already accepted `Error | ApiError | undefined`, and upstream's signature is `Error | ApiError | undefined | null`. This just catches Whisparr up to it.

useAppPage

Third pass through this file, and the shape is settled: converted slices call their hook and pass the error into `createErrorsSelector`, redux slices are still read from state, and `isPopulated` ANDs the two groups. The selector now takes `{ indexerFlagsError, languagesError, translationsError }`.

Verified with a clean solution build (analyzers on), eslint, and the production frontend build.
