### PR TITLE
New: Add useApiMutation and use react-query for backups

### DIFF
--- a/frontend/src/App/State/AppState.ts
+++ b/frontend/src/App/State/AppState.ts
@@ -100,8 +100,8 @@ interface AppState {
   series: SeriesAppState;
   seriesHistory: SeriesHistoryAppState;
   seriesIndex: SeriesIndexAppState;
-  settings: SettingsAppState;
   system: SystemAppState;
+  settings: SettingsAppState;
   tags: TagsAppState;
   wanted: WantedAppState;
 }

--- a/frontend/src/App/State/BackupAppState.ts
+++ b/frontend/src/App/State/BackupAppState.ts
@@ -1,9 +1,0 @@
-import Backup from 'typings/Backup';
-import AppSectionState, { Error } from './AppSectionState';
-
-interface BackupAppState extends AppSectionState<Backup> {
-  isRestoring: boolean;
-  restoreError?: Error;
-}
-
-export default BackupAppState;

--- a/frontend/src/App/State/SystemAppState.ts
+++ b/frontend/src/App/State/SystemAppState.ts
@@ -1,12 +1,10 @@
 import Update from 'typings/Update';
 import AppSectionState from './AppSectionState';
-import BackupAppState from './BackupAppState';
 import LogsAppState from './LogsAppState';
 
 export type UpdateAppState = AppSectionState<Update>;
 
 interface SystemAppState {
-  backups: BackupAppState;
   logs: LogsAppState;
   updates: UpdateAppState;
 }

--- a/frontend/src/Helpers/Hooks/useApiMutation.ts
+++ b/frontend/src/Helpers/Hooks/useApiMutation.ts
@@ -1,0 +1,87 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import ModelBase from 'App/ModelBase';
+import { ValidationFailures } from 'Store/Selectors/selectSettings';
+import {
+  ValidationError,
+  ValidationFailure,
+  ValidationWarning,
+} from 'typings/pending';
+import fetchJson, {
+  ApiError,
+  FetchJsonOptions,
+} from 'Utilities/Fetch/fetchJson';
+import getQueryPath from 'Utilities/Fetch/getQueryPath';
+import getQueryString, { QueryParams } from 'Utilities/Fetch/getQueryString';
+
+interface MutationOptions<T, TData>
+  extends Omit<FetchJsonOptions<TData>, 'method'> {
+  method: 'POST' | 'PUT' | 'DELETE';
+  mutationOptions?: Omit<UseMutationOptions<T, ApiError, TData>, 'mutationFn'>;
+  queryParams?: QueryParams;
+}
+
+function useApiMutation<T, TData>(options: MutationOptions<T, TData>) {
+  const requestOptions = useMemo(() => {
+    return {
+      ...options,
+      path: getQueryPath(options.path) + getQueryString(options.queryParams),
+      headers: {
+        ...options.headers,
+        'X-Api-Key': window.Whisparr.apiKey,
+        'X-Whisparr-Client': 'Whisparr',
+      },
+    };
+  }, [options]);
+
+  return useMutation<T, ApiError, TData>({
+    ...options.mutationOptions,
+    mutationFn: async (data?: TData) => {
+      const { path, ...otherOptions } = requestOptions;
+
+      return fetchJson<T, TData>({ path, ...otherOptions, body: data });
+    },
+  });
+}
+
+export default useApiMutation;
+
+export function getValidationFailures(
+  error?: ApiError | null
+): ValidationFailures {
+  if (!error || error.statusCode !== 400) {
+    return {
+      errors: [],
+      warnings: [],
+    };
+  }
+
+  return ((error.statusBody ?? []) as ValidationFailure[]).reduce(
+    (acc: ValidationFailures, failure: ValidationFailure) => {
+      if (failure.isWarning) {
+        acc.warnings.push(failure as ValidationWarning);
+      } else {
+        acc.errors.push(failure as ValidationError);
+      }
+
+      return acc;
+    },
+    {
+      errors: [],
+      warnings: [],
+    }
+  );
+}
+
+export function addOrUpdateQueryClientItem<
+  T extends ModelBase,
+  K extends keyof T
+>(oldData: T[] = [], newItem: T, key: K) {
+  const existingIndex = oldData.findIndex((item) => item[key] === newItem[key]);
+
+  if (existingIndex === -1) {
+    return [...oldData, newItem];
+  }
+
+  return oldData.map((item) => (item[key] === newItem[key] ? newItem : item));
+}

--- a/frontend/src/Settings/General/GeneralSettings.tsx
+++ b/frontend/src/Settings/General/GeneralSettings.tsx
@@ -16,10 +16,10 @@ import {
   saveGeneralSettings,
   setGeneralSettingsValue,
 } from 'Store/Actions/settingsActions';
-import { restart } from 'Store/Actions/systemActions';
 import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
 import createSettingsSectionSelector from 'Store/Selectors/createSettingsSectionSelector';
 import { useIsWindowsService } from 'System/Status/useSystemStatus';
+import { useRestart } from 'System/useSystem';
 import { InputChanged } from 'typings/inputs';
 import translate from 'Utilities/String/translate';
 import AnalyticSettings from './AnalyticSettings';
@@ -48,6 +48,7 @@ const requiresRestartKeys = [
 function GeneralSettings() {
   const dispatch = useDispatch();
   const isWindowsService = useIsWindowsService();
+  const { mutate: restart } = useRestart();
   const isResettingApiKey = useSelector(
     createCommandExecutingSelector(commandNames.RESET_API_KEY)
   );
@@ -87,8 +88,8 @@ function GeneralSettings() {
 
   const handleConfirmRestart = useCallback(() => {
     setIsRestartRequiredModalOpen(false);
-    dispatch(restart());
-  }, [dispatch]);
+    restart();
+  }, [restart]);
 
   const handleCloseRestartRequiredModalOpen = useCallback(() => {
     setIsRestartRequiredModalOpen(false);

--- a/frontend/src/Store/Actions/index.js
+++ b/frontend/src/Store/Actions/index.js
@@ -23,7 +23,6 @@ import * as series from './seriesActions';
 import * as seriesHistory from './seriesHistoryActions';
 import * as seriesIndex from './seriesIndexActions';
 import * as settings from './settingsActions';
-import * as system from './systemActions';
 import * as tags from './tagActions';
 import * as wanted from './wantedActions';
 
@@ -53,7 +52,6 @@ export default [
   seriesHistory,
   seriesIndex,
   settings,
-  system,
   tags,
   wanted
 ];

--- a/frontend/src/Store/Actions/systemActions.js
+++ b/frontend/src/Store/Actions/systemActions.js
@@ -6,10 +6,8 @@ import createAjaxRequest from 'Utilities/createAjaxRequest';
 import serverSideCollectionHandlers from 'Utilities/State/serverSideCollectionHandlers';
 import translate from 'Utilities/String/translate';
 import { pingServer } from './appActions';
-import { set } from './baseActions';
 import createFetchHandler from './Creators/createFetchHandler';
 import createHandleActions from './Creators/createHandleActions';
-import createRemoveItemHandler from './Creators/createRemoveItemHandler';
 import createServerSideCollectionHandlers from './Creators/createServerSideCollectionHandlers';
 import createClearReducer from './Creators/Reducers/createClearReducer';
 import createSetTableOptionReducer from './Creators/Reducers/createSetTableOptionReducer';
@@ -18,23 +16,11 @@ import createSetTableOptionReducer from './Creators/Reducers/createSetTableOptio
 // Variables
 
 export const section = 'system';
-const backupsSection = 'system.backups';
 
 //
 // State
 
 export const defaultState = {
-  backups: {
-    isFetching: false,
-    isPopulated: false,
-    error: null,
-    isRestoring: false,
-    restoreError: null,
-    isDeleting: false,
-    deleteError: null,
-    items: []
-  },
-
   updates: {
     isFetching: false,
     isPopulated: false,
@@ -142,11 +128,6 @@ export const persistState = [
 //
 // Actions Types
 
-export const FETCH_BACKUPS = 'system/backups/fetchBackups';
-export const RESTORE_BACKUP = 'system/backups/restoreBackup';
-export const CLEAR_RESTORE_BACKUP = 'system/backups/clearRestoreBackup';
-export const DELETE_BACKUP = 'system/backups/deleteBackup';
-
 export const FETCH_UPDATES = 'system/updates/fetchUpdates';
 
 export const FETCH_LOGS = 'system/logs/fetchLogs';
@@ -165,11 +146,6 @@ export const SHUTDOWN = 'system/shutdown';
 
 //
 // Action Creators
-
-export const fetchBackups = createThunk(FETCH_BACKUPS);
-export const restoreBackup = createThunk(RESTORE_BACKUP);
-export const clearRestoreBackup = createAction(CLEAR_RESTORE_BACKUP);
-export const deleteBackup = createThunk(DELETE_BACKUP);
 
 export const fetchUpdates = createThunk(FETCH_UPDATES);
 
@@ -191,70 +167,6 @@ export const shutdown = createThunk(SHUTDOWN);
 // Action Handlers
 
 export const actionHandlers = handleThunks({
-  [FETCH_BACKUPS]: createFetchHandler(backupsSection, '/system/backup'),
-
-  [RESTORE_BACKUP]: function(getState, payload, dispatch) {
-    const {
-      id,
-      file
-    } = payload;
-
-    dispatch(set({
-      section: backupsSection,
-      isRestoring: true
-    }));
-
-    let ajaxOptions = null;
-
-    if (id) {
-      ajaxOptions = {
-        url: `/system/backup/restore/${id}`,
-        method: 'POST',
-        contentType: 'application/json',
-        dataType: 'json',
-        data: JSON.stringify({
-          id
-        })
-      };
-    } else if (file) {
-      const formData = new FormData();
-      formData.append('restore', file);
-
-      ajaxOptions = {
-        url: '/system/backup/restore/upload',
-        method: 'POST',
-        processData: false,
-        contentType: false,
-        data: formData
-      };
-    } else {
-      dispatch(set({
-        section: backupsSection,
-        isRestoring: false,
-        restoreError: 'Error restoring backup'
-      }));
-    }
-
-    const promise = createAjaxRequest(ajaxOptions).request;
-
-    promise.done((data) => {
-      dispatch(set({
-        section: backupsSection,
-        isRestoring: false,
-        restoreError: null
-      }));
-    });
-
-    promise.fail((xhr) => {
-      dispatch(set({
-        section: backupsSection,
-        isRestoring: false,
-        restoreError: xhr
-      }));
-    });
-  },
-
-  [DELETE_BACKUP]: createRemoveItemHandler(backupsSection, '/system/backup'),
 
   [FETCH_UPDATES]: createFetchHandler('system.updates', '/update'),
 
@@ -298,17 +210,6 @@ export const actionHandlers = handleThunks({
 // Reducers
 
 export const reducers = createHandleActions({
-
-  [CLEAR_RESTORE_BACKUP]: function(state, { payload }) {
-    return {
-      ...state,
-      backups: {
-        ...state.backups,
-        isRestoring: false,
-        restoreError: null
-      }
-    };
-  },
 
   [SET_LOGS_TABLE_OPTION]: createSetTableOptionReducer('logs'),
 

--- a/frontend/src/Store/Selectors/selectSettings.ts
+++ b/frontend/src/Store/Selectors/selectSettings.ts
@@ -12,7 +12,7 @@ import {
 } from 'typings/pending';
 import isEmpty from 'Utilities/Object/isEmpty';
 
-interface ValidationFailures {
+export interface ValidationFailures {
   errors: ValidationError[];
   warnings: ValidationWarning[];
 }

--- a/frontend/src/System/Backup/BackupRow.tsx
+++ b/frontend/src/System/Backup/BackupRow.tsx
@@ -24,7 +24,7 @@ interface BackupRowProps {
 }
 
 function BackupRow({ id, type, name, path, size, time }: BackupRowProps) {
-  const deleteBackupMutation = useDeleteBackup(id);
+  const { deleteBackup } = useDeleteBackup(id);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false);
   const [isConfirmDeleteModalOpen, setIsConfirmDeleteModalOpen] =
     useState(false);
@@ -67,7 +67,7 @@ function BackupRow({ id, type, name, path, size, time }: BackupRowProps) {
   }, []);
 
   const handleConfirmDeletePress = useCallback(() => {
-    deleteBackupMutation.mutate(undefined, {
+    deleteBackup(undefined, {
       onSuccess: () => {
         setIsConfirmDeleteModalOpen(false);
       },
@@ -75,7 +75,7 @@ function BackupRow({ id, type, name, path, size, time }: BackupRowProps) {
         console.error('Failed to delete backup:', error);
       },
     });
-  }, [deleteBackupMutation]);
+  }, [deleteBackup]);
 
   return (
     <TableRow key={id}>

--- a/frontend/src/System/Backup/BackupRow.tsx
+++ b/frontend/src/System/Backup/BackupRow.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { useDispatch } from 'react-redux';
 import Icon from 'Components/Icon';
 import IconButton from 'Components/Link/IconButton';
 import Link from 'Components/Link/Link';
@@ -8,11 +7,11 @@ import RelativeDateCell from 'Components/Table/Cells/RelativeDateCell';
 import TableRowCell from 'Components/Table/Cells/TableRowCell';
 import TableRow from 'Components/Table/TableRow';
 import { icons, kinds } from 'Helpers/Props';
-import { deleteBackup } from 'Store/Actions/systemActions';
 import { BackupType } from 'typings/Backup';
 import formatBytes from 'Utilities/Number/formatBytes';
 import translate from 'Utilities/String/translate';
 import RestoreBackupModal from './RestoreBackupModal';
+import { useDeleteBackup } from './useBackups';
 import styles from './BackupRow.css';
 
 interface BackupRowProps {
@@ -25,7 +24,7 @@ interface BackupRowProps {
 }
 
 function BackupRow({ id, type, name, path, size, time }: BackupRowProps) {
-  const dispatch = useDispatch();
+  const deleteBackupMutation = useDeleteBackup(id);
   const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false);
   const [isConfirmDeleteModalOpen, setIsConfirmDeleteModalOpen] =
     useState(false);
@@ -68,9 +67,15 @@ function BackupRow({ id, type, name, path, size, time }: BackupRowProps) {
   }, []);
 
   const handleConfirmDeletePress = useCallback(() => {
-    dispatch(deleteBackup({ id }));
-    setIsConfirmDeleteModalOpen(false);
-  }, [id, dispatch]);
+    deleteBackupMutation.mutate(undefined, {
+      onSuccess: () => {
+        setIsConfirmDeleteModalOpen(false);
+      },
+      onError: (error) => {
+        console.error('Failed to delete backup:', error);
+      },
+    });
+  }, [deleteBackupMutation]);
 
   return (
     <TableRow key={id}>

--- a/frontend/src/System/Backup/RestoreBackupModal.tsx
+++ b/frontend/src/System/Backup/RestoreBackupModal.tsx
@@ -1,7 +1,5 @@
-import React, { useCallback } from 'react';
-import { useDispatch } from 'react-redux';
+import React from 'react';
 import Modal from 'Components/Modal/Modal';
-import { clearRestoreBackup } from 'Store/Actions/systemActions';
 import RestoreBackupModalContent, {
   RestoreBackupModalContentProps,
 } from './RestoreBackupModalContent';
@@ -16,19 +14,9 @@ function RestoreBackupModal({
   onModalClose,
   ...otherProps
 }: RestoreBackupModalProps) {
-  const dispatch = useDispatch();
-
-  const handleModalClose = useCallback(() => {
-    dispatch(clearRestoreBackup());
-    onModalClose();
-  }, [dispatch, onModalClose]);
-
   return (
-    <Modal isOpen={isOpen} onModalClose={handleModalClose}>
-      <RestoreBackupModalContent
-        {...otherProps}
-        onModalClose={handleModalClose}
-      />
+    <Modal isOpen={isOpen} onModalClose={onModalClose}>
+      <RestoreBackupModalContent {...otherProps} onModalClose={onModalClose} />
     </Modal>
   );
 }

--- a/frontend/src/System/Backup/RestoreBackupModalContent.tsx
+++ b/frontend/src/System/Backup/RestoreBackupModalContent.tsx
@@ -82,16 +82,10 @@ function RestoreBackupModalContent({
   const { isRestarting } = useSelector((state: AppState) => state.app);
   const dispatch = useDispatch();
 
-  const {
-    mutate: restoreBackupById,
-    isPending: isRestoreBackupPending,
-    error: restoreBackupError,
-  } = useRestoreBackup(id || 0);
-  const {
-    mutate: uploadBackupFile,
-    isPending: isUploadBackupPending,
-    error: uploadBackupError,
-  } = useRestoreBackupUpload();
+  const { restoreBackupById, isRestoringBackup, restoreBackupError } =
+    useRestoreBackup(id || 0);
+  const { uploadBackup, isUploadingBackup, uploadBackupError } =
+    useRestoreBackupUpload();
   const { mutate: restart } = useRestart();
 
   const [path, setPath] = useState('');
@@ -100,7 +94,7 @@ function RestoreBackupModalContent({
   const [isRestarted, setIsRestarted] = useState(false);
   const [isReloading, setIsReloading] = useState(false);
 
-  const isRestoring = isRestoreBackupPending || isUploadBackupPending;
+  const isRestoring = isRestoringBackup || isUploadingBackup;
   const restoreError = restoreBackupError || uploadBackupError;
   const wasRestoring = usePrevious(isRestoring);
   const wasRestarting = usePrevious(isRestarting);
@@ -123,9 +117,9 @@ function RestoreBackupModalContent({
     } else if (file) {
       const formData = new FormData();
       formData.append('restore', file);
-      uploadBackupFile(formData);
+      uploadBackup(formData);
     }
-  }, [id, file, restoreBackupById, uploadBackupFile]);
+  }, [id, file, restoreBackupById, uploadBackup]);
 
   useEffect(() => {
     if (wasRestoring && !isRestoring && !restoreError) {

--- a/frontend/src/System/Backup/useBackups.ts
+++ b/frontend/src/System/Backup/useBackups.ts
@@ -22,7 +22,7 @@ export default useBackups;
 export const useDeleteBackup = (id: number) => {
   const queryClient = useQueryClient();
 
-  return useApiMutation<object, void>({
+  const { mutate, isPending, error } = useApiMutation<object, void>({
     path: `/system/backup/${id}`,
     method: 'DELETE',
     mutationOptions: {
@@ -31,6 +31,12 @@ export const useDeleteBackup = (id: number) => {
       },
     },
   });
+
+  return {
+    deleteBackup: mutate,
+    isDeleting: isPending,
+    deleteError: error,
+  };
 };
 
 interface RestoreBackupResponse {
@@ -40,7 +46,10 @@ interface RestoreBackupResponse {
 export const useRestoreBackup = (id: number) => {
   const queryClient = useQueryClient();
 
-  return useApiMutation<RestoreBackupResponse, void>({
+  const { mutate, isPending, error } = useApiMutation<
+    RestoreBackupResponse,
+    void
+  >({
     path: `/system/backup/restore/${id}`,
     method: 'POST',
     mutationOptions: {
@@ -49,12 +58,22 @@ export const useRestoreBackup = (id: number) => {
       },
     },
   });
+
+  return {
+    restoreBackupById: mutate,
+    isRestoringBackup: isPending,
+    restoreBackupError: error,
+  };
 };
 
 export const useRestoreBackupUpload = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<RestoreBackupResponse, Error, FormData>({
+  const { mutate, isPending, error } = useMutation<
+    RestoreBackupResponse,
+    Error,
+    FormData
+  >({
     mutationFn: async (formData: FormData) => {
       const response = await fetch(
         `${window.Whisparr.urlBase}/api/v5/system/backup/restore/upload`,
@@ -79,4 +98,10 @@ export const useRestoreBackupUpload = () => {
       queryClient.invalidateQueries({ queryKey: ['/system/backup'] });
     },
   });
+
+  return {
+    uploadBackup: mutate,
+    isUploadingBackup: isPending,
+    uploadBackupError: error,
+  };
 };

--- a/frontend/src/System/Backup/useBackups.ts
+++ b/frontend/src/System/Backup/useBackups.ts
@@ -1,0 +1,82 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import useApiMutation from 'Helpers/Hooks/useApiMutation';
+import useApiQuery from 'Helpers/Hooks/useApiQuery';
+import Backup from 'typings/Backup';
+
+const useBackups = () => {
+  const result = useApiQuery<Backup[]>({
+    path: '/system/backup',
+    queryOptions: {
+      staleTime: 30 * 1000, // 30 seconds
+    },
+  });
+
+  return {
+    ...result,
+    data: result.data ?? [],
+  };
+};
+
+export default useBackups;
+
+export const useDeleteBackup = (id: number) => {
+  const queryClient = useQueryClient();
+
+  return useApiMutation<object, void>({
+    path: `/system/backup/${id}`,
+    method: 'DELETE',
+    mutationOptions: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['/system/backup'] });
+      },
+    },
+  });
+};
+
+interface RestoreBackupResponse {
+  restartRequired: boolean;
+}
+
+export const useRestoreBackup = (id: number) => {
+  const queryClient = useQueryClient();
+
+  return useApiMutation<RestoreBackupResponse, void>({
+    path: `/system/backup/restore/${id}`,
+    method: 'POST',
+    mutationOptions: {
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['/system/backup'] });
+      },
+    },
+  });
+};
+
+export const useRestoreBackupUpload = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<RestoreBackupResponse, Error, FormData>({
+    mutationFn: async (formData: FormData) => {
+      const response = await fetch(
+        `${window.Whisparr.urlBase}/api/v5/system/backup/restore/upload`,
+        {
+          method: 'POST',
+          headers: {
+            'X-Api-Key': window.Whisparr.apiKey,
+            'X-Whisparr-Client': 'Whisparr',
+            // Don't set Content-Type, let browser set it with boundary for multipart/form-data
+          },
+          body: formData,
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to restore backup: ${response.statusText}`);
+      }
+
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/system/backup'] });
+    },
+  });
+};

--- a/frontend/src/System/useSystem.ts
+++ b/frontend/src/System/useSystem.ts
@@ -1,0 +1,40 @@
+import { useMutation } from '@tanstack/react-query';
+import { useDispatch } from 'react-redux';
+import { pingServer, setAppValue } from 'Store/Actions/appActions';
+
+const createSystemMutationFn = (endpoint: string) => {
+  return async () => {
+    const response = await fetch(
+      `${window.Whisparr.urlBase}/system/${endpoint}`,
+      {
+        method: 'POST',
+        headers: {
+          'X-Api-Key': window.Whisparr.apiKey,
+          'X-Whisparr-Client': 'Whisparr',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to ${endpoint}: ${response.statusText}`);
+    }
+  };
+};
+
+export const useRestart = () => {
+  const dispatch = useDispatch();
+
+  return useMutation<void, Error, void>({
+    mutationFn: createSystemMutationFn('restart'),
+    onSuccess: () => {
+      dispatch(setAppValue({ isRestarting: true }));
+      dispatch(pingServer());
+    },
+  });
+};
+
+export const useShutdown = () => {
+  return useMutation<void, Error, void>({
+    mutationFn: createSystemMutationFn('shutdown'),
+  });
+};


### PR DESCRIPTION
First **mutation** conversion, and the infrastructure it needs.

Applied Commits (2)

Sonarr/Sonarr@c295e24fc - Use react-query for backups
Sonarr/Sonarr@d252fa8ed - Improve backup mutations

Adds `Helpers/Hooks/useApiMutation.ts`

The gate for every remaining conversion. Ported from Sonarr/Sonarr@591b569bd, unchanged apart from the Whisparr API key and client headers, and importing `ValidationFailures` from `Store/Selectors/selectSettings` — upstream moved that file to `Utilities/selectSettings`, this fork has not. The interface was declared but not exported there, so it is exported now.

It sits on the fetch layer added in #1212, so nothing else was needed.

Backups is the proof case, chosen deliberately

Of every remaining conversion, backups is the only one whose sole missing dependency was `useApiMutation` — no zustand, no `SelectContext`, no `usePagedApiQuery`. So this lands the mutation layer proven by real usage rather than as unused code, and **zustand is still not a dependency**.

Also adds `System/useSystem.ts` (`useRestart`, `useShutdown`), which comes with the commit. At this point upstream's version still dispatches redux `setAppValue`/`pingServer` rather than using their zustand app store, so it fits this fork as-is. That unblocks converting `PageHeaderActionsMenu` to `.tsx` later without zustand.

Adaptations

- `AppState.ts`: the commit removes `system: SystemAppState` because upstream deleted `SystemAppState.ts` wholesale, having converted everything in it. Whisparr still has `logs` and `updates` there, so `system` is kept.
- `SystemAppState.ts` and `systemActions.js` arrive as delete-vs-modify for the same reason. Ours are kept with only the `backups` wiring removed — state, four action constants, four thunks, five handlers, and the `CLEAR_RESTORE_BACKUP` reducer. `set` and `createRemoveItemHandler` became unused imports and were dropped.
- `BackupAppState.ts` is deleted; nothing references it now and upstream removed it too.
- `useBackups.ts` and `useSystem.ts` both shipped with `window.Sonarr` references — renamed.

Verified with a clean solution build (analyzers on), eslint, and the production frontend build.
