### PR TITLE
fix: Avoid Stale isQueuePopulated Closure in Signalr Listener

### DIFF
--- a/frontend/src/Components/SignalRListener.tsx
+++ b/frontend/src/Components/SignalRListener.tsx
@@ -42,6 +42,11 @@ function SignalRListener() {
   const isQueuePopulated = useSelector(
     (state: AppState) => state.queue.paged.isPopulated
   );
+  const isQueuePopulatedRef = useRef(isQueuePopulated);
+
+  useEffect(() => {
+    isQueuePopulatedRef.current = isQueuePopulated;
+  }, [isQueuePopulated]);
 
   const connection = useRef<HubConnection | null>(null);
 
@@ -236,7 +241,7 @@ function SignalRListener() {
     }
 
     if (name === 'queue') {
-      if (isQueuePopulated) {
+      if (isQueuePopulatedRef.current) {
         dispatch(fetchQueue());
       }
 


### PR DESCRIPTION
#### Database Migration
NO

#### Description
fixes an issue where the queue page "Refresh" button appeared dead and live queue status updates were not received via SignalR

#### Screenshot (if UI related)

#### Todos
- [ ] Tests
- [ ] Translation Keys (./src/NzbDrone.Core/Localization/Core/en.json)
- [ ] [Wiki Updates](https://wiki.servarr.com)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX