### PR TITLE
Chore: Track upstream Sonarr commits as issues and PRs

### DIFF
--- a/.github/workflows/upstream_pull.yml
+++ b/.github/workflows/upstream_pull.yml
@@ -1,0 +1,227 @@
+name: Upstream Pull
+
+# Opens one pull request per upstream Sonarr commit, oldest first.
+#
+# Replaces the Servarr app that used to do this (11 PRs on 2025-02-18, then
+# nothing -- those targeted `develop`, which no longer exists here).
+#
+# Commits that conflict still get a PR: the conflicted state is committed with
+# the markers left in and the PR is labelled `has-conflicts`, so the decision
+# about whether a change suits this fork is made on the PR rather than here.
+#
+# It never merges upstream. `git merge upstream/v5-develop` produces roughly
+# 1550 conflicted files and reintroduces anime, season, Trakt and TVDB code that
+# was removed on purpose.
+#
+# Requires UPSTREAM_PULL_TOKEN -- a PAT with `repo` scope. GITHUB_TOKEN will not
+# do: pull requests it creates do not trigger other workflows, so build.yml
+# would never run and every PR would arrive without CI. That is exactly how
+# Servarr's PR #376 died ("came in before the azure pipeline was updated, and
+# can't have tests re-run").
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'Maximum PRs to open in this run'
+        required: false
+        default: '25'
+      dry_run:
+        description: 'Report what would be opened, without pushing'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-pull
+  cancel-in-progress: false
+
+env:
+  BASE: v2-develop
+  UPSTREAM: upstream/v5-develop
+  # A safety valve, not a filter -- the remainder is picked up next run, so a
+  # misresolved sync point cannot open hundreds of PRs at once.
+  LIMIT: ${{ inputs.limit || '25' }}
+  DRY_RUN: ${{ inputs.dry_run && 'yes' || 'no' }}
+
+jobs:
+  pull:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.UPSTREAM_PULL_TOKEN }}
+
+      - name: Fetch upstream
+        run: |
+          git config user.name 'whisparr-sync'
+          git config user.email 'whisparr-sync@users.noreply.github.com'
+          git remote add upstream https://github.com/Sonarr/Sonarr.git 2>/dev/null || true
+          git fetch --quiet upstream v5-develop
+
+      - name: Find the sync point
+        id: sync
+        run: |
+          # Every picked commit records `Sonarr/Sonarr@<sha>` in its subject, and
+          # squash-merging a batch PR keeps those lines in the merge body. So the
+          # newest upstream commit referenced anywhere in this branch's history is
+          # the furthest point reached -- no external state needed.
+          point=''
+          point_date=''
+
+          for sha in $(git log "$BASE" --format=%B -n 1500 \
+                       | grep -oE 'Sonarr/Sonarr@[0-9a-f]{9,40}' \
+                       | cut -d@ -f2 | sort -u); do
+            date=$(git log -1 --format=%cI "$sha" 2>/dev/null) || continue
+            [ -z "$date" ] && continue
+            if [[ "$date" > "$point_date" ]]; then
+              point="$sha"
+              point_date="$date"
+            fi
+          done
+
+          if [ -z "$point" ]; then
+            echo "No Sonarr/Sonarr@ provenance found in the last 1500 commits." >&2
+            exit 1
+          fi
+
+          echo "point=$point" >> "$GITHUB_OUTPUT"
+          echo "Sync point $point ($point_date)"
+
+      - name: Open pull requests
+        env:
+          GH_TOKEN: ${{ secrets.UPSTREAM_PULL_TOKEN }}
+          POINT: ${{ steps.sync.outputs.point }}
+        run: |
+          # Guard hard. An empty POINT makes the range `..upstream`, which git
+          # reads as the whole of upstream history -- ~4800 commits back to 2016
+          # -- and the loop would cheerfully open PRs for them, LIMIT at a time,
+          # every day. Caught in testing when the step output was not wired up.
+          if [ -z "$POINT" ]; then
+            echo "Sync point is empty; refusing to walk all of upstream." >&2
+            exit 1
+          fi
+
+          if ! git cat-file -e "${POINT}^{commit}" 2>/dev/null; then
+            echo "Sync point $POINT is not a commit in this repository." >&2
+            exit 1
+          fi
+
+          # Note for anyone running this logic by hand: the loop does
+          # `git checkout --force`, so commit your work first or it will be
+          # discarded along with the throwaway branches.
+          behind=$(git log --no-merges --format=%H "$POINT..$UPSTREAM" | wc -l)
+          opened=0
+
+          {
+            echo "## Upstream pull"
+            echo
+            echo "Sync point \`$POINT\` - $behind commit(s) behind."
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          for sha in $(git log --no-merges --format=%H --reverse "$POINT..$UPSTREAM"); do
+            [ "$opened" -ge "$LIMIT" ] && break
+
+            short=${sha:0:8}
+            branch="sonarr-pull-$short"
+            subject=$(git log -1 --format=%s "$sha")
+
+            # Already handled? A branch or a PR in any state is enough.
+            if [ -n "$(git ls-remote --heads origin "$branch")" ]; then continue; fi
+            if [ -n "$(gh pr list --head "$branch" --state all --json number -q '.[].number')" ]; then
+              continue
+            fi
+
+            git checkout -q -B "$branch" "$BASE"
+
+            clashes=''
+            if git cherry-pick -x "$sha" >/dev/null 2>&1; then
+              git commit -q --amend --no-verify -m "$subject (Sonarr/Sonarr@${sha:0:9})"
+            else
+              clashes=$(git diff --name-only --diff-filter=U)
+
+              if [ -z "$clashes" ]; then
+                # Empty pick, or a failure with nothing to show.
+                git cherry-pick --abort >/dev/null 2>&1 || true
+                git checkout -q --force "$BASE"
+                git branch -D "$branch" >/dev/null 2>&1 || true
+                echo "- \`${sha:0:9}\` $subject - could not be applied" >> "$GITHUB_STEP_SUMMARY"
+                continue
+              fi
+
+              # Stage only what this commit touched. Never `git add -A` here: on
+              # a conflicted pick it also sweeps up anything else in the tree.
+              git show "$sha" --name-only --format= | grep . | while read -r f; do
+                git add -- "$f" 2>/dev/null || true
+              done
+
+              git commit -q --no-verify -m "$subject (Sonarr/Sonarr@${sha:0:9})"
+            fi
+
+            count=$(printf '%s' "$clashes" | grep -c . || true)
+
+            if [ "$DRY_RUN" = 'yes' ]; then
+              git checkout -q --force "$BASE"
+              git branch -D "$branch" >/dev/null 2>&1 || true
+              echo "| \`${sha:0:9}\` | ${count:-0} | $subject | (dry run) |" >> "$GITHUB_STEP_SUMMARY"
+              opened=$((opened + 1))
+              continue
+            fi
+
+            git push -q --force-with-lease origin "$branch"
+
+            # Keep upstream's conventional prefix so the release-notes tooling
+            # picks the PR up; anything else is housekeeping.
+            case "$subject" in
+              New:*|Fixed:*|Chore:*) title="$subject" ;;
+              *) title="Chore: $subject" ;;
+            esac
+
+            {
+              echo "Cherry-picked from upstream Sonarr."
+              echo
+              echo "Sonarr/Sonarr@${sha:0:9} - $subject"
+              echo
+              if [ -n "$clashes" ]; then
+                echo "### This one conflicts"
+                echo
+                echo "Committed with the conflict markers left in, so the changes"
+                echo "are visible and can be resolved on this branch. Files:"
+                echo
+                printf '%s\n' "$clashes" | sed 's/^/- `/; s/$/`/'
+                echo
+                echo "**Do not merge until the markers are gone.**"
+              else
+                echo "Applied cleanly."
+              fi
+              echo
+              echo '---'
+              echo
+              echo "Opened automatically, one PR per upstream commit. Whether the"
+              echo "change suits this fork has not been assessed - close it if it"
+              echo "does not apply."
+            } > /tmp/pr-body.md
+
+            labels='upstream-sync'
+            [ -n "$clashes" ] && labels='upstream-sync,has-conflicts'
+
+            url=$(gh pr create --base "$BASE" --head "$branch" \
+                    --title "$title" --body-file /tmp/pr-body.md \
+                    --label "$labels" 2>/dev/null) || url='(failed to open)'
+
+            git checkout -q --force "$BASE"
+
+            echo "| \`${sha:0:9}\` | ${count:-0} | $subject | $url |" >> "$GITHUB_STEP_SUMMARY"
+            opened=$((opened + 1))
+          done
+
+          echo "Opened $opened pull request(s)."

--- a/.github/workflows/upstream_pull.yml
+++ b/.github/workflows/upstream_pull.yml
@@ -1,13 +1,22 @@
 name: Upstream Pull
 
-# Opens one pull request per upstream Sonarr commit, oldest first.
+# Tracks every upstream Sonarr commit, following the design the Servarr app used
+# here until 2025-02-18 (it stopped because it targeted `develop`, which no
+# longer exists).
 #
-# Replaces the Servarr app that used to do this (11 PRs on 2025-02-18, then
-# nothing -- those targeted `develop`, which no longer exists here).
+# For each commit, oldest first:
 #
-# Commits that conflict still get a PR: the conflicted state is committed with
-# the markers left in and the PR is labelled `has-conflicts`, so the decision
-# about whether a change suits this fork is made on the PR rather than here.
+#   * always open an issue -- the upstream link, the cherry-pick command, and
+#     the conflict count;
+#   * if it applies with zero conflicts, also push the branch and open a PR that
+#     closes the issue.
+#
+# A commit that conflicts never becomes a PR. That is the whole point of the
+# split: it costs no branch and no CI run, and no red PR sits in the queue
+# waiting for someone to fix it. The issue carries the cherry-pick command so it
+# can be done by hand and batched with others. Verified against the old bot's
+# output: all 11 of its PRs came from 0-conflict commits, and all 17 conflicted
+# commits got an issue only.
 #
 # It never merges upstream. `git merge upstream/v5-develop` produces roughly
 # 1550 conflicted files and reintroduces anime, season, Trakt and TVDB code that
@@ -15,9 +24,9 @@ name: Upstream Pull
 #
 # Requires UPSTREAM_PULL_TOKEN -- a PAT with `repo` scope. GITHUB_TOKEN will not
 # do: pull requests it creates do not trigger other workflows, so build.yml
-# would never run and every PR would arrive without CI. That is exactly how
-# Servarr's PR #376 died ("came in before the azure pipeline was updated, and
-# can't have tests re-run").
+# would never run and every PR would arrive without CI. That is how the old
+# bot's PR #376 died ("came in before the azure pipeline was updated, and can't
+# have tests re-run").
 
 on:
   schedule:
@@ -25,11 +34,11 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        description: 'Maximum PRs to open in this run'
+        description: 'Maximum commits to process in this run'
         required: false
         default: '25'
       dry_run:
-        description: 'Report what would be opened, without pushing'
+        description: 'Report what would be opened, without opening anything'
         type: boolean
         required: false
         default: false
@@ -45,7 +54,7 @@ env:
   BASE: v2-develop
   UPSTREAM: upstream/v5-develop
   # A safety valve, not a filter -- the remainder is picked up next run, so a
-  # misresolved sync point cannot open hundreds of PRs at once.
+  # misresolved sync point cannot flood the queue.
   LIMIT: ${{ inputs.limit || '25' }}
   DRY_RUN: ${{ inputs.dry_run && 'yes' || 'no' }}
 
@@ -96,15 +105,13 @@ jobs:
           echo "point=$point" >> "$GITHUB_OUTPUT"
           echo "Sync point $point ($point_date)"
 
-      - name: Open pull requests
+      - name: Track upstream commits
         env:
           GH_TOKEN: ${{ secrets.UPSTREAM_PULL_TOKEN }}
           POINT: ${{ steps.sync.outputs.point }}
         run: |
           # Guard hard. An empty POINT makes the range `..upstream`, which git
-          # reads as the whole of upstream history -- ~4800 commits back to 2016
-          # -- and the loop would cheerfully open PRs for them, LIMIT at a time,
-          # every day. Caught in testing when the step output was not wired up.
+          # reads as the whole of upstream history -- ~4800 commits back to 2016.
           if [ -z "$POINT" ]; then
             echo "Sync point is empty; refusing to walk all of upstream." >&2
             exit 1
@@ -115,113 +122,126 @@ jobs:
             exit 1
           fi
 
-          # Note for anyone running this logic by hand: the loop does
-          # `git checkout --force`, so commit your work first or it will be
-          # discarded along with the throwaway branches.
+          # Note for anyone running this logic by hand: it does
+          # `git checkout --force`, so commit your work first.
           behind=$(git log --no-merges --format=%H "$POINT..$UPSTREAM" | wc -l)
-          opened=0
+          done_count=0
 
           {
             echo "## Upstream pull"
             echo
             echo "Sync point \`$POINT\` - $behind commit(s) behind."
             echo
+            echo "| commit | conflicts | opened | subject |"
+            echo "| --- | --- | --- | --- |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           for sha in $(git log --no-merges --format=%H --reverse "$POINT..$UPSTREAM"); do
-            [ "$opened" -ge "$LIMIT" ] && break
+            [ "$done_count" -ge "$LIMIT" ] && break
 
             short=${sha:0:8}
             branch="sonarr-pull-$short"
             subject=$(git log -1 --format=%s "$sha")
 
-            # Already handled? A branch or a PR in any state is enough.
+            # Already tracked? An issue or PR mentioning this commit, in any
+            # state, is enough -- closing one is a decision and must stick.
+            if [ -n "$(gh search issues --repo "$GITHUB_REPOSITORY" "$sha" --json number -q '.[].number' 2>/dev/null)" ]; then
+              continue
+            fi
             if [ -n "$(git ls-remote --heads origin "$branch")" ]; then continue; fi
-            if [ -n "$(gh pr list --head "$branch" --state all --json number -q '.[].number')" ]; then
+
+            # Count conflicts by attempting the pick on a scratch branch.
+            git checkout -q -B "$branch" "$BASE"
+            conflicts=0
+
+            if ! git cherry-pick -x "$sha" >/dev/null 2>&1; then
+              conflicts=$(git diff --name-only --diff-filter=U | grep -c . || true)
+              git cherry-pick --abort >/dev/null 2>&1 || true
+            fi
+
+            {
+              echo "Pull https://github.com/Sonarr/Sonarr/commit/$sha"
+              echo
+              echo '```'
+              echo "git cherry-pick -ex $sha"
+              echo '```'
+              echo
+              echo "This commit has $conflicts conflict(s)"
+              if [ "$conflicts" -gt 0 ]; then
+                echo
+                echo "No pull request was opened, because it does not apply"
+                echo "cleanly. Resolve it by hand, or close this if the change"
+                echo "does not belong in this fork."
+              fi
+            } > /tmp/issue-body.md
+
+            if [ "$conflicts" -gt 0 ]; then
+              # Conflicted: issue only, no branch, no CI.
+              git checkout -q --force "$BASE"
+              git branch -D "$branch" >/dev/null 2>&1 || true
+
+              if [ "$DRY_RUN" = 'yes' ]; then
+                echo "| \`${sha:0:9}\` | $conflicts | issue (dry run) | $subject |" >> "$GITHUB_STEP_SUMMARY"
+              else
+                url=$(gh issue create --title "Pull Sonarr commit '$subject'" \
+                        --body-file /tmp/issue-body.md --label 'upstream-sync' 2>/dev/null) \
+                  || url='(failed)'
+                echo "| \`${sha:0:9}\` | $conflicts | $url | $subject |" >> "$GITHUB_STEP_SUMMARY"
+              fi
+
+              done_count=$((done_count + 1))
               continue
             fi
 
-            git checkout -q -B "$branch" "$BASE"
-
-            clashes=''
-            if git cherry-pick -x "$sha" >/dev/null 2>&1; then
-              git commit -q --amend --no-verify -m "$subject (Sonarr/Sonarr@${sha:0:9})"
-            else
-              clashes=$(git diff --name-only --diff-filter=U)
-
-              if [ -z "$clashes" ]; then
-                # Empty pick, or a failure with nothing to show.
-                git cherry-pick --abort >/dev/null 2>&1 || true
-                git checkout -q --force "$BASE"
-                git branch -D "$branch" >/dev/null 2>&1 || true
-                echo "- \`${sha:0:9}\` $subject - could not be applied" >> "$GITHUB_STEP_SUMMARY"
-                continue
-              fi
-
-              # Stage only what this commit touched. Never `git add -A` here: on
-              # a conflicted pick it also sweeps up anything else in the tree.
-              git show "$sha" --name-only --format= | grep . | while read -r f; do
-                git add -- "$f" 2>/dev/null || true
-              done
-
-              git commit -q --no-verify -m "$subject (Sonarr/Sonarr@${sha:0:9})"
-            fi
-
-            count=$(printf '%s' "$clashes" | grep -c . || true)
+            # Clean: redo the pick, then open the issue and its PR together.
+            git cherry-pick -x "$sha" >/dev/null 2>&1
+            git commit -q --amend --no-verify -m "$subject (Sonarr/Sonarr@${sha:0:9})"
 
             if [ "$DRY_RUN" = 'yes' ]; then
               git checkout -q --force "$BASE"
               git branch -D "$branch" >/dev/null 2>&1 || true
-              echo "| \`${sha:0:9}\` | ${count:-0} | $subject | (dry run) |" >> "$GITHUB_STEP_SUMMARY"
-              opened=$((opened + 1))
+              echo "| \`${sha:0:9}\` | 0 | issue + PR (dry run) | $subject |" >> "$GITHUB_STEP_SUMMARY"
+              done_count=$((done_count + 1))
               continue
             fi
+
+            issue=$(gh issue create --title "Pull Sonarr commit '$subject'" \
+                      --body-file /tmp/issue-body.md --label 'upstream-sync' 2>/dev/null) \
+              || issue=''
 
             git push -q --force-with-lease origin "$branch"
 
             # Keep upstream's conventional prefix so the release-notes tooling
-            # picks the PR up; anything else is housekeeping.
+            # picks the PR up; anything else is housekeeping. The old bot titled
+            # PRs "Pull Sonarr commit '...'", which that tooling would skip.
             case "$subject" in
               New:*|Fixed:*|Chore:*) title="$subject" ;;
               *) title="Chore: $subject" ;;
             esac
 
             {
-              echo "Cherry-picked from upstream Sonarr."
+              echo "Cherry-picked from upstream Sonarr, applied cleanly."
               echo
               echo "Sonarr/Sonarr@${sha:0:9} - $subject"
-              echo
-              if [ -n "$clashes" ]; then
-                echo "### This one conflicts"
+              if [ -n "$issue" ]; then
                 echo
-                echo "Committed with the conflict markers left in, so the changes"
-                echo "are visible and can be resolved on this branch. Files:"
-                echo
-                printf '%s\n' "$clashes" | sed 's/^/- `/; s/$/`/'
-                echo
-                echo "**Do not merge until the markers are gone.**"
-              else
-                echo "Applied cleanly."
+                echo "Fixes ${issue##*/}"
               fi
               echo
               echo '---'
               echo
-              echo "Opened automatically, one PR per upstream commit. Whether the"
-              echo "change suits this fork has not been assessed - close it if it"
-              echo "does not apply."
+              echo "Opened automatically. Whether the change suits this fork has"
+              echo "not been assessed - close it, and its issue, if it does not."
             } > /tmp/pr-body.md
-
-            labels='upstream-sync'
-            [ -n "$clashes" ] && labels='upstream-sync,has-conflicts'
 
             url=$(gh pr create --base "$BASE" --head "$branch" \
                     --title "$title" --body-file /tmp/pr-body.md \
-                    --label "$labels" 2>/dev/null) || url='(failed to open)'
+                    --label 'upstream-sync' 2>/dev/null) || url='(failed to open)'
 
             git checkout -q --force "$BASE"
 
-            echo "| \`${sha:0:9}\` | ${count:-0} | $subject | $url |" >> "$GITHUB_STEP_SUMMARY"
-            opened=$((opened + 1))
+            echo "| \`${sha:0:9}\` | 0 | $url | $subject |" >> "$GITHUB_STEP_SUMMARY"
+            done_count=$((done_count + 1))
           done
 
-          echo "Opened $opened pull request(s)."
+          echo "Processed $done_count commit(s)."


### PR DESCRIPTION
Our own version of the Servarr app that used to do this here — it ran once on 2025-02-18 and then stopped, because it targeted `develop`, which no longer exists.

One workflow file. It follows the same design the old bot used, which was worked out by reading what it actually produced.

The design

For every upstream commit, oldest first:

- **always open an issue** — the upstream link, the `git cherry-pick -ex <sha>` command, and the conflict count;
- **if it applies with zero conflicts, also open a PR** that closes the issue.

A conflicting commit never becomes a PR. That is the point of the split: no branch, no CI run, and no red PR sitting in the queue. The issue carries the cherry-pick command so it can be done by hand and batched with others.

This matches the old bot exactly. Its output here was 28 issues and 11 PRs, and the rule is unambiguous:

| conflicts | what it did | count |
| --- | --- | --- |
| 0 | issue **+ PR** | 11 of 11 |
| 1 or more | issue only | 17 of 17 |

Every PR number sits in the gap right after a 0-conflict issue (#345→#346, #349→#350, #380→#381), and every issue reporting 1, 2, 4, 8, 9 or 12 conflicts got no PR.

Verified against a real batch

Replayed against the state before Batch 43 (#1221), which was worked through by hand earlier today:

| commit | conflicts | this workflow | what actually happened |
| --- | --- | --- | --- |
| Sonarr/Sonarr@85964fec1 | 0 | issue + PR | landed unchanged |
| Sonarr/Sonarr@6f850c5b9 | 0 | issue + PR | landed unchanged |
| Sonarr/Sonarr@c0023b4c2 | 0 | issue + PR | landed unchanged |
| Sonarr/Sonarr@79483e254 | 4 | issue | needed policy resolution |
| Sonarr/Sonarr@c0e859718 | 1 | issue | needed a hand fix |
| Sonarr/Sonarr@a4448b720 | 1 | issue | hand-ported onto redux |
| Sonarr/Sonarr@900cc21d3 | 3 | issue | only one of three regex changes applied |
| Sonarr/Sonarr@aee587697 | 1 | issue | skipped — false rename onto the v3 docs |
| Sonarr/Sonarr@b84a621e9 | 3 | issue | skipped — not applicable |

It auto-PRs exactly the three that needed no thought, and raises issues for the six that needed judgement.

One deliberate difference from the old bot

Its PR titles were `Pull Sonarr commit '<subject>'`, which the release-notes tooling would skip. PRs here keep upstream's `New:`/`Fixed:` prefix, or get `Chore:`. Issue titles keep the old bot's wording.

Safety

- **Requires `UPSTREAM_PULL_TOKEN`** — a PAT with `repo` scope. `GITHUB_TOKEN` will not work: PRs it creates do not trigger other workflows, so `build.yml` would never run. That is how the old bot's #376 died — *"came in before the azure pipeline was updated, and can't have tests re-run"*.
- **Refuses to run with an empty or unresolvable sync point.** Caught in testing: unset, the range becomes `..upstream`, which git reads as all of history — it began opening PRs for 2016 commits.
- **Caps at 25 commits per run**, remainder next run.
- **Skips anything already tracked** by an issue or PR in any state, so closing one is permanent.
- **Never merges.** A plain merge of upstream is ~1550 conflicted files.

Safe to enable now because the backlog is closed — it will find one commit, the one Batch 43 skipped, and open an issue for it. Run it from the Actions tab with **dry run** ticked first.

Verified locally: YAML parses, all three shell steps pass `bash -n`, both guards abort correctly, and dry runs of both paths leave no branches behind.
