### PR TITLE
Fixed: Target the repository explicitly when creating issues and PRs

### DIFF
--- a/.github/workflows/upstream_pull.yml
+++ b/.github/workflows/upstream_pull.yml
@@ -183,7 +183,7 @@ jobs:
               if [ "$DRY_RUN" = 'yes' ]; then
                 echo "| \`${sha:0:9}\` | $conflicts | issue (dry run) | $subject |" >> "$GITHUB_STEP_SUMMARY"
               else
-                url=$(gh issue create --title "Pull Sonarr commit '$subject'" \
+                url=$(gh issue create --repo "$GITHUB_REPOSITORY" --title "Pull Sonarr commit '$subject'" \
                         --body-file /tmp/issue-body.md --label 'sonarr-pull' --label 'conflict' 2>/tmp/gh-err) \
                   || { echo "issue create failed for $sha:" >&2; cat /tmp/gh-err >&2; url='(failed)'; }
                 echo "| \`${sha:0:9}\` | $conflicts | $url | $subject |" >> "$GITHUB_STEP_SUMMARY"
@@ -205,7 +205,7 @@ jobs:
               continue
             fi
 
-            issue=$(gh issue create --title "Pull Sonarr commit '$subject'" \
+            issue=$(gh issue create --repo "$GITHUB_REPOSITORY" --title "Pull Sonarr commit '$subject'" \
                       --body-file /tmp/issue-body.md --label 'sonarr-pull' --label 'no-conflict' 2>/tmp/gh-err) \
               || { echo "issue create failed for $sha:" >&2; cat /tmp/gh-err >&2; issue=''; }
 
@@ -234,7 +234,7 @@ jobs:
               echo "not been assessed - close it, and its issue, if it does not."
             } > /tmp/pr-body.md
 
-            url=$(gh pr create --base "$BASE" --head "$branch" \
+            url=$(gh pr create --repo "$GITHUB_REPOSITORY" --base "$BASE" --head "$branch" \
                     --title "$title" --body-file /tmp/pr-body.md \
                     --label 'sonarr-pull' 2>/tmp/gh-err) || { echo "pr create failed for $sha" >&2; cat /tmp/gh-err >&2; url='(failed to open)'; }
 


### PR DESCRIPTION
The workflow ran, reported `Processed 1 commit(s)`, and created nothing. With gh's stderr now visible (#1224), the reason was:

```
issue create failed for b84a621e99...:
could not add label: 'sonarr-pull' not found
```

The label does exist on this repository. It does not exist on `Gykes/Whisparr`:

| repo | has `sonarr-pull` |
| --- | --- |
| Whisparr/Whisparr | yes |
| Gykes/Whisparr | no |

`gh issue create` and `gh pr create` were called without `--repo`, so gh resolved the target itself. The token belongs to Gykes, who has a fork, and gh picked the fork — not the repository the workflow is running in. It then looked for the label there, did not find it, and failed.

Both calls now pass `--repo "$GITHUB_REPOSITORY"` explicitly, which is what `gh search issues` already did. Nothing else changes.

Worth noting the failure mode: a token that happens to belong to someone with a fork silently retargets these commands. It would have been invisible without the stderr capture from #1224 — the run exits 0 either way, because the error is swallowed by the `||` fallback.
