### PR TITLE
Fixed: Use the existing sonarr-pull labels and report create failures

### DIFF
--- a/.github/workflows/upstream_pull.yml
+++ b/.github/workflows/upstream_pull.yml
@@ -184,8 +184,8 @@ jobs:
                 echo "| \`${sha:0:9}\` | $conflicts | issue (dry run) | $subject |" >> "$GITHUB_STEP_SUMMARY"
               else
                 url=$(gh issue create --title "Pull Sonarr commit '$subject'" \
-                        --body-file /tmp/issue-body.md --label 'upstream-sync' 2>/dev/null) \
-                  || url='(failed)'
+                        --body-file /tmp/issue-body.md --label 'sonarr-pull' --label 'conflict') \
+                  || { echo "issue create failed for $sha" >&2; url='(failed)'; }
                 echo "| \`${sha:0:9}\` | $conflicts | $url | $subject |" >> "$GITHUB_STEP_SUMMARY"
               fi
 
@@ -206,8 +206,8 @@ jobs:
             fi
 
             issue=$(gh issue create --title "Pull Sonarr commit '$subject'" \
-                      --body-file /tmp/issue-body.md --label 'upstream-sync' 2>/dev/null) \
-              || issue=''
+                      --body-file /tmp/issue-body.md --label 'sonarr-pull' --label 'no-conflict') \
+              || { echo "issue create failed for $sha" >&2; issue=''; }
 
             git push -q --force-with-lease origin "$branch"
 
@@ -236,7 +236,7 @@ jobs:
 
             url=$(gh pr create --base "$BASE" --head "$branch" \
                     --title "$title" --body-file /tmp/pr-body.md \
-                    --label 'upstream-sync' 2>/dev/null) || url='(failed to open)'
+                    --label 'sonarr-pull') || { echo "pr create failed for $sha" >&2; url='(failed to open)'; }
 
             git checkout -q --force "$BASE"
 


### PR DESCRIPTION
The first live run of the workflow from #1222 reported success and created nothing. Two causes, both fixed here.

The label did not exist

It passed `--label 'upstream-sync'`, which is not a label in this repo. `gh issue create` fails outright on an unknown label, so every create failed.

The repo already has the old Servarr bot's labels, and they are now reused exactly as it used them:

| | labels |
| --- | --- |
| issue, conflicts | `sonarr-pull` + `conflict` |
| issue, no conflicts | `sonarr-pull` + `no-conflict` |
| pull request | `sonarr-pull` |

Confirmed against its output: issue #380 carries `sonarr-pull` and `no-conflict`, issue #344 carries `sonarr-pull` and `conflict`, and PR #381 carries `sonarr-pull`.

The failure was silent

The `gh` calls ended in `2>/dev/null) || url='(failed)'`, so the error was discarded and the run still exited 0 — the step summary would have shown `(failed)` in a table cell, and nothing else. They now write the failure to stderr, so it appears in the job log where it belongs.

That is the more important of the two fixes. The label was a one-line mistake; swallowing the reason it happened is what made it take a diagnostic detour to find.
