### PR TITLE
Fixed: Restore Site Translation Keys on the Library Import Page

### DIFF
--- a/frontend/src/AddSeries/ImportSeries/Import/ImportSeries.tsx
+++ b/frontend/src/AddSeries/ImportSeries/Import/ImportSeries.tsx
@@ -84,7 +84,7 @@ function ImportSeries() {
 
   return (
     <SelectProvider items={items}>
-      <PageContent title={translate('ImportSeries')}>
+      <PageContent title={translate('ImportSites')}>
         <PageContentBody ref={scrollerRef}>
           {rootFoldersFetching ? <LoadingIndicator /> : null}
 
@@ -99,7 +99,7 @@ function ImportSeries() {
           rootFoldersPopulated &&
           !unmappedFolders.length ? (
             <Alert kind={kinds.INFO}>
-              {translate('AllSeriesInRootFolderHaveBeenImported', { path })}
+              {translate('AllSitesInRootFolderHaveBeenImported', { path })}
             </Alert>
           ) : null}
 

--- a/frontend/src/AddSeries/ImportSeries/Import/ImportSeriesFooter.tsx
+++ b/frontend/src/AddSeries/ImportSeries/Import/ImportSeriesFooter.tsx
@@ -248,7 +248,7 @@ function ImportSeriesFooter() {
             isDisabled={!selectedCount || isLookingUpSeries}
             onPress={handleImportPress}
           >
-            {translate('ImportCountSeries', { selectedCount })}
+            {translate('ImportCountSites', { selectedCount })}
           </SpinnerButton>
 
           {isLookingUpSeries ? (

--- a/frontend/src/AddSeries/ImportSeries/SelectFolder/ImportSeriesSelectFolder.tsx
+++ b/frontend/src/AddSeries/ImportSeries/SelectFolder/ImportSeriesSelectFolder.tsx
@@ -35,10 +35,10 @@ function ImportSeriesSelectFolder() {
   const wasSaving = usePrevious(isSaving);
 
   const hasRootFolders = items.length > 0;
-  const goodFolderExample = isWindows ? 'C:\\tv shows' : '/tv shows';
+  const goodFolderExample = isWindows ? 'C:\\sites' : '/sites';
   const badFolderExample = isWindows
-    ? 'C:\\tv shows\\the simpsons'
-    : '/tv shows/the simpsons';
+    ? 'C:\\sites\\some site'
+    : '/sites/some site';
 
   const handleAddNewRootFolderPress = useCallback(() => {
     setIsAddNewRootFolderModalOpen(true);
@@ -72,7 +72,7 @@ function ImportSeriesSelectFolder() {
   }, [isSaving, wasSaving, saveError, items]);
 
   return (
-    <PageContent title={translate('ImportSeries')}>
+    <PageContent title={translate('ImportSites')}>
       <PageContentBody>
         {isFetching && !isPopulated ? <LoadingIndicator /> : null}
 
@@ -83,7 +83,7 @@ function ImportSeriesSelectFolder() {
         {!error && isPopulated && (
           <div>
             <div className={styles.header}>
-              {translate('LibraryImportSeriesHeader')}
+              {translate('LibraryImportHeader')}
             </div>
 
             <div className={styles.tips}>
@@ -91,14 +91,12 @@ function ImportSeriesSelectFolder() {
               <ul>
                 <li className={styles.tip}>
                   <InlineMarkdown
-                    data={translate(
-                      'LibraryImportTipsQualityInEpisodeFilename'
-                    )}
+                    data={translate('LibraryImportTipsQualityInFilename')}
                   />
                 </li>
                 <li className={styles.tip}>
                   <InlineMarkdown
-                    data={translate('LibraryImportTipsSeriesUseRootFolder', {
+                    data={translate('LibraryImportTipsUseRootFolder', {
                       goodFolderExample,
                       badFolderExample,
                     })}

--- a/frontend/src/Series/Series.ts
+++ b/frontend/src/Series/Series.ts
@@ -9,12 +9,8 @@ export type SeriesMonitor =
   | 'future'
   | 'missing'
   | 'existing'
-  | 'recent'
-  | 'pilot'
   | 'firstSeason'
-  | 'lastSeason'
-  | 'monitorSpecials'
-  | 'unmonitorSpecials'
+  | 'latestSeason'
   | 'none';
 
 export type MonitorNewItems = 'all' | 'none';

--- a/frontend/src/Utilities/Series/monitorOptions.ts
+++ b/frontend/src/Utilities/Series/monitorOptions.ts
@@ -26,18 +26,6 @@ const monitorOptions = [
     },
   },
   {
-    key: 'recent',
-    get value() {
-      return translate('MonitorRecentEpisodes');
-    },
-  },
-  {
-    key: 'pilot',
-    get value() {
-      return translate('MonitorPilotEpisode');
-    },
-  },
-  {
     key: 'firstSeason',
     get value() {
       return translate('MonitorFirstYear');
@@ -47,18 +35,6 @@ const monitorOptions = [
     key: 'latestSeason',
     get value() {
       return translate('MonitorLatestYear');
-    },
-  },
-  {
-    key: 'monitorSpecials',
-    get value() {
-      return translate('MonitorSpecialEpisodes');
-    },
-  },
-  {
-    key: 'unmonitorSpecials',
-    get value() {
-      return translate('UnmonitorSpecialEpisodes');
     },
   },
   {

--- a/frontend/src/Utilities/String/translate.ts
+++ b/frontend/src/Utilities/String/translate.ts
@@ -6,17 +6,15 @@ export function setTranslations(translationData: Record<string, string>) {
 
 export function translate(
   key: string,
-  tokens: Record<string, string | number | boolean> = { appName: 'Whisparr' }
+  tokens: Record<string, string | number | boolean> = {}
 ) {
   const translation = translations[key] || key;
 
-  if (tokens) {
-    return translation.replace(/\{([a-z0-9]+?)\}/gi, (match, tokenMatch) =>
-      String(tokens[tokenMatch] ?? match)
-    );
-  }
+  tokens.appName = 'Whisparr';
 
-  return translation;
+  return translation.replace(/\{([a-z0-9]+?)\}/gi, (match, tokenMatch) =>
+    String(tokens[tokenMatch] ?? match)
+  );
 }
 
 export default translate;

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1053,7 +1053,7 @@
   "LibraryImportHeader": "Import sites you already have",
   "LibraryImportTips": "Some tips to ensure the import goes smoothly:",
   "LibraryImportTipsDontUseDownloadsFolder": "Do not use for importing downloads from your download client, this is only for existing organized libraries, not unsorted files.",
-  "LibraryImportTipsQualityInFilename": "Make sure that your files include the quality in their filenames. eg. `episode.s02e15.bluray.mkv`",
+  "LibraryImportTipsQualityInFilename": "Make sure that your files include the quality in their filenames. eg. `some site - 2024-01-15 - scene title bluray-1080p.mkv`",
   "LibraryImportTipsUseRootFolder": "Point {appName} to the folder containing all of your scenes, not a specific one. eg. \"`{goodFolderExample}`\" and not \"`{badFolderExample}`\". Additionally, each site must be in its own folder within the root/library folder.",
   "Links": "Links",
   "ListExclusionsLoadError": "Unable to load List Exclusions",


### PR DESCRIPTION
The Library Import page renders raw translation identifiers instead of text — the page header shows literally `LibraryImportSeriesHeader`, and both import steps are titled `ImportSeries`.

## Cause

The TypeScript conversion sync in #1166 (Sonarr/Sonarr@6f871a1bf) reintroduced Sonarr's `*Series*` translation keys, but Whisparr's `en.json` uses Site terminology. `translate()` falls back to printing the key when it can't resolve it, so the Sonarr keys leak into the UI. The `v2` branch still has the correct keys, so this is a regression on `v2-develop` only.

## Changes

**Translation keys mapped back to their Whisparr equivalents**

| Was rendered as | Now shows |
| --- | --- |
| `LibraryImportSeriesHeader` | Import sites you already have |
| `LibraryImportTipsQualityInEpisodeFilename` | quality-in-filename tip |
| `LibraryImportTipsSeriesUseRootFolder` | root folder tip |
| `ImportSeries` (page title, both steps) | Import Sites |
| `ImportCountSeries` (import button) | Import {n} Sites |
| `AllSeriesInRootFolderHaveBeenImported` | All sites in {path} have been imported |

**`{appName}` token was silently dropped.** `appName: 'Whisparr'` was declared as a default parameter value on `translate()`, so it disappeared as soon as a caller passed any tokens of its own. The root folder tip passes `goodFolderExample` / `badFolderExample`, so it would have rendered "Point **{appName}** to the folder containing all of your scenes" even after the key fix. `appName` is now assigned unconditionally, matching the upstream fix in Sonarr/Sonarr@2e51b8792.

**Monitor dropdown offered options the backend rejects.** `monitorOptions` listed `recent`, `pilot`, `monitorSpecials` and `unmonitorSpecials`, none of which exist in Whisparr's `MonitorTypes` enum. They rendered as raw keys in the dropdown *and* would have posted an invalid monitor type if selected. Removed, leaving the seven values that match the enum and the monitoring options popover. `migrateAddSeriesDefaults` already resets a persisted value that is no longer in the list, so existing users with one of these selected fall back to `all`.

**`SeriesMonitor` type narrowed to match.** The union still permitted the four removed values, and spelled `latestSeason` as `lastSeason` — neither the backend enum nor `monitorOptions` ever used that spelling.

**Folder examples were Sonarr's.** `C:\tv shows` / `C:\tv shows\the simpsons` are now `C:\sites` / `C:\sites\some site`. `LibraryImportTipsQualityInFilename` in `en.json` cited `episode.s02e15.bluray.mkv` and now uses a scene-style filename.

## Testing

- `tsc --noEmit` clean for `frontend/src`
- `eslint` clean on all changed files
- Every `translate()` call on the Library Import page now resolves against `en.json`

## Note

A scan of the whole frontend against `en.json` turns up 69 unresolved translation keys from the same root cause, 59 of which remain after this PR, in Series edit, Media Management settings, System Updates, Interactive Import and the filter builders. This PR fixes the Library Import page only; the rest can follow separately.

