### PR TITLE
fix: Prevent Free-Text Tag Input From Collapsing to 0

### DIFF
--- a/frontend/src/Components/Form/Tag/TagInput.tsx
+++ b/frontend/src/Components/Form/Tag/TagInput.tsx
@@ -23,11 +23,11 @@ import TagInputTag, { EditedTag, TagInputTagProps } from './TagInputTag';
 import styles from './TagInput.css';
 
 export interface TagBase {
-  id: boolean | number | string;
+  id?: boolean | number | string;
   name: string | number;
 }
 
-function getTag<T extends { id: T['id']; name: T['name'] }>(
+function getTag<T extends TagBase>(
   value: string,
   selectedIndex: number,
   suggestions: T[],
@@ -41,7 +41,7 @@ function getTag<T extends { id: T['id']; name: T['name'] }>(
     if (existingTag) {
       return existingTag;
     } else if (allowNew) {
-      return { id: 0, name: value } as T;
+      return { name: value } as T;
     }
   } else if (selectedIndex != null) {
     return suggestions[selectedIndex];


### PR DESCRIPTION
#### Database Migration
NO

#### Description
fixes an issue where typing custom text into a filter (for example "Title contains X") turned the value into "0".

looked a bit at sonarr source code how they have it there.

#### Screenshot (if UI related)
before:
<img width="1441" height="549" alt="image" src="https://github.com/user-attachments/assets/6d8cdf50-ece9-48d9-8744-936b4c865817" />

after:
<img width="1441" height="549" alt="image" src="https://github.com/user-attachments/assets/44b723ae-c3f1-4ec6-a017-8ad714a8f21f" />


#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX